### PR TITLE
fix: improve QR share modal and header share UI

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,6 +16,7 @@ export default function Header({ title, subtitle }: HeaderProps) {
         position: "sticky",
         top: 0,
         zIndex: 10,
+        height: 88,
         backdropFilter: "blur(10px)",
         background: "rgba(16,16,16,0.85)",
         borderBottom: "1px solid rgba(255,255,255,0.10)",
@@ -66,9 +67,8 @@ export default function Header({ title, subtitle }: HeaderProps) {
 
         {/* 右側は空でもOK（将来: ダーク/ライト切替やGitHubリンク等を置ける） */}
         <div>
-          <ShareButtons text="MINI TOOLS" />
+          <ShareButtons text="mini-tools" methods={["qr"]} />
         </div>
-        <div />
       </div>
     </header>
   );


### PR DESCRIPTION
## 概要
トップ画面のQR共有まわりを改善しました。

## 変更内容
- ヘッダーの共有UIをQRのみに整理（SNSの重複表示を解消）
- QRモーダルの表示崩れ/見切れを修正（Portal化 + スクロール対応）
- QR/コピーURLを正規URLに統一し、Google Lens でリンクとして認識されるよう改善

## 動作確認
- [x] npm run lint
- [x] npm run build
- [x] QR読み取りで正規サイトへ遷移
- [x] URLコピーで正規サイトURLがコピーされる

## 関連Issue
Closes #10
Closes #11
Closes #12
