### PR TITLE
refactor(yutai-expiry): cleanup link underline styling

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -715,7 +715,6 @@ export default function ToolClient() {
                         rel="noopener noreferrer"
                         className={styles.link}
                         title={it.link}
-                        style={{ textDecoration: "underline" }}
                       >
                         🔗 {displayHost(it.link)}
                       </a>


### PR DESCRIPTION
Closes #17

## 概要
yutai-expiry に追加した「リンク機能」に関する最終的なUI整理です。
インライン指定していた underline を CSS に統一し、スタイルの一貫性を改善しました。

## 背景
リンク機能（保存 / 編集 / 表示 / コピー / 検索）は #18 で実装済み。
本PRはその仕上げとして、スタイル定義を CSS 側に寄せる軽微なリファクタリングを行っています。

## 変更内容
- リンク表示の underline 指定を inline style から CSS に統一
- 既存の `.link` / `.linkRow` スタイルを正式に使用
- 振る舞い・機能面の変更はなし（見た目のみ）

## 影響範囲
- yutai-expiry のカード / テーブル表示のみ
- データ構造・localStorage・挙動への影響なし

## 補足
リンク機能の要件（保存・編集・表示・コピー・検索）はすべて満たしているため、
本PRのマージと同時に Issue #17 をクローズします。