### PR TITLE
feat(yutai-memo): add user-defined tags with management modal

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -118,3 +118,28 @@
   border-color: #111;
   background: #f6f6f6;
 }
+
+/* ===== Tag Manager Modal ===== */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.dialog {
+  width: min(520px, calc(100vw - 24px));
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+}
+
+.dialogTitle {
+  font-weight: 700;
+  margin-bottom: 12px;
+}

--- a/app/tools/yutai-memo/storage.ts
+++ b/app/tools/yutai-memo/storage.ts
@@ -1,16 +1,48 @@
 // app/tools/yutai-memo/storage.ts
-import type { MemoItem } from "./types";
+import type { MemoItem, Tag } from "./types";
+import { DEFAULT_TAGS } from "./types";
 
-const KEY = "yutai_memo_items_v1";
+const ITEMS_KEY = "yutai_memo_items_v1";
+const TAGS_KEY = "yutai_memo_tags_v1";
+const MIGRATED_KEY = "yutai_memo_migrated_tags_v1";
+
+type LegacyTagKey = "early" | "one_share" | "tenure" | "failure" | "must";
+type LegacyMemoItem = Omit<MemoItem, "tagIds"> & { tags: LegacyTagKey[] };
+
+export function loadTags(): Tag[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(TAGS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as Tag[];
+    if (!Array.isArray(parsed)) return [];
+    // 正規化：createdAt が無い古いデータを補完（読み取り時に直す）
+    const normalized = parsed.map((t) =>
+      t && typeof t === "object" && "id" in t && "name" in t
+        ? ({ ...t, createdAt: (t as any).createdAt ?? Date.now() } as Tag)
+        : t
+    );
+    // ついでに保存して“次回から”補完不要にする（任意）
+    localStorage.setItem(TAGS_KEY, JSON.stringify(normalized));
+    return normalized;
+  } catch {
+    return [];
+  }
+}
+
+export function saveTags(tags: Tag[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(TAGS_KEY, JSON.stringify(tags));
+}
 
 export function loadItems(): MemoItem[] {
   if (typeof window === "undefined") return [];
+  migrateIfNeeded(); // ★ ここで旧データを救う
   try {
-    const raw = localStorage.getItem(KEY);
+    const raw = localStorage.getItem(ITEMS_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw) as MemoItem[];
-    if (!Array.isArray(parsed)) return [];
-    return parsed;
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
@@ -18,5 +50,61 @@ export function loadItems(): MemoItem[] {
 
 export function saveItems(items: MemoItem[]) {
   if (typeof window === "undefined") return;
-  localStorage.setItem(KEY, JSON.stringify(items));
+  localStorage.setItem(ITEMS_KEY, JSON.stringify(items));
+}
+
+function migrateIfNeeded() {
+  if (typeof window === "undefined") return;
+  if (localStorage.getItem(MIGRATED_KEY) === "1") return;
+
+  // tags がまだ無ければ初期タグを投入
+  const existingTags = loadTags();
+  if (existingTags.length === 0)
+    saveTags(DEFAULT_TAGS.map((t) => ({ ...t, createdAt: Date.now() })));
+
+  // 旧 items を見て、tags フィールドなら変換して保存し直す
+  const raw = localStorage.getItem(ITEMS_KEY);
+  if (!raw) {
+    localStorage.setItem(MIGRATED_KEY, "1");
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    localStorage.setItem(MIGRATED_KEY, "1");
+    return;
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    localStorage.setItem(MIGRATED_KEY, "1");
+    return;
+  }
+
+  const first = parsed[0] as any;
+  // 既に新形式なら何もしない
+  if (Array.isArray(first.tagIds)) {
+    localStorage.setItem(MIGRATED_KEY, "1");
+    return;
+  }
+
+  // 旧形式（tags: LegacyTagKey[]）とみなして変換
+  if (!Array.isArray(first.tags)) {
+    localStorage.setItem(MIGRATED_KEY, "1");
+    return;
+  }
+
+  const legacyItems = parsed as LegacyMemoItem[];
+
+  // legacyのタグは id がそのまま使える（early, one_share, ...）
+  const migrated: MemoItem[] = legacyItems.map((it) => {
+    const { tags, ...rest } = it as any;
+    return {
+      ...rest,
+      tagIds: (tags ?? []) as string[],
+    };
+  });
+
+  localStorage.setItem(ITEMS_KEY, JSON.stringify(migrated));
+  localStorage.setItem(MIGRATED_KEY, "1");
 }

--- a/app/tools/yutai-memo/types.ts
+++ b/app/tools/yutai-memo/types.ts
@@ -1,12 +1,16 @@
 // app/tools/yutai-memo/types.ts
-export type TagKey = "early" | "one_share" | "tenure" | "failure" | "must";
+export type Tag = {
+  id: string;
+  name: string;
+  createdAt: number;
+};
 
 export type MemoItem = {
   id: string;
   name: string;
   code?: string;
   months: number[]; // 1-12 (複数可)
-  tags: TagKey[];
+  tagIds: string[]; // ★ tags -> tagIds
   entryTiming?: string; // 早打ち目安
   tenureRule?: string; // 任期条件
   oneShareHold: boolean;
@@ -15,10 +19,10 @@ export type MemoItem = {
   updatedAt: string; // ISO
 };
 
-export const TAG_LABEL: Record<TagKey, string> = {
-  early: "早取り",
-  one_share: "長期1株",
-  tenure: "任期注意",
-  failure: "失敗ログ",
-  must: "鉄板",
-};
+export const DEFAULT_TAGS: Tag[] = [
+  { id: "early", name: "早取り", createdAt: 0 },
+  { id: "one_share", name: "長期1株", createdAt: 0 },
+  { id: "tenure", name: "任期注意", createdAt: 0 },
+  { id: "failure", name: "失敗ログ", createdAt: 0 },
+  { id: "must", name: "鉄板", createdAt: 0 },
+];


### PR DESCRIPTION
## 概要
yutai-memo にユーザー定義タグ機能を追加しました。

## 変更点
- タグをユーザーが追加・編集・削除可能
- タグ削除時は、付与済みメモから自動で外れる仕様（A）
- タグ管理用モーダルUIを追加
- 既存データは自動マイグレーションで保持

## 動作確認
- lint / build OK
- 既存データあり状態で正常起動
- タグCRUD / フィルタ / メモ編集すべて確認済み

Close #20
