### PR TITLE
fix(yutai-memo): constrain tag manager modal height and enable inner …

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -43,8 +43,10 @@
 .card {
   border: 1px solid #eee;
   border-radius: 14px;
-  padding: 12px;
+  padding: 8px 10px;
   background: #fff;
+  display: block; /* ★保険 */
+  width: 100%; /* ★保険 */
 }
 .list {
   display: grid;
@@ -129,6 +131,7 @@
   align-items: center;
   justify-content: center;
   z-index: 50;
+  padding: 12px;
 }
 
 .dialog {
@@ -137,9 +140,21 @@
   border-radius: 12px;
   padding: 16px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+  max-height: min(560px, calc(100vh - 24px));
+  display: flex;
+  flex-direction: column;
 }
 
 .dialogTitle {
   font-weight: 700;
   margin-bottom: 12px;
+}
+
+.dialogBody {
+  overflow: auto;
+  min-height: 0;
+}
+
+.dialogFooter {
+  margin-top: 12px;
 }

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -335,50 +335,52 @@ export default function ToolClient() {
               >
                 <div className={styles.dialogTitle}>タグ管理</div>
 
-                <div className={styles.row} style={{ gap: 8 }}>
-                  <input
-                    className={styles.input}
-                    placeholder="新しいタグ名"
-                    value={newTagName}
-                    onChange={(e) => setNewTagName(e.target.value)}
-                  />
-                  <button
-                    className={styles.btnPrimary}
-                    type="button"
-                    onClick={addTag}
-                  >
-                    追加
-                  </button>
-                </div>
+                <div className={styles.dialogBody}>
+                  <div className={styles.row} style={{ gap: 8 }}>
+                    <input
+                      className={styles.input}
+                      placeholder="新しいタグ名"
+                      value={newTagName}
+                      onChange={(e) => setNewTagName(e.target.value)}
+                    />
+                    <button
+                      className={styles.btnPrimary}
+                      type="button"
+                      onClick={addTag}
+                    >
+                      追加
+                    </button>
+                  </div>
 
-                <div style={{ marginTop: 10, display: "grid", gap: 8 }}>
-                  {tags.length === 0 ? (
-                    <div className={styles.small}>タグがありません</div>
-                  ) : (
-                    tags.map((t) => (
-                      <div
-                        key={t.id}
-                        className={styles.row}
-                        style={{ gap: 8, alignItems: "center" }}
-                      >
-                        <input
-                          className={styles.input}
-                          value={t.name}
-                          onChange={(e) => renameTag(t.id, e.target.value)}
-                        />
-                        <button
-                          className={styles.btn}
-                          type="button"
-                          onClick={() => deleteTag(t.id)}
+                  <div style={{ marginTop: 10, display: "grid", gap: 8 }}>
+                    {tags.length === 0 ? (
+                      <div className={styles.small}>タグがありません</div>
+                    ) : (
+                      tags.map((t) => (
+                        <div
+                          key={t.id}
+                          className={styles.row}
+                          style={{ gap: 8, alignItems: "center" }}
                         >
-                          削除
-                        </button>
-                      </div>
-                    ))
-                  )}
+                          <input
+                            className={styles.input}
+                            value={t.name}
+                            onChange={(e) => renameTag(t.id, e.target.value)}
+                          />
+                          <button
+                            className={styles.btn}
+                            type="button"
+                            onClick={() => deleteTag(t.id)}
+                          >
+                            削除
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
                 </div>
 
-                <div className={styles.actions} style={{ marginTop: 12 }}>
+                <div className={`${styles.actions} ${styles.dialogFooter}`}>
                   <button
                     className={styles.btn}
                     type="button"


### PR DESCRIPTION
## 概要
タグ管理モーダルの高さを制限し、内容が増えたときにモーダル内部だけスクロールするように調整しました。
タグ数が増えると画面からはみ出して操作しづらい問題の対策です。

## 変更点
- モーダル（dialog）の max-height を調整し、画面内に収まるように制限
- 本文領域（dialogBody）をスクロール可能にして、ヘッダー/フッターの視認性を維持

## 動作確認
- タグ数が多い状態で「タグ管理」を開いてもモーダルがフレームアウトしない
- モーダル内部のみスクロールできる
- 追加/削除/閉じるが従来通り動作する

## 関連
- refs #関連issueなし