### PR TITLE
feat(yutai-memo): add archive flow for acquired memos

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -83,6 +83,17 @@
   border-color: #111;
   background: #f6f6f6;
 }
+.archiveBtn {
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+  background: #fff;
+  font-size: 12px;
+}
+.archiveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 .chips {
   display: flex;
   gap: 8px;
@@ -187,4 +198,25 @@
 
 .dialogFooter {
   margin-top: 12px;
+}
+
+.archivePanel {
+  margin-top: 16px;
+  border: 1px solid #eee;
+  border-radius: 12px;
+  padding: 12px;
+  background: #fff;
+}
+.archiveTitle {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.archiveList {
+  display: grid;
+  gap: 8px;
+}
+.archiveRow {
+  border: 1px solid #f0f0f0;
+  border-radius: 10px;
+  padding: 8px 10px;
 }

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -2,9 +2,16 @@
 
 import { useEffect, useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
-import type { MemoItem, Tag } from "./types";
+import type { ArchivedMemoItem, MemoItem, Tag } from "./types";
 import { DEFAULT_TAGS } from "./types";
-import { loadItems, saveItems, loadTags, saveTags } from "./storage";
+import {
+  loadArchivedItems,
+  loadItems,
+  loadTags,
+  saveArchivedItems,
+  saveItems,
+  saveTags,
+} from "./storage";
 
 function uid() {
   // 十分実用（uuid不要ならこれでOK）
@@ -66,8 +73,17 @@ function saveSortState(state: SortState) {
   localStorage.setItem(SORT_KEY, JSON.stringify(state));
 }
 
+function formatArchiveDate(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+  return new Date(t).toLocaleString("ja-JP");
+}
+
 export default function ToolClient() {
   const [items, setItems] = useState<MemoItem[]>(() => loadItems());
+  const [archives, setArchives] = useState<ArchivedMemoItem[]>(() =>
+    loadArchivedItems()
+  );
 
   const [tags, setTags] = useState<Tag[]>(() => {
     const t = loadTags();
@@ -92,6 +108,10 @@ export default function ToolClient() {
   useEffect(() => {
     saveItems(items);
   }, [items]);
+
+  useEffect(() => {
+    saveArchivedItems(archives);
+  }, [archives]);
 
   useEffect(() => {
     saveTags(tags);
@@ -318,6 +338,38 @@ export default function ToolClient() {
     );
   }
 
+  function archiveMemo(id: string) {
+    const target = items.find((it) => it.id === id);
+    if (!target) return;
+    if (
+      !confirm(
+        "取得リストに追加し、メモを未取得に戻します。よろしいですか？"
+      )
+    )
+      return;
+
+    const now = new Date().toISOString();
+    setArchives((prev) => [
+      {
+        id: uid(),
+        memoId: target.id,
+        code: target.code,
+        name: target.name,
+        acquiredAt: now,
+        note: target.memo?.trim() || undefined,
+      },
+      ...prev,
+    ]);
+
+    setItems((prev) =>
+      prev.map((it) =>
+        it.id === id ? { ...it, acquired: false, updatedAt: now } : it
+      )
+    );
+
+    alert("アーカイブしました（取得リストに追加・未取得へ戻しました）。");
+  }
+
   const selectedCount = selectedIds.size;
 
   return (
@@ -496,6 +548,18 @@ export default function ToolClient() {
                       >
                         {it.acquired ? "取得済み" : "未取得"}
                       </button>
+                      <button
+                        type="button"
+                        className={styles.archiveBtn}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          archiveMemo(it.id);
+                        }}
+                        disabled={!it.acquired}
+                        title={it.acquired ? "取得履歴へ移動" : "取得済みのメモのみ対応"}
+                      >
+                        アーカイブ
+                      </button>
                       <div className={styles.small}>★{it.priority}</div>
                     </div>
                   </div>
@@ -527,6 +591,38 @@ export default function ToolClient() {
                   </div>
                 </div>
               ))
+            )}
+          </div>
+
+          <div className={styles.archivePanel}>
+            <div className={styles.archiveTitle}>
+              取得リスト（履歴）
+              <span className={styles.small} style={{ marginLeft: 8 }}>
+                {archives.length}件
+              </span>
+            </div>
+            {archives.length === 0 ? (
+              <div className={styles.small}>まだ履歴はありません。</div>
+            ) : (
+              <div className={styles.archiveList}>
+                {archives.slice(0, 20).map((a) => (
+                  <div key={a.id} className={styles.archiveRow}>
+                    <div style={{ fontWeight: 600 }}>
+                      {a.name}
+                      {a.code ? `（${a.code}）` : ""}
+                    </div>
+                    <div className={styles.small}>
+                      取得日: {formatArchiveDate(a.acquiredAt)}
+                    </div>
+                    {a.note ? (
+                      <div className={styles.small}>
+                        {a.note.slice(0, 80)}
+                        {a.note.length > 80 ? "…" : ""}
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
             )}
           </div>
 

--- a/app/tools/yutai-memo/storage.ts
+++ b/app/tools/yutai-memo/storage.ts
@@ -1,9 +1,10 @@
 // app/tools/yutai-memo/storage.ts
-import type { MemoItem, Tag } from "./types";
+import type { ArchivedMemoItem, MemoItem, Tag } from "./types";
 import { DEFAULT_TAGS } from "./types";
 
 const ITEMS_KEY = "yutai_memo_items_v1";
 const TAGS_KEY = "yutai_memo_tags_v1";
+const ARCHIVES_KEY = "yutai_memo_archives_v1";
 const MIGRATED_KEY = "yutai_memo_migrated_tags_v1";
 
 type LegacyTagKey = "early" | "one_share" | "tenure" | "failure" | "must";
@@ -62,6 +63,34 @@ export function loadItems(): MemoItem[] {
 export function saveItems(items: MemoItem[]) {
   if (typeof window === "undefined") return;
   localStorage.setItem(ITEMS_KEY, JSON.stringify(items));
+}
+
+export function loadArchivedItems(): ArchivedMemoItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(ARCHIVES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ArchivedMemoItem[];
+    if (!Array.isArray(parsed)) return [];
+    const normalized = parsed.filter(
+      (it) =>
+        it &&
+        typeof it === "object" &&
+        typeof (it as any).id === "string" &&
+        typeof (it as any).memoId === "string" &&
+        typeof (it as any).name === "string" &&
+        typeof (it as any).acquiredAt === "string"
+    );
+    localStorage.setItem(ARCHIVES_KEY, JSON.stringify(normalized));
+    return normalized;
+  } catch {
+    return [];
+  }
+}
+
+export function saveArchivedItems(items: ArchivedMemoItem[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(ARCHIVES_KEY, JSON.stringify(items));
 }
 
 function migrateIfNeeded() {

--- a/app/tools/yutai-memo/types.ts
+++ b/app/tools/yutai-memo/types.ts
@@ -21,6 +21,15 @@ export type MemoItem = {
   updatedAt: string; // ISO
 };
 
+export type ArchivedMemoItem = {
+  id: string;
+  memoId: string;
+  code?: string;
+  name: string;
+  acquiredAt: string; // ISO
+  note?: string;
+};
+
 export const DEFAULT_TAGS: Tag[] = [
   { id: "early", name: "早取り", createdAt: 0 },
   { id: "one_share", name: "長期1株", createdAt: 0 },


### PR DESCRIPTION
## 概要
Issue #33 に対応し、取得済みメモを履歴へ退避しつつ未取得へ戻すアーカイブフローを追加しました。

## 変更内容
- yutai-memo の型定義に取得履歴（archive）関連の型を追加
- storage に archive 処理と履歴保持ロジックを追加
- 一覧UIにアーカイブ導線（確認ダイアログ含む）を追加
- アーカイブ実行後の表示/状態更新を反映

## 確認項目（lint/test/動作確認）
- [x] npm run lint
- [x] 取得済みメモのアーカイブ実行で履歴追加 + 未取得へ戻ること
- [x] 一覧表示で既存の編集/取得トグル導線を壊していないこと

## 関連 Issue
Closes #33