### PR TITLE
UI(yutai-memo): move entitlement month to top-right status area

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -66,6 +66,21 @@
   align-items: flex-end;
   gap: 8px;
 }
+.monthPriorityRow {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+}
+.monthPriorityBadge {
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid #111;
+  background: #fffaf0;
+  color: #111;
+  font-size: 12px;
+  line-height: 1.2;
+  font-weight: 700;
+}
 .list {
   display: grid;
   gap: 10px;
@@ -175,6 +190,10 @@
   .cardSide {
     width: 100%;
     align-items: flex-end;
+  }
+
+  .monthPriorityRow {
+    justify-content: flex-end;
   }
 
   .statusRow {

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -852,6 +852,11 @@ export default function ToolClient() {
                         </div>
                       </div>
                       <div className={styles.cardSide}>
+                        <div className={styles.monthPriorityRow}>
+                          <span className={styles.monthPriorityBadge}>
+                            {it.months.join("/") + "月"}
+                          </span>
+                        </div>
                         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                           <button
                             type="button"
@@ -899,9 +904,6 @@ export default function ToolClient() {
                     </div>
 
                     <div className={styles.meta}>
-                      <span className={styles.chip}>
-                        {it.months.join("/") + "月"}
-                      </span>
                       {it.tagIds.map((id) => (
                         <span key={id} className={styles.chip}>
                           {tagNameById.get(id) ?? "（不明タグ）"}


### PR DESCRIPTION
## 概要
yutai-memo 一覧カードで、権利月をカード右上のステータス領域に移動し、最初に認識しやすい配置へ調整します。

## 変更内容
- 権利月をカード中段のタグ列から外し、右上ステータス領域の最上段に移動
- 権利月を優先表示する専用バッジを追加
- 既存の 未取得 / アーカイブ 操作や戦略・1株保有UIと干渉しないようレイアウト調整
- モバイルでも右上優先表示を維持するようCSS調整

## 確認項目
- [x] npm run lint
- [x] 権利月がカード右上の優先位置に表示される
- [x] 既存の状態操作と干渉しない
- [x] モバイルでも見づらくならない

## 関連 Issue
Closes #49