### PR TITLE
feat(yutai-memo): highlight current entitlement month badges

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -48,12 +48,6 @@
   display: block; /* ★保険 */
   width: 100%; /* ★保険 */
 }
-.cardCurrentMonth {
-  border-color: #d7b351;
-  background:
-    linear-gradient(180deg, rgba(255, 249, 228, 0.95), rgba(255, 255, 255, 1) 64%);
-  box-shadow: 0 0 0 1px rgba(215, 179, 81, 0.16);
-}
 .cardHeader {
   display: flex;
   justify-content: space-between;
@@ -75,6 +69,8 @@
 .monthPriorityRow {
   display: flex;
   justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
   width: 100%;
 }
 .monthPriorityBadge {
@@ -86,6 +82,12 @@
   font-size: 12px;
   line-height: 1.2;
   font-weight: 700;
+}
+.monthPriorityBadgeCurrent {
+  border-color: #c78b18;
+  background: #fff0c7;
+  color: #7a4f00;
+  box-shadow: 0 0 0 1px rgba(199, 139, 24, 0.12);
 }
 .list {
   display: grid;

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -159,9 +159,8 @@ function getNextCrossType(current?: CrossType): CrossType {
   return CROSS_TYPES[(index + 1) % CROSS_TYPES.length];
 }
 
-function isCurrentEntitlementMonth(months: number[]): boolean {
-  const currentMonth = toJstYearMonth(new Date()).month;
-  return months.includes(currentMonth);
+function isCurrentEntitlementMonth(month: number): boolean {
+  return toJstYearMonth(new Date()).month === month;
 }
 
 export default function ToolClient() {
@@ -836,11 +835,7 @@ export default function ToolClient() {
                       onChange={() => toggleSelect(it.id)}
                     />
                   </label>
-                  <div
-                    className={`${styles.card} ${
-                      isCurrentEntitlementMonth(it.months) ? styles.cardCurrentMonth : ""
-                    }`}
-                  >
+                  <div className={styles.card}>
                     <div className={styles.cardHeader}>
                       <div
                         className={styles.cardMain}
@@ -860,12 +855,21 @@ export default function ToolClient() {
                           {it.code ? `（${it.code}）` : ""}
                         </div>
                       </div>
-                      <div className={styles.cardSide}>
-                        <div className={styles.monthPriorityRow}>
-                          <span className={styles.monthPriorityBadge}>
-                            {it.months.join("/") + "月"}
-                          </span>
-                        </div>
+                        <div className={styles.cardSide}>
+                          <div className={styles.monthPriorityRow}>
+                            {it.months.map((month) => (
+                              <span
+                                key={`${it.id}-${month}`}
+                                className={`${styles.monthPriorityBadge} ${
+                                  isCurrentEntitlementMonth(month)
+                                    ? styles.monthPriorityBadgeCurrent
+                                    : ""
+                                }`}
+                              >
+                                {month}月
+                              </span>
+                            ))}
+                          </div>
                         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                           <button
                             type="button"


### PR DESCRIPTION
## 概要
権利月が当月に一致するメモで、該当する権利月バッジだけを強調表示します。

## 変更内容
- 右上の権利月表示を月ごとのバッジに分割
- JST 基準の当月と一致する権利月バッジだけに強調スタイルを適用
- カード全体の強調表示は廃止

## 確認項目
- npm run lint
- 権利月が複数あるカードでも当月のバッジだけ色が付くことを確認
- 当月に一致しないカードは従来どおりの見た目であることを確認

## 関連 Issue
Closes #50