### PR TITLE
refactor(yutai-memo): rearrange top control groups

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -9,11 +9,40 @@
   font-weight: 700;
   margin-bottom: 12px;
 }
+.pageHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.headerActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
 .row {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
   align-items: center;
+}
+.searchGroup {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.searchInput {
+  flex: 1 1 320px;
+}
+.sortGroup {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 10px;
 }
 .input {
   width: 100%;
@@ -199,6 +228,23 @@
 }
 
 @media (max-width: 640px) {
+  .pageHeader {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .headerActions {
+    width: 100%;
+  }
+
+  .searchGroup {
+    width: 100%;
+  }
+
+  .searchInput {
+    flex-basis: 100%;
+  }
+
   .cardHeader {
     flex-direction: column;
   }

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -743,13 +743,27 @@ export default function ToolClient() {
 
   return (
     <div className={styles.wrap}>
-      <div className={styles.h1}>優待銘柄メモ帳</div>
-
       {mode === "list" ? (
         <>
-          <div className={styles.row}>
+          <div className={styles.pageHeader}>
+            <div className={styles.h1}>優待銘柄メモ帳</div>
+            <div className={styles.headerActions}>
+              <button className={styles.btnPrimary} onClick={openNew}>
+                + 追加
+              </button>
+              <button
+                className={styles.btn}
+                type="button"
+                onClick={openTagManager}
+              >
+                タグ管理
+              </button>
+            </div>
+          </div>
+
+          <div className={styles.searchGroup}>
             <input
-              className={styles.input}
+              className={`${styles.input} ${styles.searchInput}`}
               placeholder="検索（銘柄/コード/メモ/任期/早打ち目安）"
               value={q}
               onChange={(e) => {
@@ -757,9 +771,6 @@ export default function ToolClient() {
                 setQ(e.target.value);
               }}
             />
-          </div>
-
-          <div className={styles.row} style={{ marginTop: 10 }}>
             <select
               className={styles.select}
               value={monthFilter}
@@ -791,6 +802,9 @@ export default function ToolClient() {
                 </option>
               ))}
             </select>
+          </div>
+
+          <div className={styles.sortGroup}>
             <select
               className={styles.select}
               value={sortState.key}
@@ -815,16 +829,6 @@ export default function ToolClient() {
               <option value="desc">順序: 降順</option>
               <option value="asc">順序: 昇順</option>
             </select>
-            <button className={styles.btnPrimary} onClick={openNew}>
-              + 追加
-            </button>
-            <button
-              className={styles.btn}
-              type="button"
-              onClick={openTagManager}
-            >
-              タグ管理
-            </button>
           </div>
 
           <div className={styles.bulkBar}>


### PR DESCRIPTION
## 概要
yutai-memo の上部操作エリアを役割ごとに再配置し、関連する操作が近く見えるように整理します。

## 変更内容
- タイトル行右側へ +追加 / タグ管理 を移動
- 検索 / 権利月 / タグ を近い位置に再配置
- 並び替え / 順序 を独立した段に整理
- 一括操作行は独立下段のまま維持
- モバイルでの段落ちを抑えるための CSS 調整

## 確認項目
- npm run lint
- タイトル行で 優待銘柄メモ帳 と +追加 / タグ管理 が同段に見えること
- 検索 / 権利月 / タグ が近い位置でまとまっていること
- 並び替え / 順序 が独立した段として見えること
- PC/モバイルの両方で大きく破綻しないこと

## 関連 Issue
Closes #57