### PR TITLE
fix(yutai-memo): follow up top controls mobile alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - `main` へ直接コミットしない。必ず feature ブランチで作業する。
 - 1 PR = 1 目的。無関係な差分は混ぜない。
 - 変更前後で `git status --short` を確認する。
+- スクショ確認やレビュー後に追加修正した場合、PRマージ前に `git status --short` を確認し、未コミット差分が残っていないことを必ず確認する。
 - `next-env.d.ts` などの環境起因ファイルは、意図がない限りコミットしない。
 - コミット前に最低 `npm run lint` を実行する。
 
@@ -78,6 +79,7 @@ git push
 ## 7. マージ
 
 ```powershell
+git status --short
 gh pr merge <PR番号> --merge --delete-branch=false
 ```
 

--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -16,6 +16,9 @@
   gap: 12px;
   margin-bottom: 12px;
 }
+.pageHeader .h1 {
+  margin-bottom: 0;
+}
 .headerActions {
   display: flex;
   gap: 8px;
@@ -33,9 +36,12 @@
   gap: 8px;
   flex-wrap: wrap;
   align-items: center;
+  margin-top: 10px;
 }
 .searchInput {
-  flex: 1 1 320px;
+  flex: 1 1 260px;
+  min-width: 0;
+  width: auto;
 }
 .sortGroup {
   display: flex;
@@ -229,12 +235,12 @@
 
 @media (max-width: 640px) {
   .pageHeader {
-    align-items: flex-start;
-    flex-direction: column;
+    align-items: center;
+    flex-direction: row;
   }
 
   .headerActions {
-    width: 100%;
+    width: auto;
   }
 
   .searchGroup {
@@ -242,7 +248,8 @@
   }
 
   .searchInput {
-    flex-basis: 100%;
+    flex: 1 1 180px;
+    width: auto;
   }
 
   .cardHeader {


### PR DESCRIPTION
## 概要
PR #62 の後に確認された、上部操作エリアのモバイル表示ずれを follow-up で修正します。あわせて、同種の取りこぼしを防ぐため AGENTS.md にマージ前チェックを追加します。

## 変更内容
- タイトル行内で見出しの下マージンを打ち消し
- モバイル時に +追加 / タグ管理 がタイトルと別段にならないよう調整
- 検索欄が 権利月 / タグ と同段に収まりやすいよう調整
- AGENTS.md にマージ前の git status --short 確認ルールを追加

## 確認項目
- npm run lint
- モバイルで 優待銘柄メモ帳 と +追加 / タグ管理 が同段に見えること
- モバイルで 検索 / 権利月 / タグ が横に並びやすくなっていること
- AGENTS.md に再発防止ルールが追記されていること

## 関連 Issue
- Follow-up of #57