### PR TITLE
feat(yutai-memo): collapse sort controls

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -52,9 +52,23 @@
 }
 .sortToggleRow {
   display: flex;
-  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+.sortToggleBtn {
+  display: inline-flex;
   align-items: center;
-  margin-top: 10px;
+  gap: 6px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: #666;
+  font-size: 12px;
+  line-height: 1.2;
+}
+.sortToggleChevron {
+  font-size: 10px;
+  color: #888;
 }
 .input {
   width: 100%;

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -807,12 +807,14 @@ export default function ToolClient() {
 
           <div className={styles.sortToggleRow}>
             <button
-              className={styles.btn}
+              className={styles.sortToggleBtn}
               type="button"
               onClick={() => setSortControlsOpen((prev) => !prev)}
             >
-              並び替え設定
-              {sortControlsOpen ? " ▲" : " ▼"}
+              表示順を変更
+              <span className={styles.sortToggleChevron} aria-hidden="true">
+                {sortControlsOpen ? "▲" : "▼"}
+              </span>
             </button>
           </div>
 


### PR DESCRIPTION
## 概要
yutai-memo の 並び替え / 順序 操作を通常時は折りたたみ、必要なときだけ展開できるようにします。

## 変更内容
- 表示順を変更 トグルを追加
- 初期状態では 並び替え / 順序 を非表示
- トグル押下で 並び替え / 順序 を展開
- トグルの見た目を補助操作寄りに軽く調整

## 確認項目
- npm run lint
- 初期表示時に 並び替え / 順序 が閉じていること
- トグル押下で既存の 並び替え / 順序 操作が使えること
- モバイルで縦占有と圧迫感が現状より減っていること

## 関連 Issue
Closes #59