### PR TITLE
feat(yutai-memo): compact bulk action bar

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -149,19 +149,46 @@
   gap: 10px;
   margin-top: 12px;
 }
+.bulkBarSection {
+  margin-top: 10px;
+}
+.bulkBarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
 .bulkBar {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 .bulkBarCount {
+  display: inline-flex;
+  align-items: center;
   font-size: 12px;
   color: #666;
+  line-height: 1.2;
 }
 .bulkBarButton {
   white-space: nowrap;
+}
+.bulkBarToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: #666;
+  font-size: 12px;
+  line-height: 1.2;
+}
+.bulkBarChevron {
+  font-size: 10px;
+  color: #888;
 }
 .cardRow {
   display: grid;
@@ -284,9 +311,17 @@
     align-items: flex-start;
   }
 
+  .bulkBarHeader {
+    align-items: center;
+  }
+
   .bulkBarCount {
     font-size: 11px;
     line-height: 1.2;
+  }
+
+  .bulkBarToggle {
+    font-size: 11px;
   }
 
   .bulkBarButton {

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -184,6 +184,7 @@ export default function ToolClient() {
   const [tagFilter, setTagFilter] = useState<string | "all">("all");
   const [sortState, setSortState] = useState<SortState>(() => loadSortState());
   const [sortControlsOpen, setSortControlsOpen] = useState(false);
+  const [bulkActionsOpen, setBulkActionsOpen] = useState(false);
 
   const [draft, setDraft] = useState<Draft>(emptyDraft());
   const [mode, setMode] = useState<"list" | "edit">("list");
@@ -847,46 +848,63 @@ export default function ToolClient() {
             </div>
           ) : null}
 
-          <div className={styles.bulkBar}>
-            <div className={styles.bulkBarCount}>{selectedCount}件選択中</div>
-            <button
-              className={`${styles.btn} ${styles.bulkBarButton}`}
-              type="button"
-              onClick={selectAllVisible}
-            >
-              全選択
-            </button>
-            <button
-              className={`${styles.btn} ${styles.bulkBarButton}`}
-              type="button"
-              onClick={clearSelection}
-            >
-              全解除
-            </button>
-            <button
-              className={`${styles.btn} ${styles.bulkBarButton}`}
-              type="button"
-              onClick={() => bulkSetAcquired(true)}
-              disabled={selectedCount === 0}
-            >
-              取得済みにする
-            </button>
-            <button
-              className={`${styles.btn} ${styles.bulkBarButton}`}
-              type="button"
-              onClick={() => bulkSetAcquired(false)}
-              disabled={selectedCount === 0}
-            >
-              未取得に戻す
-            </button>
-            <button
-              className={`${styles.btn} ${styles.bulkBarButton}`}
-              type="button"
-              onClick={bulkRemoveSelected}
-              disabled={selectedCount === 0}
-            >
-              削除
-            </button>
+          <div className={styles.bulkBarSection}>
+            <div className={styles.bulkBarHeader}>
+              <div className={styles.bulkBarCount}>{selectedCount}件選択中</div>
+              <button
+                className={styles.bulkBarToggle}
+                type="button"
+                onClick={() => setBulkActionsOpen((prev) => !prev)}
+              >
+                一括操作
+                <span className={styles.bulkBarChevron} aria-hidden="true">
+                  {bulkActionsOpen ? "▲" : "▼"}
+                </span>
+              </button>
+            </div>
+
+            {bulkActionsOpen ? (
+              <div className={styles.bulkBar}>
+                <button
+                  className={`${styles.btn} ${styles.bulkBarButton}`}
+                  type="button"
+                  onClick={selectAllVisible}
+                >
+                  全選択
+                </button>
+                <button
+                  className={`${styles.btn} ${styles.bulkBarButton}`}
+                  type="button"
+                  onClick={clearSelection}
+                >
+                  全解除
+                </button>
+                <button
+                  className={`${styles.btn} ${styles.bulkBarButton}`}
+                  type="button"
+                  onClick={() => bulkSetAcquired(true)}
+                  disabled={selectedCount === 0}
+                >
+                  取得済みにする
+                </button>
+                <button
+                  className={`${styles.btn} ${styles.bulkBarButton}`}
+                  type="button"
+                  onClick={() => bulkSetAcquired(false)}
+                  disabled={selectedCount === 0}
+                >
+                  未取得に戻す
+                </button>
+                <button
+                  className={`${styles.btn} ${styles.bulkBarButton}`}
+                  type="button"
+                  onClick={bulkRemoveSelected}
+                  disabled={selectedCount === 0}
+                >
+                  削除
+                </button>
+              </div>
+            ) : null}
           </div>
 
           <div className={styles.list}>


### PR DESCRIPTION
## 概要
yutai-memo の一括操作行をモバイルで圧縮し、必要時だけ展開できるようにします。

## 変更内容
- 一括操作行の件数表示とボタンの縦位置を調整
- モバイルでボタン余白・文字サイズを圧縮
- 一括操作 トグルを追加
- 初期状態では件数表示とトグルのみを表示し、必要時だけ操作ボタン群を展開

## 確認項目
- npm run lint
- 