### PR TITLE
feat(yutai-memo): default month filter to current month

### DIFF
--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -180,7 +180,9 @@ export default function ToolClient() {
   });
 
   const [q, setQ] = useState("");
-  const [monthFilter, setMonthFilter] = useState<number | "all">("all");
+  const [monthFilter, setMonthFilter] = useState<number | "all">(
+    () => toJstYearMonth(new Date()).month
+  );
   const [tagFilter, setTagFilter] = useState<string | "all">("all");
   const [sortState, setSortState] = useState<SortState>(() => loadSortState());
   const [sortControlsOpen, setSortControlsOpen] = useState(false);


### PR DESCRIPTION
## 概要
yutai-memo の権利月フィルタ初期値を すべて から JST 基準の当月へ変更します。

## 変更内容
- monthFilter の初期値を JST 基準の当月に変更
- すべて を含む既存の切り替え挙動は維持

## 確認項目
- npm run lint
- 初期表示時に権利月フィルタが当月になっていること
- すべて を含む既存の切り替えがそのまま使えること

## 関連 Issue
Closes #58