### PR TITLE
style(yutai-memo): add floating card surface

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -3,6 +3,8 @@
   max-width: 760px;
   margin: 0 auto;
   padding: 16px;
+  border-radius: 24px;
+  background: #f4f5f7;
 }
 .h1 {
   font-size: 20px;
@@ -96,10 +98,11 @@
   color: #fff;
 }
 .card {
-  border: 1px solid #eee;
+  border: 1px solid #eceef2;
   border-radius: 14px;
   padding: 8px 10px;
   background: #fff;
+  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.06);
   display: block; /* ★保険 */
   width: 100%; /* ★保険 */
 }
@@ -439,10 +442,11 @@
 
 .archivePanel {
   margin-top: 16px;
-  border: 1px solid #eee;
+  border: 1px solid #eceef2;
   border-radius: 12px;
   padding: 12px;
   background: #fff;
+  box-shadow: 0 8px 20px rgba(17, 24, 39, 0.05);
 }
 .archiveTitle {
   font-weight: 700;
@@ -453,7 +457,7 @@
   gap: 8px;
 }
 .archiveGroup {
-  border: 1px solid #f0f0f0;
+  border: 1px solid #f0f1f4;
   border-radius: 10px;
   background: #fff;
 }
@@ -482,9 +486,11 @@
   transform: rotate(180deg);
 }
 .archiveRow {
-  border: 1px solid #f0f0f0;
+  border: 1px solid #eef0f3;
   border-radius: 10px;
   padding: 8px 10px;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(17, 24, 39, 0.04);
 }
 .archiveRowHead {
   display: flex;


### PR DESCRIPTION
## 概要
yutai-memo の背景を薄いグレー寄りにし、カードを白地で少し浮いて見えるように調整します。

## 変更内容
- 画面全体の背景を薄いグレー系に調整
- カードに控えめなシャドーを追加
- 履歴パネルと履歴行にも同系統の控えめシャドーを追加
- カード面が背景から少し浮いて見えるように調整

## 確認項目
- npm run lint
- 背景が薄いグレー系になっていること
- メモカードと履歴パネルが白地で少し浮いて見えること
- シャドーが強すぎず、可読性を損なっていないこと
- PC/モバイルの両方で大きく破綻しないこと

## 関連 Issue
Closes #67