### PR TITLE
fix(yutai-memo): align memo cards and archive panel

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -1,5 +1,11 @@
 /* app/tools/yutai-memo/ToolClient.module.css */
 .wrap {
+  --selection-col-width: 18px;
+  --selection-col-gap: 6px;
+  --selection-col-offset: calc(
+    var(--selection-col-width) + var(--selection-col-gap)
+  );
+  --content-right-gap: 10px;
   max-width: 760px;
   margin: 0 auto;
   padding: 16px;
@@ -101,6 +107,7 @@
   border: 1px solid #eceef2;
   border-radius: 14px;
   padding: 8px 10px;
+  box-sizing: border-box;
   background: #fff;
   box-shadow: 0 6px 18px rgba(17, 24, 39, 0.06);
   display: block; /* ★保険 */
@@ -151,6 +158,7 @@
   display: grid;
   gap: 10px;
   margin-top: 12px;
+  padding-right: var(--content-right-gap);
 }
 .bulkBarSection {
   margin-top: 10px;
@@ -195,11 +203,12 @@
 }
 .cardRow {
   display: grid;
-  grid-template-columns: 28px 1fr;
-  gap: 8px;
+  grid-template-columns: var(--selection-col-width) 1fr;
+  gap: var(--selection-col-gap);
   align-items: start;
 }
 .selectBox {
+  width: var(--selection-col-width);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -291,6 +300,12 @@
 }
 
 @media (max-width: 640px) {
+  .wrap {
+    --selection-col-width: 16px;
+    --selection-col-gap: 4px;
+    --content-right-gap: 8px;
+  }
+
   .pageHeader {
     align-items: center;
     flex-direction: row;
@@ -481,6 +496,9 @@
 
 .archivePanel {
   margin-top: 16px;
+  margin-left: var(--selection-col-offset);
+  width: calc(100% - var(--selection-col-offset) - var(--content-right-gap));
+  box-sizing: border-box;
   border: 1px solid #eceef2;
   border-radius: 12px;
   padding: 12px;


### PR DESCRIPTION
## 概要
- メモカード一覧と取得リスト（履歴）の左右位置を揃えます
- 一覧カードが右に寄りすぎて見える問題も合わせて調整します

## 変更内容
- 選択チェック列の幅と gap を縮小
- 一覧側に右余白を追加して、カード外側の右余白を確保
- 取得リストパネルにも同じ右余白と左オフセットを適用
- カードに ox-sizing: border-box を追加し、右端計算を一致させる

## 確認項目
- [x] npm run lint
- [x] 一覧カードと取得リストの左右位置が揃うことを確認
- [x] 一覧カードが右に寄りすぎて見えないことを確認

## 関連 Issue
- Closes #69