### PR TITLE
docs(agents): use body-file for multiline gh comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - 変更前後で `git status --short` を確認する。
 - スクショ確認やレビュー後に追加修正した場合、PRマージ前に `git status --short` を確認し、未コミット差分が残っていないことを必ず確認する。
 - Issue はタイトルだけで「どの tool の、何の話か」が分かるように書く（例: `UI(yutai-memo): ...`, `feat(yutai-expiry): ...`, `TOP-UI: ...`）。
+- `gh issue create` / `gh issue comment` / `gh pr create` / `gh pr comment` で複数行本文を渡すときは、CLI の `--body "..."` に直接改行を書かず、本文ファイル（例: 一時 `.md`）を作って `--body-file` で渡す。
 - `next-env.d.ts` などの環境起因ファイルは、意図がない限りコミットしない。
 - コミット前に最低 `npm run lint` を実行する。
 


### PR DESCRIPTION
## 概要
- GitHub Issue / PR の複数行本文を CLI で扱うときの運用ルールを追加します

## 変更内容
- `gh issue create` / `gh issue comment` / `gh pr create` / `gh pr comment` で複数行本文を扱うときは、`--body` に直接改行を書かず `--body-file` を使うルールを追加

## 確認項目
- [x] npm run lint
- [x] 新ルールに従って #28 のコメント・クローズを実施

## 関連 Issue
- なし
