### PR TITLE
fix(top-ui): smooth shared header scroll behavior

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
         ) : null}
       </head>
 
-      <body>
+      <body style={{ margin: 0 }}>
         <Header />
         {children}
       </body>


### PR DESCRIPTION
## 概要
- 共通ヘッダーがスクロール時に中途半端に動いて見える違和感を軽減します

## 変更内容
- `app/layout.tsx` の `body` に `margin: 0` を追加
- ブラウザ標準の body 余白による sticky ヘッダーの段差感を解消

## 確認項目
- [x] npm run lint
- [x] npm run build
- [x] スクロール時のヘッダー違和感が解消されることを確認

## 関連 Issue
- Closes #60
