### PR TITLE
fix(yutai-memo): normalize ticker search input

### DIFF
--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -180,6 +180,9 @@ function normalizeTickerSearch(value: string): string {
   return value
     .normalize("NFKC")
     .toLowerCase()
+    .replace(/[\u30a1-\u30f6]/g, (char) =>
+      String.fromCharCode(char.charCodeAt(0) - 0x60)
+    )
     .replace(/\s+/g, "");
 }
 


### PR DESCRIPTION
## 概要
- 銘柄マスタ検索で、ひらがな / カタカナ と英字の大文字 / 小文字を区別しないようにします

## 変更内容
- `normalizeTickerSearch()` にカタカナ→ひらがな変換を追加
- 既存の `toLowerCase()` と合わせて、英字の大文字 / 小文字差も吸収
- これにより検索時の表記ゆれで候補が漏れにくくなる

## 確認項目
- [x] npm run lint
- [x] npm run build
- [x] 検索正規化の変更がビルドを壊していないことを確認

## 関連 Issue
- Closes #75
