### PR TITLE
fix(yutai-memo): tighten mobile search row sizing

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -80,11 +80,13 @@
 }
 .input {
   width: 100%;
+  box-sizing: border-box;
   padding: 10px 12px;
   border: 1px solid #ddd;
   border-radius: 10px;
 }
 .select {
+  box-sizing: border-box;
   padding: 10px 12px;
   border: 1px solid #ddd;
   border-radius: 10px;
@@ -317,11 +319,23 @@
 
   .searchGroup {
     width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 88px 112px;
+    gap: 6px;
+    align-items: stretch;
   }
 
   .searchInput {
-    flex: 1 1 180px;
-    width: auto;
+    width: 100%;
+    min-width: 0;
+    flex: none;
+  }
+
+  .searchGroup .select {
+    width: 100%;
+    min-width: 0;
+    padding: 10px 8px;
+    font-size: 14px;
   }
 
   .bulkBar {


### PR DESCRIPTION
## 概要
- モバイル時の検索行が横幅不足で2段化・重なりを起こしやすかったため調整します

## 変更内容
- モバイル時の `検索 / 権利月 / タグ` 行を grid ベースに調整
- input / select に `box-sizing: border-box` を追加
- 検索欄とセレクトの幅計算を安定させ、Pixel 10 Pro 相当でも1段に収まりやすくする

## 確認項目
- [x] npm run lint
- [x] モバイル幅で検索行が重ならないことを確認
- [x] 検索欄・権利月・タグが1段に収まりやすくなっていることを確認

## 関連 Issue
- なし
