### PR TITLE
fix(yutai-memo): normalize ticker display width

### DIFF
--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -195,6 +195,10 @@ function toOpenableUrl(value: string): string {
   return `https://${trimmed}`;
 }
 
+function normalizeDisplayText(value: string): string {
+  return value.normalize("NFKC");
+}
+
 export default function ToolClient() {
   const [items, setItems] = useState<MemoItem[]>(() => loadItems());
   const [archives, setArchives] = useState<ArchivedMemoItem[]>(() =>
@@ -1129,8 +1133,8 @@ export default function ToolClient() {
                         }}
                       >
                         <div style={{ fontWeight: 700 }}>
-                          {it.name}
-                          {it.code ? `（${it.code}）` : ""}
+                          {normalizeDisplayText(it.name)}
+                          {it.code ? ` (${normalizeDisplayText(it.code)})` : ""}
                         </div>
                       </div>
                         <div className={styles.cardSide}>


### PR DESCRIPTION
## 概要
- `yutai-memo` のカードタイトル表示で、全角英数字を半角寄せにしました

## 変更内容
- カード表示時のみ `NFKC` 正規化を適用
- 銘柄名と銘柄コードの表示幅を詰めて、狭い幅での折り返しを緩和
- 保存データ自体は変更しない

## 確認項目
- `npm run lint`
- `npm run build`

## 関連 Issue
- Closes #87
