### PR TITLE
fix(yutai-memo): restore list scroll on return

### DIFF
--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -221,6 +221,7 @@ export default function ToolClient() {
 
   const [draft, setDraft] = useState<Draft>(emptyDraft());
   const [mode, setMode] = useState<"list" | "edit">("list");
+  const [listScrollY, setListScrollY] = useState<number | null>(null);
 
   const [tagManagerOpen, setTagManagerOpen] = useState(false);
   const [newTagName, setNewTagName] = useState("");
@@ -277,6 +278,24 @@ export default function ToolClient() {
   useEffect(() => {
     saveSortState(sortState);
   }, [sortState]);
+
+  useEffect(() => {
+    if (mode !== "list" || listScrollY === null || typeof window === "undefined") {
+      return;
+    }
+    let frame1 = 0;
+    let frame2 = 0;
+    frame1 = window.requestAnimationFrame(() => {
+      frame2 = window.requestAnimationFrame(() => {
+        window.scrollTo({ top: listScrollY, behavior: "auto" });
+        setListScrollY(null);
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(frame1);
+      window.cancelAnimationFrame(frame2);
+    };
+  }, [mode, listScrollY]);
 
   const tagNameById = useMemo(() => {
     const m = new Map<string, string>();
@@ -336,6 +355,9 @@ export default function ToolClient() {
   }, [items, q, monthFilter, tagFilter, tagNameById, sortState]);
 
   function openNew(seed?: Partial<Draft>) {
+    if (typeof window !== "undefined") {
+      setListScrollY(window.scrollY);
+    }
     setDraft({ ...emptyDraft(), ...seed });
     setMode("edit");
   }
@@ -355,6 +377,9 @@ export default function ToolClient() {
   }
 
   function openEdit(it: MemoItem) {
+    if (typeof window !== "undefined") {
+      setListScrollY(window.scrollY);
+    }
     setDraft({
       id: it.id,
       createdAt: it.createdAt,


### PR DESCRIPTION
概要
- 優待メモで詳細を開いて戻った時に、一覧のスクロール位置を復元する

変更内容
- 一覧から編集に入る直前の `window.scrollY` を保持
- `mode` が `list` に戻ったタイミングでスクロール位置を復元
- `+追加` から編集に入る場合も同じ仕組みを使用

確認項目
- npm run lint
- npm run build
- 一覧をスクロールして詳細を開き、戻る/保存後に前回位置へ戻ること

関連 Issue
- Closes #90
