### PR TITLE
feat(top-seo): add sitemap and robots

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://mini-tools-rho.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: new URL("/sitemap.xml", SITE_URL).toString(),
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://mini-tools-rho.vercel.app";
+
+const ROUTES = [
+  "/",
+  "/tools/charcount",
+  "/tools/total",
+  "/tools/yutai-expiry",
+  "/tools/yutai-memo",
+] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return ROUTES.map((route) => ({
+    url: new URL(route, SITE_URL).toString(),
+    lastModified: now,
+    changeFrequency: route === "/" ? "weekly" : "monthly",
+    priority: route === "/" ? 1 : 0.8,
+  }));
+}


### PR DESCRIPTION
概要
- mini-tools の SEO 基盤として sitemap と robots を追加しました。

変更内容
- app/sitemap.ts を追加して主要ページの sitemap.xml を生成
- app/robots.ts を追加して robots.txt を生成
- sitemap の対象はトップページと各ツールページを静的に列挙
- metadataBase と同じサイトURL基準で sitemap / host を生成

確認項目
- npm run lint
- npm run build
- build 結果で /sitemap.xml と /robots.txt が生成されることを確認

関連 Issue
- Refs #95
