### PR TITLE
fix(yutai-memo): widen card tap area

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -126,6 +126,18 @@
   box-shadow: 0 6px 18px rgba(17, 24, 39, 0.06);
   display: block; /* ★保険 */
   width: 100%; /* ★保険 */
+  cursor: pointer;
+  transition:
+    box-shadow 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
+}
+.card:hover {
+  border-color: #e3e7ef;
+  box-shadow: 0 9px 22px rgba(17, 24, 39, 0.08);
+}
+.card:active {
+  transform: translateY(1px);
 }
 .cardHeader {
   display: grid;
@@ -400,6 +412,11 @@
 
   .cardHeader {
     gap: 6px;
+  }
+
+  .card:hover {
+    border-color: #eceef2;
+    box-shadow: 0 6px 18px rgba(17, 24, 39, 0.06);
   }
 
   .formTwoCol {

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -391,6 +391,11 @@ export default function ToolClient() {
     setTagManagerOpen(false);
   }
 
+  function shouldOpenEditFromCard(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) return true;
+    return !target.closest("button, a, input, label");
+  }
+
   function openEdit(it: MemoItem) {
     if (typeof window !== "undefined") {
       setListScrollY(window.scrollY);
@@ -1179,7 +1184,13 @@ export default function ToolClient() {
                       onChange={() => toggleSelect(it.id)}
                     />
                   </label>
-                  <div className={styles.card}>
+                  <div
+                    className={styles.card}
+                    onClick={(e) => {
+                      if (!shouldOpenEditFromCard(e.target)) return;
+                      openEdit(it);
+                    }}
+                  >
                     <div className={styles.cardHeader}>
                       <div className={styles.cardHeaderTop}>
                         <div


### PR DESCRIPTION
## 概要
- yutai-memo のカードで、編集を開くタップ範囲を広げます
- #72 はタップ範囲改善だけに絞り、長押し導線は #104 へ分離しました

## 変更内容
- カード本体クリックで編集を開けるよう変更
- ただし `button / a / input / label` は除外し、既存の独立操作を維持
- カード全体に控えめな hover / active を追加して、押せる場所が分かりやすい見た目に調整
- #72 の Issue 本文をタップ範囲改善専用に更新
- 長押し選択の検討 Issue #104 を追加

## 確認項目
- `npm run lint`
- `npm run build`
- カード本文・タグ・メモを押すと編集が開く
- 右側の状態ボタン、戦略、1株保有、関連リンクは従来どおり個別動作する

## 関連 Issue
- Closes #72
- Related #104
