### PR TITLE
docs(agents): require codex review before merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,14 @@ PR 本文に必ず記載する項目:
 ## 6. レビュー確認と対応
 
 ```powershell
+# PR作成後、マージ前に Codex CLI review を1回実施する
+codex review --base main
 gh pr view <PR番号> --comments
 gh api repos/Yuichi-TanakaJP/mini-tools/pulls/<PR番号>/reviews
 gh api repos/Yuichi-TanakaJP/mini-tools/pulls/<PR番号>/comments
 ```
 
+- Codex review は、PR作成後の差分に対して必ず1回実施する。
 - P1/P0 指摘は優先対応する。
 - 修正後は同じブランチで再コミットし push する。
 


### PR DESCRIPTION
## 概要
- AGENTS.md に、PR マージ前の Codex CLI review 実施ルールを追加します

## 変更内容
- レビュー確認手順に `codex review --base main` を追加
- PR 作成後、マージ前に Codex review を1回通すことを明記

## 確認項目
- ドキュメント変更のみ

## 関連 Issue
- なし
