### PR TITLE
fix(calendar): avoid duplicate keys in empty months

### DIFF
--- a/app/tools/earnings-calendar/ToolClient.tsx
+++ b/app/tools/earnings-calendar/ToolClient.tsx
@@ -71,7 +71,7 @@ function createEmptyMonth(id: string, updatedAt: string): CalendarMonth {
 
   for (let index = 0; index < firstWeekday; index += 1) {
     const mutedDay = prevMonthLastDay - firstWeekday + index + 1;
-    const prevDate = new Date(Date.UTC(year, month - 1, mutedDay));
+    const prevDate = new Date(Date.UTC(year, month - 2, mutedDay));
     cells.push({
       key: `${prevDate.getUTCFullYear()}-${String(prevDate.getUTCMonth() + 1).padStart(2, "0")}-${String(
         prevDate.getUTCDate(),
@@ -163,7 +163,7 @@ function buildMonths(data: EarningsCalendarResponse): CalendarMonth[] {
 
       for (let index = 0; index < firstWeekday; index += 1) {
         const mutedDay = prevMonthLastDay - firstWeekday + index + 1;
-        const prevDate = new Date(Date.UTC(year, month - 1, mutedDay));
+        const prevDate = new Date(Date.UTC(year, month - 2, mutedDay));
         cells.push({
           key: `${prevDate.getUTCFullYear()}-${String(prevDate.getUTCMonth() + 1).padStart(2, "0")}-${String(
             prevDate.getUTCDate(),


### PR DESCRIPTION
## 概要
空月へ移動したときに決算カレンダーの日付セル key が重複する問題を修正します。

## 変更内容
- 前月の薄いセルを生成する日付計算を修正
- 2026年4月/5月へ移動したときの duplicate key error を解消

## 確認項目
- `npm run lint`
- `npm run build`
- 空月へ移動しても duplicate key error が出ないこと

## 関連Issue
Closes #114
