### PR TITLE
docs(agents): allow skipping codex review for docs-only PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,14 +67,16 @@ PR 本文に必ず記載する項目:
 ## 6. レビュー確認と対応
 
 ```powershell
-# PR作成後、マージ前に Codex CLI review を1回実施する
+# コード変更を含むPRは、PR作成後〜マージ前に Codex CLI review を1回実施する
+# ドキュメント変更のみのPRは、必要に応じてスキップ可
 codex review --base main
 gh pr view <PR番号> --comments
 gh api repos/Yuichi-TanakaJP/mini-tools/pulls/<PR番号>/reviews
 gh api repos/Yuichi-TanakaJP/mini-tools/pulls/<PR番号>/comments
 ```
 
-- Codex review は、PR作成後の差分に対して必ず1回実施する。
+- Codex review は、コード変更を含むPRでは原則1回実施する。
+- ドキュメント変更のみのPRは、内容が明確で低リスクならスキップしてよい。
 - P1/P0 指摘は優先対応する。
 - 修正後は同じブランチで再コミットし push する。
 


### PR DESCRIPTION
## 概要
AGENTS.md の Codex review ルールを、ドキュメント変更だけの PR では柔軟にスキップできる表現へ調整します。

## 変更内容
- コード変更を含む PR では Codex review を原則実施と明記
- ドキュメント変更のみの PR は、低リスクならスキップ可と明記

## 確認項目
- `npm run lint`
- AGENTS.md の手順が実運用に合っていること

## 関連Issue
なし
