### PR TITLE
refactor(calendar): simplify earnings list presentation

### DIFF
--- a/app/tools/earnings-calendar/ToolClient.tsx
+++ b/app/tools/earnings-calendar/ToolClient.tsx
@@ -66,10 +66,6 @@ function normalizeTimeLabel(time: string) {
   return time.replace(/\s*\/\s*（?予定）?$/, "").replace(/\s*\/\s*\(予定\)$/, "");
 }
 
-function shouldShowPublishStatus(status: string) {
-  return status.trim() !== "" && status !== "予定";
-}
-
 function createEmptyMonth(id: string, updatedAt: string): CalendarMonth {
   const [year, month] = id.split("-").map(Number);
   const firstWeekday = new Date(Date.UTC(year, month - 1, 1)).getUTCDay();
@@ -435,16 +431,8 @@ export default function ToolClient({ data }: { data: EarningsCalendarResponse })
                   <div style={styles.itemName}>{item.name}</div>
                   <div style={styles.itemMetaRow}>
                     <span>{item.code}</span>
-                    <span>•</span>
                     <span>{normalizeMarket(item.market)}</span>
-                    <span>•</span>
                     <span>{item.announcement_type}</span>
-                    {shouldShowPublishStatus(item.publish_status) ? (
-                      <>
-                        <span>•</span>
-                        <span>{item.publish_status}</span>
-                      </>
-                    ) : null}
                   </div>
                 </div>
 
@@ -716,7 +704,7 @@ const styles: Record<string, React.CSSProperties> = {
   itemMetaRow: {
     marginTop: 4,
     display: "flex",
-    gap: 6,
+    gap: 10,
     flexWrap: "wrap",
     alignItems: "center",
     fontSize: 12,


### PR DESCRIPTION
## 概要
決算カレンダーの日別一覧を、日本株向けに見やすく整理します。

## 変更内容
- 一覧カードの CODE ラベルを削除
- 銘柄コードの数字は補助情報として維持
- 発表済み / 予定 の表示を削除
- • 区切りをやめて、より素直なメタ表示へ整理
- 更新運用の検討は #119 に分離

## 確認項目
- 
pm run lint
- 
pm run build
- 決算一覧の見え方確認

## 補足
- market_info 側の latest.json は、現時点ではまだ 2026年3月単月でした
- 4月データや vent_id の反映は、次回出力を受けて別途取り込みます

## 関連 Issue
- Related #106
- Related #119
