### PR TITLE
data(calendar): refresh april earnings month

### DIFF
--- a/app/tools/earnings-calendar/data/earnings_calendar_domestic_20260401_to_20260430.json
+++ b/app/tools/earnings-calendar/data/earnings_calendar_domestic_20260401_to_20260430.json
@@ -4,20 +4,243 @@
     {
       "date": "2026-04-01",
       "count": 2,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-01|5942|14:00 / (予定)|1Q|221cf31ab8|01",
+          "time": "14:00 / (予定)",
+          "code": "5942",
+          "name": "日本フイルコン",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-01|6664|15:45 / (予定)|1Q|507fa55704|01",
+          "time": "15:45 / (予定)",
+          "code": "6664",
+          "name": "オプトエレクトロニクス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-02",
       "count": 6,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-02|8276|13:30 / (予定)|本決算|210fc106a0|01",
+          "time": "13:30 / (予定)",
+          "code": "8276",
+          "name": "平和堂",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-02|2493|15:30 / (予定)|1Q|d0fd5715e6|01",
+          "time": "15:30 / (予定)",
+          "code": "2493",
+          "name": "イーサポートリンク",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-02|3549|15:30 / (予定)|3Q|6d1fabb103|01",
+          "time": "15:30 / (予定)",
+          "code": "3549",
+          "name": "クスリのアオキホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-02|7447|15:30 / (予定)|中間 / 決算|d3f0327db0|01",
+          "time": "15:30 / (予定)",
+          "code": "7447",
+          "name": "ナガイレーベン",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-02|7545|15:30 / (予定)|本決算|95d7686c71|01",
+          "time": "15:30 / (予定)",
+          "code": "7545",
+          "name": "西松屋チェーン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-02|3498|15:35 / (予定)|中間 / 決算|5fc9a571cc|01",
+          "time": "15:35 / (予定)",
+          "code": "3498",
+          "name": "霞ヶ関キャピタル",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-03",
       "count": 14,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-03|2753|09:00 / (予定)|本決算|60d702ea7f|01",
+          "time": "09:00 / (予定)",
+          "code": "2753",
+          "name": "あみやき亭",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|3333|13:00 / (予定)|本決算|2dcccb7c75|01",
+          "time": "13:00 / (予定)",
+          "code": "3333",
+          "name": "あさひ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|1997|15:00 / (予定)|中間 / 決算|ea73c79034|01",
+          "time": "15:00 / (予定)",
+          "code": "1997",
+          "name": "暁飯島工業",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|1376|15:30 / (予定)|3Q|8b099c1525|01",
+          "time": "15:30 / (予定)",
+          "code": "1376",
+          "name": "カネコ種苗",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|3321|15:30 / (予定)|3Q|d318531d5b|01",
+          "time": "15:30 / (予定)",
+          "code": "3321",
+          "name": "ミタチ産業",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|3377|15:30 / (予定)|1Q|df0fff32e0|01",
+          "time": "15:30 / (予定)",
+          "code": "3377",
+          "name": "バイク王＆カンパニー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|3612|15:30 / (予定)|本決算|d8b1477af5|01",
+          "time": "15:30 / (予定)",
+          "code": "3612",
+          "name": "ワールド",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|4394|15:30 / (予定)|1Q|4705b7ac12|01",
+          "time": "15:30 / (予定)",
+          "code": "4394",
+          "name": "エクスモーション",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|6093|15:30 / (予定)|本決算|1384bb6b9c|01",
+          "time": "15:30 / (予定)",
+          "code": "6093",
+          "name": "エスクロー・エージェント・ジャパン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|6264|15:30 / (予定)|中間 / 決算|0db9f59ac3|01",
+          "time": "15:30 / (予定)",
+          "code": "6264",
+          "name": "マルマエ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|7975|15:30 / (予定)|本決算|798ff044fa|01",
+          "time": "15:30 / (予定)",
+          "code": "7975",
+          "name": "リヒトラブ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|3035|15:45 / (予定)|中間 / 決算|1e06c429d2|01",
+          "time": "15:45 / (予定)",
+          "code": "3035",
+          "name": "ケイティケイ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|6279|16:00 / (予定)|本決算|2c86b4fe17|01",
+          "time": "16:00 / (予定)",
+          "code": "6279",
+          "name": "瑞光",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-03|9872|16:00 / (予定)|1Q|5dbb6444e6|01",
+          "time": "16:00 / (予定)",
+          "code": "9872",
+          "name": "北恵",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-04",
@@ -34,32 +257,1757 @@
     {
       "date": "2026-04-06",
       "count": 12,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-06|8217|13:00 / (予定)|本決算|d5531d14b7|01",
+          "time": "13:00 / (予定)",
+          "code": "8217",
+          "name": "オークワ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|8923|14:30 / (予定)|1Q|f726236aa1|01",
+          "time": "14:30 / (予定)",
+          "code": "8923",
+          "name": "トーセイ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|2789|15:00 / (予定)|本決算|b31a122f1b|01",
+          "time": "15:00 / (予定)",
+          "code": "2789",
+          "name": "カルラ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|6474|15:00 / (予定)|1Q|b203e4467f|01",
+          "time": "15:00 / (予定)",
+          "code": "6474",
+          "name": "不二越",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|2685|15:30 / (予定)|本決算|a03e236d04|01",
+          "time": "15:30 / (予定)",
+          "code": "2685",
+          "name": "アンドエスティＨＤ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|3148|15:30 / (予定)|3Q|2f0900b3b5|01",
+          "time": "15:30 / (予定)",
+          "code": "3148",
+          "name": "クリエイトＳＤホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|3186|15:30 / (予定)|1Q|e9968fc99c|01",
+          "time": "15:30 / (予定)",
+          "code": "3186",
+          "name": "ネクステージ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|3353|15:30 / (予定)|本決算|5784cd6eab|01",
+          "time": "15:30 / (予定)",
+          "code": "3353",
+          "name": "メディカル一光グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|4825|15:30 / (予定)|3Q|5aab9161f4|01",
+          "time": "15:30 / (予定)",
+          "code": "4825",
+          "name": "ウェザーニューズ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|7630|15:30 / (予定)|本決算|30856ca3a7|01",
+          "time": "15:30 / (予定)",
+          "code": "7630",
+          "name": "壱番屋",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|7679|15:30 / (予定)|本決算|93cbf01344|01",
+          "time": "15:30 / (予定)",
+          "code": "7679",
+          "name": "薬王堂ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-06|9558|15:30 / (予定)|1Q|7697103c39|01",
+          "time": "15:30 / (予定)",
+          "code": "9558",
+          "name": "ジャパニアス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-07",
       "count": 14,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-07|2659|15:00 / (予定)|本決算|f38d523a9a|01",
+          "time": "15:00 / (予定)",
+          "code": "2659",
+          "name": "サンエー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|2734|15:00 / (予定)|1Q|c70d763928|01",
+          "time": "15:00 / (予定)",
+          "code": "2734",
+          "name": "サーラコーポレーション",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|1377|15:30 / (予定)|3Q|6cc508ccd2|01",
+          "time": "15:30 / (予定)",
+          "code": "1377",
+          "name": "サカタのタネ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|2408|15:30 / (予定)|1Q|d520234887|01",
+          "time": "15:30 / (予定)",
+          "code": "2408",
+          "name": "ＫＧ情報",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|2726|15:30 / (予定)|本決算|0c3149ef62|01",
+          "time": "15:30 / (予定)",
+          "code": "2726",
+          "name": "パルグループホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|3222|15:30 / (予定)|本決算|caee5603df|01",
+          "time": "15:30 / (予定)",
+          "code": "3222",
+          "name": "ユナイテッド・スーパーマーケット・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|3396|15:30 / (予定)|本決算|681577e54e|01",
+          "time": "15:30 / (予定)",
+          "code": "3396",
+          "name": "フェリシモ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|5932|15:30 / (予定)|3Q|10d2626365|01",
+          "time": "15:30 / (予定)",
+          "code": "5932",
+          "name": "三協立山",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|6496|15:30 / (予定)|3Q|feda0c55f0|01",
+          "time": "15:30 / (予定)",
+          "code": "6496",
+          "name": "中北製作所",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|7888|15:30 / (予定)|3Q|4478d3fb30|01",
+          "time": "15:30 / (予定)",
+          "code": "7888",
+          "name": "三光合成",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|8278|15:30 / (予定)|本決算|523e7612f4|01",
+          "time": "15:30 / (予定)",
+          "code": "8278",
+          "name": "フジ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|9253|15:30 / (予定)|本決算|4e596af45d|01",
+          "time": "15:30 / (予定)",
+          "code": "9253",
+          "name": "スローガン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|9793|15:30 / (予定)|本決算|6416811d9b|01",
+          "time": "15:30 / (予定)",
+          "code": "9793",
+          "name": "ダイセキ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-07|6469|16:00 / (予定)|本決算|7f599e4b83|01",
+          "time": "16:00 / (予定)",
+          "code": "6469",
+          "name": "放電精密加工研究所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-08",
       "count": 17,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-08|4834|13:00 / (予定)|3Q|08e42717c7|01",
+          "time": "13:00 / (予定)",
+          "code": "4834",
+          "name": "キャリアバンク",
+          "market": "SPR",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|8570|15:15 / (予定)|本決算|b18afd915b|01",
+          "time": "15:15 / (予定)",
+          "code": "8570",
+          "name": "イオンフィナンシャルサービス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|2437|15:30 / (予定)|3Q|b2374ef404|01",
+          "time": "15:30 / (予定)",
+          "code": "2437",
+          "name": "Ｓｈｉｎｗａ　Ｗｉｓｅ　Ｈｏｌｄｉｎｇｓ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|2670|15:30 / (予定)|本決算|69c635bbd7|01",
+          "time": "15:30 / (予定)",
+          "code": "2670",
+          "name": "エービーシー・マート",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|2918|15:30 / (予定)|本決算|a63a653bea|01",
+          "time": "15:30 / (予定)",
+          "code": "2918",
+          "name": "わらべや日洋ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|3543|15:30 / (予定)|本決算|ea1858fde0|01",
+          "time": "15:30 / (予定)",
+          "code": "3543",
+          "name": "コメダホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|4494|15:30 / (予定)|本決算|59d7c2922d|01",
+          "time": "15:30 / (予定)",
+          "code": "4494",
+          "name": "バリオセキュア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|6183|15:30 / (予定)|本決算|dc10153d11|01",
+          "time": "15:30 / (予定)",
+          "code": "6183",
+          "name": "ベルシステム２４ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|6255|15:30 / (予定)|中間 / 決算|50b95ad870|01",
+          "time": "15:30 / (予定)",
+          "code": "6255",
+          "name": "エヌ・ピー・シー",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|6552|15:30 / (予定)|3Q|ae8d42003d|01",
+          "time": "15:30 / (予定)",
+          "code": "6552",
+          "name": "ＧａｍｅＷｉｔｈ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|7581|15:30 / (予定)|中間 / 決算|6497cef252|01",
+          "time": "15:30 / (予定)",
+          "code": "7581",
+          "name": "サイゼリヤ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|9720|15:30 / (予定)|1Q|febf6314b4|01",
+          "time": "15:30 / (予定)",
+          "code": "9720",
+          "name": "ホテル、ニューグランド",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|9946|15:30 / (予定)|本決算|f10cd89422|01",
+          "time": "15:30 / (予定)",
+          "code": "9946",
+          "name": "ミニストップ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|2459|16:00 / (予定)|3Q|d141bab9a8|01",
+          "time": "16:00 / (予定)",
+          "code": "2459",
+          "name": "アウンコンサルティング",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|4714|16:00 / (予定)|本決算|04860f6472|01",
+          "time": "16:00 / (予定)",
+          "code": "4714",
+          "name": "リソー教育グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|3454|17:00 / (予定)|1Q|cb2f310a51|01",
+          "time": "17:00 / (予定)",
+          "code": "3454",
+          "name": "ファーストブラザーズ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-08|7463|18:00 / (予定)|本決算|7f734e8161|01",
+          "time": "18:00 / (予定)",
+          "code": "7463",
+          "name": "アドヴァングループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-09",
       "count": 38,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-09|8194|11:30 / (予定)|本決算|1c0b5dabd2|01",
+          "time": "11:30 / (予定)",
+          "code": "8194",
+          "name": "ライフコーポレーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|4432|12:00 / (予定)|本決算|ce3eb3b3b1|01",
+          "time": "12:00 / (予定)",
+          "code": "4432",
+          "name": "ウイングアーク１ｓｔ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2303|14:00 / (予定)|3Q|380b6b7b15|01",
+          "time": "14:00 / (予定)",
+          "code": "2303",
+          "name": "ドーン",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2653|14:45 / (予定)|本決算|df6f133e7c|01",
+          "time": "14:45 / (予定)",
+          "code": "2653",
+          "name": "イオン九州",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|7713|15:00 / (予定)|3Q|9c6cb01fef|01",
+          "time": "15:00 / (予定)",
+          "code": "7713",
+          "name": "シグマ光機",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|8203|15:00 / (予定)|本決算|fa44b48151|01",
+          "time": "15:00 / (予定)",
+          "code": "8203",
+          "name": "ＭｒＭａｘＨＤ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9414|15:00 / (予定)|中間 / 決算|dcbf374393|01",
+          "time": "15:00 / (予定)",
+          "code": "9414",
+          "name": "日本ＢＳ放送",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|228A|15:30 / (予定)|1Q|b86b795f73|01",
+          "time": "15:30 / (予定)",
+          "code": "228A",
+          "name": "オプロ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2341|15:30 / (予定)|本決算|71b03f2d45|01",
+          "time": "15:30 / (予定)",
+          "code": "2341",
+          "name": "アルバイトタイムス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2669|15:30 / (予定)|本決算|d83a68945d|01",
+          "time": "15:30 / (予定)",
+          "code": "2669",
+          "name": "カネ美食品",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2686|15:30 / (予定)|本決算|7d3154dfb8|01",
+          "time": "15:30 / (予定)",
+          "code": "2686",
+          "name": "ジーフット",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2698|15:30 / (予定)|本決算|32ca1f0852|01",
+          "time": "15:30 / (予定)",
+          "code": "2698",
+          "name": "キャンドゥ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|2809|15:30 / (予定)|1Q|9401c6a88c|01",
+          "time": "15:30 / (予定)",
+          "code": "2809",
+          "name": "キユーピー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|3093|15:30 / (予定)|本決算|4235feac8b|01",
+          "time": "15:30 / (予定)",
+          "code": "3093",
+          "name": "トレジャー・ファクトリー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|3382|15:30 / (予定)|本決算|d4fb405e64|01",
+          "time": "15:30 / (予定)",
+          "code": "3382",
+          "name": "セブン＆アイ・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|3490|15:30 / (予定)|本決算|67611288a3|01",
+          "time": "15:30 / (予定)",
+          "code": "3490",
+          "name": "アズ企画設計",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|4343|15:30 / (予定)|本決算|199b8ece3c|01",
+          "time": "15:30 / (予定)",
+          "code": "4343",
+          "name": "イオンファンタジー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|4728|15:30 / (予定)|中間 / 決算|4239dfc48b|01",
+          "time": "15:30 / (予定)",
+          "code": "4728",
+          "name": "トーセ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|4763|15:30 / (予定)|本決算|aef4a7b46f|01",
+          "time": "15:30 / (予定)",
+          "code": "4763",
+          "name": "クリーク・アンド・リバー社",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|6323|15:30 / (予定)|本決算|8ecb4f3975|01",
+          "time": "15:30 / (予定)",
+          "code": "6323",
+          "name": "ローツェ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|6814|15:30 / (予定)|本決算|94446caac1|01",
+          "time": "15:30 / (予定)",
+          "code": "6814",
+          "name": "古野電気",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|7512|15:30 / (予定)|本決算|1e9f77ffd5|01",
+          "time": "15:30 / (予定)",
+          "code": "7512",
+          "name": "イオン北海道",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|7513|15:30 / (予定)|中間 / 決算|b115cf92d3|01",
+          "time": "15:30 / (予定)",
+          "code": "7513",
+          "name": "コジマ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|7649|15:30 / (予定)|本決算|f528fe6b5c|01",
+          "time": "15:30 / (予定)",
+          "code": "7649",
+          "name": "スギホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|8016|15:30 / (予定)|本決算|4947f22348|01",
+          "time": "15:30 / (予定)",
+          "code": "8016",
+          "name": "オンワードホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|8198|15:30 / (予定)|本決算|daa9806439|01",
+          "time": "15:30 / (予定)",
+          "code": "8198",
+          "name": "マックスバリュ東海",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|8267|15:30 / (予定)|本決算|b3fcd6ea32|01",
+          "time": "15:30 / (予定)",
+          "code": "8267",
+          "name": "イオン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9560|15:30 / (予定)|中間 / 決算|6e120d035a|01",
+          "time": "15:30 / (予定)",
+          "code": "9560",
+          "name": "プログリット",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9876|15:30 / (予定)|本決算|001fd2b5d9|01",
+          "time": "15:30 / (予定)",
+          "code": "9876",
+          "name": "コックス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9903|15:30 / (予定)|本決算|d01be61ca3|01",
+          "time": "15:30 / (予定)",
+          "code": "9903",
+          "name": "カンセキ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9983|15:31 / (予定)|中間 / 決算|2a08e363f0|01",
+          "time": "15:31 / (予定)",
+          "code": "9983",
+          "name": "ファーストリテイリング",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|4829|16:00 / (予定)|3Q|3d0c150e67|01",
+          "time": "16:00 / (予定)",
+          "code": "4829",
+          "name": "日本エンタープライズ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|7544|16:00 / (予定)|本決算|e4ffc9ee6a|01",
+          "time": "16:00 / (予定)",
+          "code": "7544",
+          "name": "スリーエフ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|8125|16:00 / (予定)|本決算|9d23323ad7|01",
+          "time": "16:00 / (予定)",
+          "code": "8125",
+          "name": "ワキタ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9765|16:00 / (予定)|3Q|3f1e8efe3a|01",
+          "time": "16:00 / (予定)",
+          "code": "9765",
+          "name": "オオバ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9861|16:00 / (予定)|本決算|b393ba023f|01",
+          "time": "16:00 / (予定)",
+          "code": "9861",
+          "name": "吉野家ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|3391|16:30 / (予定)|本決算|590296c3a6|01",
+          "time": "16:30 / (予定)",
+          "code": "3391",
+          "name": "ツルハホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-09|9972|16:30 / (予定)|1Q|9e4f990982|01",
+          "time": "16:30 / (予定)",
+          "code": "9972",
+          "name": "アルテック",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-10",
       "count": 91,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-10|428A|--|中間 / 決算|dff14a411e|01",
+          "time": "--",
+          "code": "428A",
+          "name": "サイプレス・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3048|12:00 / (予定)|中間 / 決算|c8f61287d2|01",
+          "time": "12:00 / (予定)",
+          "code": "3048",
+          "name": "ビックカメラ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2157|13:00 / (予定)|中間 / 決算|b9ef9d0941|01",
+          "time": "13:00 / (予定)",
+          "code": "2157",
+          "name": "コシダカホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4995|14:00 / (予定)|1Q|99143758b8|01",
+          "time": "14:00 / (予定)",
+          "code": "4995",
+          "name": "サンケイ化学",
+          "market": "FKO",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8127|14:00 / (予定)|中間 / 決算|873d2f336c|01",
+          "time": "14:00 / (予定)",
+          "code": "8127",
+          "name": "ヤマトインターナショナル",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9313|14:00 / (予定)|1Q|089ff49c85|01",
+          "time": "14:00 / (予定)",
+          "code": "9313",
+          "name": "丸八倉庫",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9974|14:00 / (予定)|本決算|1713dd6b03|01",
+          "time": "14:00 / (予定)",
+          "code": "9974",
+          "name": "ベルク",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2747|15:00 / (予定)|本決算|0cdf6e68d1|01",
+          "time": "15:00 / (予定)",
+          "code": "2747",
+          "name": "北雄ラッキー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3815|15:00 / (予定)|中間 / 決算|7515caa0e3|01",
+          "time": "15:00 / (予定)",
+          "code": "3815",
+          "name": "メディア工房",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4076|15:00 / (予定)|3Q|b4c203485f|01",
+          "time": "15:00 / (予定)",
+          "code": "4076",
+          "name": "シイエヌエス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4490|15:00 / (予定)|本決算|cee7e1c0b7|01",
+          "time": "15:00 / (予定)",
+          "code": "4490",
+          "name": "ビザスク",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4673|15:00 / (予定)|1Q|b8b9028dec|01",
+          "time": "15:00 / (予定)",
+          "code": "4673",
+          "name": "川崎地質",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7450|15:00 / (予定)|本決算|bf2412ea51|01",
+          "time": "15:00 / (予定)",
+          "code": "7450",
+          "name": "サンデー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7611|15:00 / (予定)|本決算|f0b5719aef|01",
+          "time": "15:00 / (予定)",
+          "code": "7611",
+          "name": "ハイデイ日高",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7811|15:00 / (予定)|本決算|79a170c6b9|01",
+          "time": "15:00 / (予定)",
+          "code": "7811",
+          "name": "中本パックス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|137A|15:30 / (予定)|3Q|58040ae4ce|01",
+          "time": "15:30 / (予定)",
+          "code": "137A",
+          "name": "Ｃｏｃｏｌｉｖｅ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|1419|15:30 / (予定)|3Q|67fe71718d|01",
+          "time": "15:30 / (予定)",
+          "code": "1419",
+          "name": "タマホーム",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2164|15:30 / (予定)|中間 / 決算|f7f259cd03|01",
+          "time": "15:30 / (予定)",
+          "code": "2164",
+          "name": "地域新聞社",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2683|15:30 / (予定)|本決算|9efa3ef0a5|01",
+          "time": "15:30 / (予定)",
+          "code": "2683",
+          "name": "魚喜",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2735|15:30 / (予定)|中間 / 決算|d7519816a1|01",
+          "time": "15:30 / (予定)",
+          "code": "2735",
+          "name": "ワッツ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2742|15:30 / (予定)|本決算|7125547308|01",
+          "time": "15:30 / (予定)",
+          "code": "2742",
+          "name": "ハローズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2791|15:30 / (予定)|3Q|e40c23a51f|01",
+          "time": "15:30 / (予定)",
+          "code": "2791",
+          "name": "大黒天物産",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2999|15:30 / (予定)|中間 / 決算|e5541874d4|01",
+          "time": "15:30 / (予定)",
+          "code": "2999",
+          "name": "ホームポジション",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3063|15:30 / (予定)|本決算|0e39bec04e|01",
+          "time": "15:30 / (予定)",
+          "code": "3063",
+          "name": "ジェイグループホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3192|15:30 / (予定)|1Q|e5938966be|01",
+          "time": "15:30 / (予定)",
+          "code": "3192",
+          "name": "白鳩",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3201|15:30 / (予定)|1Q|da0e2bd30e|01",
+          "time": "15:30 / (予定)",
+          "code": "3201",
+          "name": "日本毛織",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3280|15:30 / (予定)|本決算|40149495a8|01",
+          "time": "15:30 / (予定)",
+          "code": "3280",
+          "name": "エストラスト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3501|15:30 / (予定)|3Q|b31cb3959e|01",
+          "time": "15:30 / (予定)",
+          "code": "3501",
+          "name": "ＳＵＭＩＮＯＥ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3546|15:30 / (予定)|本決算|b45ad6e7ea|01",
+          "time": "15:30 / (予定)",
+          "code": "3546",
+          "name": "アレンザホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3560|15:30 / (予定)|中間 / 決算|5d72ea476a|01",
+          "time": "15:30 / (予定)",
+          "code": "3560",
+          "name": "ほぼ日",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3608|15:30 / (予定)|本決算|0a8ff727df|01",
+          "time": "15:30 / (予定)",
+          "code": "3608",
+          "name": "ＴＳＩホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3627|15:30 / (予定)|本決算|fa8b936b8b|01",
+          "time": "15:30 / (予定)",
+          "code": "3627",
+          "name": "テクミラホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3824|15:30 / (予定)|3Q|0f92f560be|01",
+          "time": "15:30 / (予定)",
+          "code": "3824",
+          "name": "メディアファイブ",
+          "market": "FKO",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4017|15:30 / (予定)|本決算|7b6440f51a|01",
+          "time": "15:30 / (予定)",
+          "code": "4017",
+          "name": "クリーマ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4187|15:30 / (予定)|1Q|2e46328ded|01",
+          "time": "15:30 / (予定)",
+          "code": "4187",
+          "name": "大阪有機化学工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4361|15:30 / (予定)|1Q|798cf33f21|01",
+          "time": "15:30 / (予定)",
+          "code": "4361",
+          "name": "川口化学工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4370|15:30 / (予定)|中間 / 決算|e488ba60e1|01",
+          "time": "15:30 / (予定)",
+          "code": "4370",
+          "name": "モビルス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4430|15:30 / (予定)|3Q|f405568c94|01",
+          "time": "15:30 / (予定)",
+          "code": "4430",
+          "name": "東海ソフト",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4443|15:30 / (予定)|3Q|f0774a3a2a|01",
+          "time": "15:30 / (予定)",
+          "code": "4443",
+          "name": "Ｓａｎｓａｎ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4577|15:30 / (予定)|3Q|531b0f68eb|01",
+          "time": "15:30 / (予定)",
+          "code": "4577",
+          "name": "ダイト",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4760|15:30 / (予定)|中間 / 決算|75823d1c73|01",
+          "time": "15:30 / (予定)",
+          "code": "4760",
+          "name": "アルファ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4992|15:30 / (予定)|1Q|bd0a03b996|01",
+          "time": "15:30 / (予定)",
+          "code": "4992",
+          "name": "北興化学工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|5271|15:30 / (予定)|本決算|3858154d91|01",
+          "time": "15:30 / (予定)",
+          "code": "5271",
+          "name": "トーヨーアサノ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|5900|15:30 / (予定)|本決算|e03ef330bd|01",
+          "time": "15:30 / (予定)",
+          "code": "5900",
+          "name": "ダイケン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6076|15:30 / (予定)|1Q|d3388d06f3|01",
+          "time": "15:30 / (予定)",
+          "code": "6076",
+          "name": "アメイズ",
+          "market": "FKO",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6136|15:30 / (予定)|1Q|d6d6be7a7a|01",
+          "time": "15:30 / (予定)",
+          "code": "6136",
+          "name": "オーエスジー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6289|15:30 / (予定)|中間 / 決算|20178f8744|01",
+          "time": "15:30 / (予定)",
+          "code": "6289",
+          "name": "技研製作所",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6432|15:30 / (予定)|本決算|966bbeeab0|01",
+          "time": "15:30 / (予定)",
+          "code": "6432",
+          "name": "竹内製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6668|15:30 / (予定)|中間 / 決算|afb13ec9d0|01",
+          "time": "15:30 / (予定)",
+          "code": "6668",
+          "name": "アドテック　プラズマ　テクノロジー",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7219|15:30 / (予定)|中間 / 決算|6e8100dd9f|01",
+          "time": "15:30 / (予定)",
+          "code": "7219",
+          "name": "エッチ・ケー・エス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7360|15:30 / (予定)|1Q|bdbe6c319c|01",
+          "time": "15:30 / (予定)",
+          "code": "7360",
+          "name": "オンデック",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7373|15:30 / (予定)|中間 / 決算|458af8876b|01",
+          "time": "15:30 / (予定)",
+          "code": "7373",
+          "name": "アイドマ・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7453|15:30 / (予定)|中間 / 決算|f16ba42266|01",
+          "time": "15:30 / (予定)",
+          "code": "7453",
+          "name": "良品計画",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7487|15:30 / (予定)|3Q|2a8850da11|01",
+          "time": "15:30 / (予定)",
+          "code": "7487",
+          "name": "小津産業",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7501|15:30 / (予定)|1Q|e09fbed5fe|01",
+          "time": "15:30 / (予定)",
+          "code": "7501",
+          "name": "ティムコ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7514|15:30 / (予定)|中間 / 決算|bfeaa634dd|01",
+          "time": "15:30 / (予定)",
+          "code": "7514",
+          "name": "ヒマラヤ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7603|15:30 / (予定)|本決算|1c83676be6|01",
+          "time": "15:30 / (予定)",
+          "code": "7603",
+          "name": "ジーイエット",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7673|15:30 / (予定)|3Q|8cbd5aecac|01",
+          "time": "15:30 / (予定)",
+          "code": "7673",
+          "name": "ダイコー通産",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8008|15:30 / (予定)|本決算|2fe318f0cf|01",
+          "time": "15:30 / (予定)",
+          "code": "8008",
+          "name": "ヨンドシーホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8166|15:30 / (予定)|本決算|f06c5415f0|01",
+          "time": "15:30 / (予定)",
+          "code": "8166",
+          "name": "タカキュー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8185|15:30 / (予定)|本決算|d0014caeb0|01",
+          "time": "15:30 / (予定)",
+          "code": "8185",
+          "name": "チヨダ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8200|15:30 / (予定)|本決算|85ef9fd9c5|01",
+          "time": "15:30 / (予定)",
+          "code": "8200",
+          "name": "リンガーハット",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8244|15:30 / (予定)|本決算|367d9c32c4|01",
+          "time": "15:30 / (予定)",
+          "code": "8244",
+          "name": "近鉄百貨店",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8247|15:30 / (予定)|本決算|8d55a5c24c|01",
+          "time": "15:30 / (予定)",
+          "code": "8247",
+          "name": "大和",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8260|15:30 / (予定)|本決算|3e9e5f3ba5|01",
+          "time": "15:30 / (予定)",
+          "code": "8260",
+          "name": "井筒屋",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8908|15:30 / (予定)|3Q|5656bc696a|01",
+          "time": "15:30 / (予定)",
+          "code": "8908",
+          "name": "毎日コムネット",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8918|15:30 / (予定)|本決算|bc5eae4742|01",
+          "time": "15:30 / (予定)",
+          "code": "8918",
+          "name": "ランド",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|8931|15:30 / (予定)|本決算|0116e1179e|01",
+          "time": "15:30 / (予定)",
+          "code": "8931",
+          "name": "和田興産",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9216|15:30 / (予定)|3Q|38e2c7ab1f|01",
+          "time": "15:30 / (予定)",
+          "code": "9216",
+          "name": "ビーウィズ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9647|15:30 / (予定)|1Q|4d1626c25e|01",
+          "time": "15:30 / (予定)",
+          "code": "9647",
+          "name": "協和コンサルタンツ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9835|15:30 / (予定)|本決算|aa7b6ad187|01",
+          "time": "15:30 / (予定)",
+          "code": "9835",
+          "name": "ジュンテンドー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2769|15:40 / (予定)|3Q|d8c612dbb2|01",
+          "time": "15:40 / (予定)",
+          "code": "2769",
+          "name": "ヴィレッジヴァンガードコーポレーション",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6159|15:40 / (予定)|中間 / 決算|c75b7d8e5e|01",
+          "time": "15:40 / (予定)",
+          "code": "6159",
+          "name": "ミクロン精密",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7427|15:40 / (予定)|本決算|11126f9c4d|01",
+          "time": "15:40 / (予定)",
+          "code": "7427",
+          "name": "エコートレーディング",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2872|16:00 / (予定)|本決算|cbc1e9cae4|01",
+          "time": "16:00 / (予定)",
+          "code": "2872",
+          "name": "セイヒョー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3046|16:00 / (予定)|中間 / 決算|22ee3ad19f|01",
+          "time": "16:00 / (予定)",
+          "code": "3046",
+          "name": "ジンズホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3550|16:00 / (予定)|本決算|8f9104362f|01",
+          "time": "16:00 / (予定)",
+          "code": "3550",
+          "name": "スタジオアタオ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|3647|16:00 / (予定)|中間 / 決算|487619b8d9|01",
+          "time": "16:00 / (予定)",
+          "code": "3647",
+          "name": "アスリナ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4668|16:00 / (予定)|中間 / 決算|13186cf159|01",
+          "time": "16:00 / (予定)",
+          "code": "4668",
+          "name": "明光ネットワークジャパン",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|4735|16:00 / (予定)|本決算|c3aefd61a8|01",
+          "time": "16:00 / (予定)",
+          "code": "4735",
+          "name": "京進",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|5129|16:00 / (予定)|中間 / 決算|3bdbe5e62d|01",
+          "time": "16:00 / (予定)",
+          "code": "5129",
+          "name": "ＦＩＸＥＲ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|5341|16:00 / (予定)|1Q|480f268b34|01",
+          "time": "16:00 / (予定)",
+          "code": "5341",
+          "name": "ＡＳＡＨＩ　ＥＩＴＯホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|5982|16:00 / (予定)|本決算|b99e7a5f74|01",
+          "time": "16:00 / (予定)",
+          "code": "5982",
+          "name": "マルゼン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6489|16:00 / (予定)|3Q|b4c0edb69d|01",
+          "time": "16:00 / (予定)",
+          "code": "6489",
+          "name": "前澤工業",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6506|16:00 / (予定)|本決算|c8cc698532|01",
+          "time": "16:00 / (予定)",
+          "code": "6506",
+          "name": "安川電機",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|6555|16:00 / (予定)|本決算|28cf1e01bc|01",
+          "time": "16:00 / (予定)",
+          "code": "6555",
+          "name": "ＭＳ＆Ｃｏｎｓｕｌｔｉｎｇ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7607|16:00 / (予定)|中間 / 決算|1059fb8b46|01",
+          "time": "16:00 / (予定)",
+          "code": "7607",
+          "name": "進和",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|7725|16:00 / (予定)|3Q|0143114b2a|01",
+          "time": "16:00 / (予定)",
+          "code": "7725",
+          "name": "インターアクション",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9270|16:00 / (予定)|中間 / 決算|b7dfcb81f2|01",
+          "time": "16:00 / (予定)",
+          "code": "9270",
+          "name": "バリュエンスホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|9326|16:00 / (予定)|本決算|26a8799a9b|01",
+          "time": "16:00 / (予定)",
+          "code": "9326",
+          "name": "関通",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-10|2687|17:50 / (予定)|本決算|1da9c98d90|01",
+          "time": "17:50 / (予定)",
+          "code": "2687",
+          "name": "シー・ヴイ・エス・ベイエリア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-11",
@@ -76,20 +2024,2523 @@
     {
       "date": "2026-04-13",
       "count": 61,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-13|373A|--|中間 / 決算|6d6594f865|01",
+          "time": "--",
+          "code": "373A",
+          "name": "リップス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|463A|--|3Q|8990c0db8b|01",
+          "time": "--",
+          "code": "463A",
+          "name": "インテリックスホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|464A|--|3Q|a3d61fec8a|01",
+          "time": "--",
+          "code": "464A",
+          "name": "ＱＰＳホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|505A|--|3Q|976bccc8f7|01",
+          "time": "--",
+          "code": "505A",
+          "name": "ギークリー",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7815|--|本決算|d64ff52bef|01",
+          "time": "--",
+          "code": "7815",
+          "name": "東京ボード工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|4057|11:00 / (予定)|3Q|1901abc147|01",
+          "time": "11:00 / (予定)",
+          "code": "4057",
+          "name": "インターファクトリー",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|4440|12:00 / (予定)|中間 / 決算|c34e2003a3|01",
+          "time": "12:00 / (予定)",
+          "code": "4440",
+          "name": "ヴィッツ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7434|13:00 / (予定)|3Q|49da32a173|01",
+          "time": "13:00 / (予定)",
+          "code": "7434",
+          "name": "オータケ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|1401|14:00 / (予定)|3Q|a8aa45e492|01",
+          "time": "14:00 / (予定)",
+          "code": "1401",
+          "name": "エムビーエス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9982|14:00 / (予定)|本決算|88b8dfc642|01",
+          "time": "14:00 / (予定)",
+          "code": "9982",
+          "name": "タキヒヨー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|2462|15:00 / (予定)|3Q|d50be4b3ba|01",
+          "time": "15:00 / (予定)",
+          "code": "2462",
+          "name": "ライク",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|5967|15:00 / (予定)|3Q|43ec7cf545|01",
+          "time": "15:00 / (予定)",
+          "code": "5967",
+          "name": "ＴＯＮＥ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|6217|15:00 / (予定)|1Q|5a8fff5332|01",
+          "time": "15:00 / (予定)",
+          "code": "6217",
+          "name": "津田駒工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7928|15:00 / (予定)|中間 / 決算|52be90a59c|01",
+          "time": "15:00 / (予定)",
+          "code": "7928",
+          "name": "旭化学工業",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|8167|15:00 / (予定)|本決算|7c47135bf6|01",
+          "time": "15:00 / (予定)",
+          "code": "8167",
+          "name": "リテールパートナーズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9846|15:00 / (予定)|本決算|6b3dd63eac|01",
+          "time": "15:00 / (予定)",
+          "code": "9846",
+          "name": "天満屋ストア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3065|15:15 / (予定)|本決算|947c003e30|01",
+          "time": "15:15 / (予定)",
+          "code": "3065",
+          "name": "ライフフーズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|1434|15:30 / (予定)|中間 / 決算|433efe52fd|01",
+          "time": "15:30 / (予定)",
+          "code": "1434",
+          "name": "ＪＥＳＣＯホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|198A|15:30 / (予定)|3Q|33df28d513|01",
+          "time": "15:30 / (予定)",
+          "code": "198A",
+          "name": "ＰｏｓｔＰｒｉｍｅ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|2153|15:30 / (予定)|3Q|54eb7bbd8c|01",
+          "time": "15:30 / (予定)",
+          "code": "2153",
+          "name": "Ｅ・Ｊホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|2186|15:30 / (予定)|本決算|58afcc3bb8|01",
+          "time": "15:30 / (予定)",
+          "code": "2186",
+          "name": "ソーバル",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|276A|15:30 / (予定)|中間 / 決算|fb58dd23f0|01",
+          "time": "15:30 / (予定)",
+          "code": "276A",
+          "name": "ククレブ・アドバイザーズ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3030|15:30 / (予定)|本決算|7a92d23307|01",
+          "time": "15:30 / (予定)",
+          "code": "3030",
+          "name": "ハブ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3168|15:30 / (予定)|中間 / 決算|9741c511ec|01",
+          "time": "15:30 / (予定)",
+          "code": "3168",
+          "name": "ＭＥＲＦ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3236|15:30 / (予定)|3Q|8f502678b9|01",
+          "time": "15:30 / (予定)",
+          "code": "3236",
+          "name": "プロパスト",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3349|15:30 / (予定)|3Q|23aed08b99|01",
+          "time": "15:30 / (予定)",
+          "code": "3349",
+          "name": "コスモス薬品",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|340A|15:30 / (予定)|3Q|acf42a3f7f|01",
+          "time": "15:30 / (予定)",
+          "code": "340A",
+          "name": "ジグザグ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3562|15:30 / (予定)|本決算|7dd3e07b54|01",
+          "time": "15:30 / (予定)",
+          "code": "3562",
+          "name": "Ｎｏ．１",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3760|15:30 / (予定)|3Q|3222944651|01",
+          "time": "15:30 / (予定)",
+          "code": "3760",
+          "name": "ケイブ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3922|15:30 / (予定)|本決算|f8e983a4f8|01",
+          "time": "15:30 / (予定)",
+          "code": "3922",
+          "name": "ＰＲ　ＴＩＭＥＳ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3996|15:30 / (予定)|本決算|39d7ec664b|01",
+          "time": "15:30 / (予定)",
+          "code": "3996",
+          "name": "サインポスト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|4199|15:30 / (予定)|中間 / 決算|8c284ab51e|01",
+          "time": "15:30 / (予定)",
+          "code": "4199",
+          "name": "ワンダープラネット",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|4397|15:30 / (予定)|中間 / 決算|ec6e9c10cc|01",
+          "time": "15:30 / (予定)",
+          "code": "4397",
+          "name": "チームスピリット",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|4530|15:30 / (予定)|本決算|a89e3705a0|01",
+          "time": "15:30 / (予定)",
+          "code": "4530",
+          "name": "久光製薬",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|5250|15:30 / (予定)|1Q|b882d60fdd|01",
+          "time": "15:30 / (予定)",
+          "code": "5250",
+          "name": "ＧＭＯプライム・ストラテジー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|6505|15:30 / (予定)|3Q|32783a5e32|01",
+          "time": "15:30 / (予定)",
+          "code": "6505",
+          "name": "東洋電機製造",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|6634|15:30 / (予定)|1Q|3063034639|01",
+          "time": "15:30 / (予定)",
+          "code": "6634",
+          "name": "ＪＮグループ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7049|15:30 / (予定)|本決算|37346c2001|01",
+          "time": "15:30 / (予定)",
+          "code": "7049",
+          "name": "識学",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7085|15:30 / (予定)|中間 / 決算|4e4bf0c471|01",
+          "time": "15:30 / (予定)",
+          "code": "7085",
+          "name": "カーブスホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7370|15:30 / (予定)|3Q|245ff854d1|01",
+          "time": "15:30 / (予定)",
+          "code": "7370",
+          "name": "Ｅｎｊｉｎ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7516|15:30 / (予定)|本決算|4fa01f907e|01",
+          "time": "15:30 / (予定)",
+          "code": "7516",
+          "name": "コーナン商事",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|7599|15:30 / (予定)|本決算|99f00cdc43|01",
+          "time": "15:30 / (予定)",
+          "code": "7599",
+          "name": "ＩＤＯＭ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|8095|15:30 / (予定)|1Q|3e8df35e0c|01",
+          "time": "15:30 / (予定)",
+          "code": "8095",
+          "name": "アステナホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|8181|15:30 / (予定)|本決算|4eff43e439|01",
+          "time": "15:30 / (予定)",
+          "code": "8181",
+          "name": "東天紅",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9168|15:30 / (予定)|本決算|79c7c85a31|01",
+          "time": "15:30 / (予定)",
+          "code": "9168",
+          "name": "ライズ・コンサルティング・グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9278|15:30 / (予定)|3Q|f090a59cee|01",
+          "time": "15:30 / (予定)",
+          "code": "9278",
+          "name": "ブックオフグループホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9740|15:30 / (予定)|本決算|c31f030cc2|01",
+          "time": "15:30 / (予定)",
+          "code": "9740",
+          "name": "セントラル警備保障",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9948|15:30 / (予定)|本決算|256673df8e|01",
+          "time": "15:30 / (予定)",
+          "code": "9948",
+          "name": "アークス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|2736|16:00 / (予定)|中間 / 決算|1dad7e605d|01",
+          "time": "16:00 / (予定)",
+          "code": "2736",
+          "name": "フェスタリアホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3080|16:00 / (予定)|本決算|15b41c7e98|01",
+          "time": "16:00 / (予定)",
+          "code": "3080",
+          "name": "ジェーソン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|323A|16:00 / (予定)|本決算|d5926b7aeb|01",
+          "time": "16:00 / (予定)",
+          "code": "323A",
+          "name": "フライヤー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3678|16:00 / (予定)|本決算|e2d7b58685|01",
+          "time": "16:00 / (予定)",
+          "code": "3678",
+          "name": "メディアドゥ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|3907|16:00 / (予定)|1Q|e528b313f1|01",
+          "time": "16:00 / (予定)",
+          "code": "3907",
+          "name": "シリコンスタジオ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|5246|16:00 / (予定)|1Q|5cf1aa4292|01",
+          "time": "16:00 / (予定)",
+          "code": "5246",
+          "name": "ＥＬＥＭＥＮＴＳ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|5578|16:00 / (予定)|中間 / 決算|bf7a582bb9|01",
+          "time": "16:00 / (予定)",
+          "code": "5578",
+          "name": "ＡＲアドバンストテクノロジ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9264|16:00 / (予定)|中間 / 決算|462aefbe4b|01",
+          "time": "16:00 / (予定)",
+          "code": "9264",
+          "name": "ポエック",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9331|16:00 / (予定)|中間 / 決算|17474ebb5d|01",
+          "time": "16:00 / (予定)",
+          "code": "9331",
+          "name": "キャスター",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9418|16:00 / (予定)|中間 / 決算|c72dadf59b|01",
+          "time": "16:00 / (予定)",
+          "code": "9418",
+          "name": "Ｕ－ＮＥＸＴ　ＨＯＬＤＩＮＧＳ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|9661|16:00 / (予定)|本決算|b1359993f5|01",
+          "time": "16:00 / (予定)",
+          "code": "9661",
+          "name": "歌舞伎座",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|4920|17:00 / (予定)|本決算|2def2c49f7|01",
+          "time": "17:00 / (予定)",
+          "code": "4920",
+          "name": "日本色材工業研究所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-13|8289|17:00 / (予定)|本決算|3c407d1c69|01",
+          "time": "17:00 / (予定)",
+          "code": "8289",
+          "name": "Ｏｌｙｍｐｉｃグループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-14",
       "count": 184,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-14|2901|--|中間 / 決算|2602519afd|01",
+          "time": "--",
+          "code": "2901",
+          "name": "ウェルディッシュ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3077|--|1Q|a8409cd52b|01",
+          "time": "--",
+          "code": "3077",
+          "name": "ホリイフードサービス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|325A|--|中間 / 決算|fdabc7985b|01",
+          "time": "--",
+          "code": "325A",
+          "name": "ＴＥＮＴＩＡＬ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|367A|--|中間 / 決算|44f50298d3|01",
+          "time": "--",
+          "code": "367A",
+          "name": "プリモグローバルホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|369A|--|中間 / 決算|54c6a9a39b|01",
+          "time": "--",
+          "code": "369A",
+          "name": "エータイ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|372A|--|3Q|95f72c27e5|01",
+          "time": "--",
+          "code": "372A",
+          "name": "レント",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|402A|--|3Q|342c5b9163|01",
+          "time": "--",
+          "code": "402A",
+          "name": "アクセルスペースホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|414A|--|中間 / 決算|2f2a60a4fd|01",
+          "time": "--",
+          "code": "414A",
+          "name": "オーバーラップホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|469A|--|1Q|4f9f14f63f|01",
+          "time": "--",
+          "code": "469A",
+          "name": "フィットクルー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8783|--|中間 / 決算|fdb3867859|01",
+          "time": "--",
+          "code": "8783",
+          "name": "ａｂｃ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|1407|10:00 / (予定)|中間 / 決算|bdb96b6f90|01",
+          "time": "10:00 / (予定)",
+          "code": "1407",
+          "name": "ウエストホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8011|11:00 / (予定)|本決算|e1a499810e|01",
+          "time": "11:00 / (予定)",
+          "code": "8011",
+          "name": "三陽商会",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|190A|11:30 / (予定)|中間 / 決算|f843a97056|01",
+          "time": "11:30 / (予定)",
+          "code": "190A",
+          "name": "Ｃｈｏｒｄｉａ　Ｔｈｅｒａｐｅｕｔｉｃｓ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4434|11:30 / (予定)|本決算|cac4e53246|01",
+          "time": "11:30 / (予定)",
+          "code": "4434",
+          "name": "サーバーワークス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|1430|12:00 / (予定)|3Q|57d130d493|01",
+          "time": "12:00 / (予定)",
+          "code": "1430",
+          "name": "ファーストコーポレーション",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6521|12:00 / (予定)|本決算|e5d2b201e8|01",
+          "time": "12:00 / (予定)",
+          "code": "6521",
+          "name": "オキサイド",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7608|12:00 / (予定)|本決算|492aa047a1|01",
+          "time": "12:00 / (予定)",
+          "code": "7608",
+          "name": "エスケイジャパン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7805|12:00 / (予定)|中間 / 決算|b2245852d8|01",
+          "time": "12:00 / (予定)",
+          "code": "7805",
+          "name": "プリントネット",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9381|12:00 / (予定)|本決算|3b95dedb29|01",
+          "time": "12:00 / (予定)",
+          "code": "9381",
+          "name": "エーアイテイー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3021|12:30 / (予定)|3Q|9bb3c6e1f7|01",
+          "time": "12:30 / (予定)",
+          "code": "3021",
+          "name": "パシフィックネット",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7065|12:30 / (予定)|中間 / 決算|14cbbd3611|01",
+          "time": "12:30 / (予定)",
+          "code": "7065",
+          "name": "ユーピーアール",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3892|13:00 / (予定)|3Q|3660935d37|01",
+          "time": "13:00 / (予定)",
+          "code": "3892",
+          "name": "岡山製紙",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3935|13:00 / (予定)|本決算|8c7ce9c39d|01",
+          "time": "13:00 / (予定)",
+          "code": "3935",
+          "name": "エディア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4015|13:00 / (予定)|中間 / 決算|571bdcc3f6|01",
+          "time": "13:00 / (予定)",
+          "code": "4015",
+          "name": "ペイクラウドホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5026|13:00 / (予定)|中間 / 決算|da9029f9c9|01",
+          "time": "13:00 / (予定)",
+          "code": "5026",
+          "name": "トリプルアイズ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3177|13:30 / (予定)|本決算|a5514732c7|01",
+          "time": "13:30 / (予定)",
+          "code": "3177",
+          "name": "ありがとうサービス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3536|13:30 / (予定)|中間 / 決算|f5f97fd34f|01",
+          "time": "13:30 / (予定)",
+          "code": "3536",
+          "name": "アクサスホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3260|14:00 / (予定)|本決算|95d5d32246|01",
+          "time": "14:00 / (予定)",
+          "code": "3260",
+          "name": "エスポア",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5078|14:00 / (予定)|本決算|a4bb98247b|01",
+          "time": "14:00 / (予定)",
+          "code": "5078",
+          "name": "セレコーポレーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5817|14:00 / (予定)|本決算|66dc350f2f|01",
+          "time": "14:00 / (予定)",
+          "code": "5817",
+          "name": "ＪＭＡＣＳ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7601|14:00 / (予定)|本決算|c9236cfdcf|01",
+          "time": "14:00 / (予定)",
+          "code": "7601",
+          "name": "ポプラ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9601|14:00 / (予定)|本決算|29251f5bd7|01",
+          "time": "14:00 / (予定)",
+          "code": "9601",
+          "name": "松竹",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2404|14:20 / (予定)|中間 / 決算|3d1e108173|01",
+          "time": "14:20 / (予定)",
+          "code": "2404",
+          "name": "鉄人化ホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|189A|14:30 / (予定)|3Q|a06ec579a4|01",
+          "time": "14:30 / (予定)",
+          "code": "189A",
+          "name": "Ｄ＆Ｍカンパニー",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2722|15:00 / (予定)|3Q|df0d0b9f5d|01",
+          "time": "15:00 / (予定)",
+          "code": "2722",
+          "name": "ＩＫホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3181|15:00 / (予定)|本決算|a022697591|01",
+          "time": "15:00 / (予定)",
+          "code": "3181",
+          "name": "買取王国",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6142|15:00 / (予定)|本決算|f4ed9d2573|01",
+          "time": "15:00 / (予定)",
+          "code": "6142",
+          "name": "富士精工",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6150|15:00 / (予定)|3Q|690a0c2b09|01",
+          "time": "15:00 / (予定)",
+          "code": "6150",
+          "name": "タケダ機械",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6897|15:00 / (予定)|本決算|0eb1db9ab3|01",
+          "time": "15:00 / (予定)",
+          "code": "6897",
+          "name": "ツインバード",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7520|15:00 / (予定)|本決算|0b7dcb6056|01",
+          "time": "15:00 / (予定)",
+          "code": "7520",
+          "name": "エコス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7719|15:00 / (予定)|本決算|8dd5725476|01",
+          "time": "15:00 / (予定)",
+          "code": "7719",
+          "name": "東京衡機",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8233|15:00 / (予定)|本決算|7dc7a7d03e|01",
+          "time": "15:00 / (予定)",
+          "code": "8233",
+          "name": "高島屋",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8887|15:00 / (予定)|3Q|10f1874c8d|01",
+          "time": "15:00 / (予定)",
+          "code": "8887",
+          "name": "シーラホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9716|15:00 / (予定)|本決算|c4604bcffa|01",
+          "time": "15:00 / (予定)",
+          "code": "9716",
+          "name": "乃村工藝社",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|138A|15:30 / (予定)|1Q|8455772947|01",
+          "time": "15:30 / (予定)",
+          "code": "138A",
+          "name": "光フードサービス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|156A|15:30 / (予定)|中間 / 決算|8ee876437a|01",
+          "time": "15:30 / (予定)",
+          "code": "156A",
+          "name": "マテリアルグループ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|205A|15:30 / (予定)|3Q|5f75a8fdb1|01",
+          "time": "15:30 / (予定)",
+          "code": "205A",
+          "name": "ロゴスホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2168|15:30 / (予定)|3Q|192a1b8c95|01",
+          "time": "15:30 / (予定)",
+          "code": "2168",
+          "name": "パソナグループ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2292|15:30 / (予定)|本決算|af7fc1c62a|01",
+          "time": "15:30 / (予定)",
+          "code": "2292",
+          "name": "Ｓ　Ｆｏｏｄｓ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2305|15:30 / (予定)|本決算|028811120b|01",
+          "time": "15:30 / (予定)",
+          "code": "2305",
+          "name": "スタジオアリス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2337|15:30 / (予定)|本決算|a643b43909|01",
+          "time": "15:30 / (予定)",
+          "code": "2337",
+          "name": "いちご",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2379|15:30 / (予定)|本決算|23dc3b59d8|01",
+          "time": "15:30 / (予定)",
+          "code": "2379",
+          "name": "ディップ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2449|15:30 / (予定)|中間 / 決算|1c53f6a155|01",
+          "time": "15:30 / (予定)",
+          "code": "2449",
+          "name": "プラップジャパン",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2471|15:30 / (予定)|1Q|0fa2594026|01",
+          "time": "15:30 / (予定)",
+          "code": "2471",
+          "name": "エスプール",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2484|15:30 / (予定)|中間 / 決算|c2f18f63fd|01",
+          "time": "15:30 / (予定)",
+          "code": "2484",
+          "name": "出前館",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2668|15:30 / (予定)|本決算|844989252e|01",
+          "time": "15:30 / (予定)",
+          "code": "2668",
+          "name": "タビオ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|277A|15:30 / (予定)|3Q|e63d661b71|01",
+          "time": "15:30 / (予定)",
+          "code": "277A",
+          "name": "グロービング",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2882|15:30 / (予定)|本決算|b8019983a5|01",
+          "time": "15:30 / (予定)",
+          "code": "2882",
+          "name": "イートアンドホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2927|15:30 / (予定)|中間 / 決算|2c76d07d99|01",
+          "time": "15:30 / (予定)",
+          "code": "2927",
+          "name": "ＡＦＣ－ＨＤアムスライフサイエンス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2930|15:30 / (予定)|本決算|ab4e9f4fac|01",
+          "time": "15:30 / (予定)",
+          "code": "2930",
+          "name": "北の達人コーポレーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2934|15:30 / (予定)|3Q|9afdb0b62a|01",
+          "time": "15:30 / (予定)",
+          "code": "2934",
+          "name": "ジェイフロンティア",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2936|15:30 / (予定)|本決算|c2fe4ffb41|01",
+          "time": "15:30 / (予定)",
+          "code": "2936",
+          "name": "ベースフード",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3045|15:30 / (予定)|中間 / 決算|af8dc114b6|01",
+          "time": "15:30 / (予定)",
+          "code": "3045",
+          "name": "カワサキ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|304A|15:30 / (予定)|本決算|612479c977|01",
+          "time": "15:30 / (予定)",
+          "code": "304A",
+          "name": "フォルシア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3050|15:30 / (予定)|本決算|66c7908685|01",
+          "time": "15:30 / (予定)",
+          "code": "3050",
+          "name": "ＤＣＭホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3086|15:30 / (予定)|本決算|d19719961f|01",
+          "time": "15:30 / (予定)",
+          "code": "3086",
+          "name": "Ｊ．フロント　リテイリング",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3087|15:30 / (予定)|本決算|4090aa3a4d|01",
+          "time": "15:30 / (予定)",
+          "code": "3087",
+          "name": "ドトール・日レスホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3139|15:30 / (予定)|1Q|b0e174f811|01",
+          "time": "15:30 / (予定)",
+          "code": "3139",
+          "name": "ラクト・ジャパン",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3223|15:30 / (予定)|本決算|910b0bf146|01",
+          "time": "15:30 / (予定)",
+          "code": "3223",
+          "name": "エスエルディー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3267|15:30 / (予定)|1Q|8803b813cf|01",
+          "time": "15:30 / (予定)",
+          "code": "3267",
+          "name": "フィル・カンパニー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3297|15:30 / (予定)|3Q|82be60978a|01",
+          "time": "15:30 / (予定)",
+          "code": "3297",
+          "name": "東武住販",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|339A|15:30 / (予定)|本決算|22e32c5bdd|01",
+          "time": "15:30 / (予定)",
+          "code": "339A",
+          "name": "プログレス・テクノロジーズ　グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3440|15:30 / (予定)|中間 / 決算|a95d7b118b|01",
+          "time": "15:30 / (予定)",
+          "code": "3440",
+          "name": "日創グループ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3541|15:30 / (予定)|中間 / 決算|fb1c5eb235|01",
+          "time": "15:30 / (予定)",
+          "code": "3541",
+          "name": "農業総合研究所",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3548|15:30 / (予定)|本決算|a849e843d7|01",
+          "time": "15:30 / (予定)",
+          "code": "3548",
+          "name": "バロックジャパンリミテッド",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3558|15:30 / (予定)|本決算|6921a6cfbd|01",
+          "time": "15:30 / (予定)",
+          "code": "3558",
+          "name": "ジェイドグループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3697|15:30 / (予定)|中間 / 決算|37bab09d63|01",
+          "time": "15:30 / (予定)",
+          "code": "3697",
+          "name": "ＳＨＩＦＴ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3791|15:30 / (予定)|3Q|a475bb93d2|01",
+          "time": "15:30 / (予定)",
+          "code": "3791",
+          "name": "ＩＧポート",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3810|15:30 / (予定)|3Q|5f844afd9d|01",
+          "time": "15:30 / (予定)",
+          "code": "3810",
+          "name": "サイバーステップホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3823|15:30 / (予定)|中間 / 決算|8063b688e3|01",
+          "time": "15:30 / (予定)",
+          "code": "3823",
+          "name": "ＴＨＥ　ＷＨＹ　ＨＯＷ　ＤＯ　ＣＯＭＰＡＮＹ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3826|15:30 / (予定)|本決算|247aee1109|01",
+          "time": "15:30 / (予定)",
+          "code": "3826",
+          "name": "システムインテグレータ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3915|15:30 / (予定)|本決算|a0dff2f66f|01",
+          "time": "15:30 / (予定)",
+          "code": "3915",
+          "name": "テラスカイ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3977|15:30 / (予定)|本決算|647f5a71d3|01",
+          "time": "15:30 / (予定)",
+          "code": "3977",
+          "name": "フュージョン",
+          "market": "SPR",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3987|15:30 / (予定)|中間 / 決算|3a37641019|01",
+          "time": "15:30 / (予定)",
+          "code": "3987",
+          "name": "エコモット",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3991|15:30 / (予定)|中間 / 決算|366ddbe5c4|01",
+          "time": "15:30 / (予定)",
+          "code": "3991",
+          "name": "ウォンテッドリー",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3994|15:30 / (予定)|1Q|a70134d8a1|01",
+          "time": "15:30 / (予定)",
+          "code": "3994",
+          "name": "マネーフォワード",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4176|15:30 / (予定)|中間 / 決算|cb4618c437|01",
+          "time": "15:30 / (予定)",
+          "code": "4176",
+          "name": "ココナラ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4270|15:30 / (予定)|本決算|03d3725c15|01",
+          "time": "15:30 / (予定)",
+          "code": "4270",
+          "name": "ＢｅｅＸ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4317|15:30 / (予定)|本決算|9265ed1244|01",
+          "time": "15:30 / (予定)",
+          "code": "4317",
+          "name": "レイ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4412|15:30 / (予定)|中間 / 決算|70e6d60678|01",
+          "time": "15:30 / (予定)",
+          "code": "4412",
+          "name": "サイエンスアーツ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4433|15:30 / (予定)|中間 / 決算|b10e631d7e|01",
+          "time": "15:30 / (予定)",
+          "code": "4433",
+          "name": "ヒト・コミュニケーションズ・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4439|15:30 / (予定)|中間 / 決算|666257e7bc|01",
+          "time": "15:30 / (予定)",
+          "code": "4439",
+          "name": "東名",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4616|15:30 / (予定)|1Q|1c97a8633b|01",
+          "time": "15:30 / (予定)",
+          "code": "4616",
+          "name": "川上塗料",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5025|15:30 / (予定)|本決算|a823d990a3|01",
+          "time": "15:30 / (予定)",
+          "code": "5025",
+          "name": "マーキュリー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5243|15:30 / (予定)|1Q|592091165a|01",
+          "time": "15:30 / (予定)",
+          "code": "5243",
+          "name": "ｎｏｔｅ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5574|15:30 / (予定)|中間 / 決算|7566be155a|01",
+          "time": "15:30 / (予定)",
+          "code": "5574",
+          "name": "ＡＢＥＪＡ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5575|15:30 / (予定)|3Q|abae926507|01",
+          "time": "15:30 / (予定)",
+          "code": "5575",
+          "name": "Ｇｌｏｂｅｅ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5580|15:30 / (予定)|中間 / 決算|7fa0bc43eb|01",
+          "time": "15:30 / (予定)",
+          "code": "5580",
+          "name": "プロディライト",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5885|15:30 / (予定)|3Q|39ef5c8c61|01",
+          "time": "15:30 / (予定)",
+          "code": "5885",
+          "name": "ジーデップ・アドバンス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6044|15:30 / (予定)|3Q|93ccc3ebe7|01",
+          "time": "15:30 / (予定)",
+          "code": "6044",
+          "name": "三機サービス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6047|15:30 / (予定)|3Q|7a1e9fbd73|01",
+          "time": "15:30 / (予定)",
+          "code": "6047",
+          "name": "Ｇｕｎｏｓｙ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6058|15:30 / (予定)|本決算|a54b82b90c|01",
+          "time": "15:30 / (予定)",
+          "code": "6058",
+          "name": "ベクトル",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6086|15:30 / (予定)|本決算|2867a7aa57|01",
+          "time": "15:30 / (予定)",
+          "code": "6086",
+          "name": "シンメンテホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6182|15:30 / (予定)|本決算|6e41f4f278|01",
+          "time": "15:30 / (予定)",
+          "code": "6182",
+          "name": "メタリアル",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6199|15:30 / (予定)|中間 / 決算|2e0cb3937b|01",
+          "time": "15:30 / (予定)",
+          "code": "6199",
+          "name": "セラク",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6224|15:30 / (予定)|本決算|473ba98577|01",
+          "time": "15:30 / (予定)",
+          "code": "6224",
+          "name": "ＪＲＣ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6522|15:30 / (予定)|中間 / 決算|d7ec59b7e7|01",
+          "time": "15:30 / (予定)",
+          "code": "6522",
+          "name": "アスタリスク",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6532|15:30 / (予定)|本決算|4d50308830|01",
+          "time": "15:30 / (予定)",
+          "code": "6532",
+          "name": "ベイカレント",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6543|15:30 / (予定)|本決算|9eddc99025|01",
+          "time": "15:30 / (予定)",
+          "code": "6543",
+          "name": "日宣",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6558|15:30 / (予定)|1Q|a9e2f80ec1|01",
+          "time": "15:30 / (予定)",
+          "code": "6558",
+          "name": "クックビズ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6734|15:30 / (予定)|本決算|ea777b9430|01",
+          "time": "15:30 / (予定)",
+          "code": "6734",
+          "name": "ニューテック",
+          "market": "",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7077|15:30 / (予定)|本決算|06ef42e41b|01",
+          "time": "15:30 / (予定)",
+          "code": "7077",
+          "name": "ＡＬｉＮＫインターネット",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7083|15:30 / (予定)|1Q|22f22f3bee|01",
+          "time": "15:30 / (予定)",
+          "code": "7083",
+          "name": "ＡＨＣグループ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7351|15:30 / (予定)|中間 / 決算|06e6ea48a7|01",
+          "time": "15:30 / (予定)",
+          "code": "7351",
+          "name": "グッドパッチ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7352|15:30 / (予定)|中間 / 決算|2387f92ba1|01",
+          "time": "15:30 / (予定)",
+          "code": "7352",
+          "name": "ＴＷＯＳＴＯＮＥ＆Ｓｏｎｓ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7388|15:30 / (予定)|1Q|2ff6117f0b|01",
+          "time": "15:30 / (予定)",
+          "code": "7388",
+          "name": "ＦＰパートナー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7420|15:30 / (予定)|3Q|55bef533de|01",
+          "time": "15:30 / (予定)",
+          "code": "7420",
+          "name": "佐鳥電機",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7689|15:30 / (予定)|本決算|bf798db999|01",
+          "time": "15:30 / (予定)",
+          "code": "7689",
+          "name": "コパ・コーポレーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7730|15:30 / (予定)|中間 / 決算|fdaaa729c9|01",
+          "time": "15:30 / (予定)",
+          "code": "7730",
+          "name": "マニー",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7807|15:30 / (予定)|本決算|3d5d17db7f|01",
+          "time": "15:30 / (予定)",
+          "code": "7807",
+          "name": "幸和製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7808|15:30 / (予定)|3Q|342367aa86|01",
+          "time": "15:30 / (予定)",
+          "code": "7808",
+          "name": "シー・エス・ランバー",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7818|15:30 / (予定)|中間 / 決算|80d10af3f1|01",
+          "time": "15:30 / (予定)",
+          "code": "7818",
+          "name": "トランザクション",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7894|15:30 / (予定)|本決算|7eaca84b8e|01",
+          "time": "15:30 / (予定)",
+          "code": "7894",
+          "name": "丸東産業",
+          "market": "FKO",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7997|15:30 / (予定)|1Q|6049a22234|01",
+          "time": "15:30 / (予定)",
+          "code": "7997",
+          "name": "くろがね工作所",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8237|15:30 / (予定)|本決算|00dbe735a4|01",
+          "time": "15:30 / (予定)",
+          "code": "8237",
+          "name": "松屋",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8254|15:30 / (予定)|中間 / 決算|b97ce27257|01",
+          "time": "15:30 / (予定)",
+          "code": "8254",
+          "name": "さいか屋",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8273|15:30 / (予定)|本決算|8eb745bd79|01",
+          "time": "15:30 / (予定)",
+          "code": "8273",
+          "name": "イズミ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8904|15:30 / (予定)|中間 / 決算|50949e7c13|01",
+          "time": "15:30 / (予定)",
+          "code": "8904",
+          "name": "ＡＶＡＮＴＩＡ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9238|15:30 / (予定)|本決算|67baf2fb51|01",
+          "time": "15:30 / (予定)",
+          "code": "9238",
+          "name": "バリュークリエーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9252|15:30 / (予定)|中間 / 決算|db7321a935|01",
+          "time": "15:30 / (予定)",
+          "code": "9252",
+          "name": "ラストワンマイル",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9602|15:30 / (予定)|本決算|e534e56064|01",
+          "time": "15:30 / (予定)",
+          "code": "9602",
+          "name": "東宝",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9778|15:30 / (予定)|本決算|d83a64e396|01",
+          "time": "15:30 / (予定)",
+          "code": "9778",
+          "name": "昴",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9812|15:30 / (予定)|3Q|df75c44a82|01",
+          "time": "15:30 / (予定)",
+          "code": "9812",
+          "name": "テーオーホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9837|15:30 / (予定)|1Q|c0274b3e25|01",
+          "time": "15:30 / (予定)",
+          "code": "9837",
+          "name": "モリト",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9842|15:30 / (予定)|本決算|e1dc6cca0e|01",
+          "time": "15:30 / (予定)",
+          "code": "9842",
+          "name": "アークランズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9978|15:30 / (予定)|中間 / 決算|ca09b4419a|01",
+          "time": "15:30 / (予定)",
+          "code": "9978",
+          "name": "文教堂グループホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9993|15:30 / (予定)|本決算|ea81805e4c|01",
+          "time": "15:30 / (予定)",
+          "code": "9993",
+          "name": "ヤマザワ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6578|15:33 / (予定)|本決算|1687bf9ebe|01",
+          "time": "15:33 / (予定)",
+          "code": "6578",
+          "name": "コレックホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|274A|15:40 / (予定)|本決算|f89e3f28ec|01",
+          "time": "15:40 / (予定)",
+          "code": "274A",
+          "name": "ガーデン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3174|15:40 / (予定)|中間 / 決算|0cd3e5b2a4|01",
+          "time": "15:40 / (予定)",
+          "code": "3174",
+          "name": "ハピネス・アンド・ディ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2935|15:50 / (予定)|本決算|3b590a3668|01",
+          "time": "15:50 / (予定)",
+          "code": "2935",
+          "name": "ピックルスホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|135A|16:00 / (予定)|本決算|9e8f34d4e7|01",
+          "time": "16:00 / (予定)",
+          "code": "135A",
+          "name": "ＶＲＡＩＮ　Ｓｏｌｕｔｉｏｎ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|1418|16:00 / (予定)|本決算|6712400acb|01",
+          "time": "16:00 / (予定)",
+          "code": "1418",
+          "name": "インターライフホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2338|16:00 / (予定)|本決算|09183a3eef|01",
+          "time": "16:00 / (予定)",
+          "code": "2338",
+          "name": "クオンタムソリューションズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|244A|16:00 / (予定)|中間 / 決算|055c46b749|01",
+          "time": "16:00 / (予定)",
+          "code": "244A",
+          "name": "グロースエクスパートナーズ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|245A|16:00 / (予定)|中間 / 決算|78cf1877c8|01",
+          "time": "16:00 / (予定)",
+          "code": "245A",
+          "name": "ＩＮＧＳ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3083|16:00 / (予定)|本決算|384d948b1f|01",
+          "time": "16:00 / (予定)",
+          "code": "3083",
+          "name": "スターシーズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3189|16:00 / (予定)|中間 / 決算|d69a2a1c33|01",
+          "time": "16:00 / (予定)",
+          "code": "3189",
+          "name": "ＡＮＡＰホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3198|16:00 / (予定)|本決算|53dcbc2cb1|01",
+          "time": "16:00 / (予定)",
+          "code": "3198",
+          "name": "ＳＦＰホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3266|16:00 / (予定)|1Q|66489f40b3|01",
+          "time": "16:00 / (予定)",
+          "code": "3266",
+          "name": "ファンドクリエーショングループ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3384|16:00 / (予定)|本決算|48526d0ddb|01",
+          "time": "16:00 / (予定)",
+          "code": "3384",
+          "name": "アークコア",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3479|16:00 / (予定)|本決算|75e3e2a059|01",
+          "time": "16:00 / (予定)",
+          "code": "3479",
+          "name": "ティーケーピー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3967|16:00 / (予定)|本決算|0fc4f2e948|01",
+          "time": "16:00 / (予定)",
+          "code": "3967",
+          "name": "エルテス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4016|16:00 / (予定)|1Q|6cfc444e53|01",
+          "time": "16:00 / (予定)",
+          "code": "4016",
+          "name": "ＭＩＴホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4197|16:00 / (予定)|1Q|f0a7f7e516|01",
+          "time": "16:00 / (予定)",
+          "code": "4197",
+          "name": "アスマーク",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4413|16:00 / (予定)|本決算|914e8e2362|01",
+          "time": "16:00 / (予定)",
+          "code": "4413",
+          "name": "ボードルア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4429|16:00 / (予定)|本決算|ffee61e37f|01",
+          "time": "16:00 / (予定)",
+          "code": "4429",
+          "name": "リックソフト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4645|16:00 / (予定)|本決算|1b34e74183|01",
+          "time": "16:00 / (予定)",
+          "code": "4645",
+          "name": "市進ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4885|16:00 / (予定)|3Q|24c7b9255e|01",
+          "time": "16:00 / (予定)",
+          "code": "4885",
+          "name": "室町ケミカル",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5018|16:00 / (予定)|本決算|a4ce139c5c|01",
+          "time": "16:00 / (予定)",
+          "code": "5018",
+          "name": "ＭＯＲＥＳＣＯ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|5527|16:00 / (予定)|1Q|87cf94f74e|01",
+          "time": "16:00 / (予定)",
+          "code": "5527",
+          "name": "ｐｒｏｐｅｒｔｙ　ｔｅｃｈｎｏｌｏｇｉｅｓ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6025|16:00 / (予定)|中間 / 決算|33f1bce2a8|01",
+          "time": "16:00 / (予定)",
+          "code": "6025",
+          "name": "日本ＰＣサービス",
+          "market": "NGY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6173|16:00 / (予定)|本決算|d27d1e23b4|01",
+          "time": "16:00 / (予定)",
+          "code": "6173",
+          "name": "アクアライン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|6572|16:00 / (予定)|本決算|dd6b2ffc0f|01",
+          "time": "16:00 / (予定)",
+          "code": "6572",
+          "name": "オープングループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7035|16:00 / (予定)|中間 / 決算|e000a3ab11|01",
+          "time": "16:00 / (予定)",
+          "code": "7035",
+          "name": "ａｎｄ　ｆａｃｔｏｒｙ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7074|16:00 / (予定)|1Q|b61d82a7c0|01",
+          "time": "16:00 / (予定)",
+          "code": "7074",
+          "name": "トゥエンティーフォーセブンホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7357|16:00 / (予定)|本決算|ef664718b2|01",
+          "time": "16:00 / (予定)",
+          "code": "7357",
+          "name": "ジオコード",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7515|16:00 / (予定)|本決算|ff10151c39|01",
+          "time": "16:00 / (予定)",
+          "code": "7515",
+          "name": "マルヨシセンター",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7610|16:00 / (予定)|本決算|937cd02713|01",
+          "time": "16:00 / (予定)",
+          "code": "7610",
+          "name": "テイツー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|7879|16:00 / (予定)|1Q|2146360a6c|01",
+          "time": "16:00 / (予定)",
+          "code": "7879",
+          "name": "ノダ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9241|16:00 / (予定)|中間 / 決算|ae84190edb|01",
+          "time": "16:00 / (予定)",
+          "code": "9241",
+          "name": "フューチャーリンクネットワーク",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9979|16:00 / (予定)|中間 / 決算|1e477b43e5|01",
+          "time": "16:00 / (予定)",
+          "code": "9979",
+          "name": "大庄",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|1887|16:30 / (予定)|3Q|a701461ca5|01",
+          "time": "16:30 / (予定)",
+          "code": "1887",
+          "name": "日本国土開発",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|280A|16:30 / (予定)|1Q|120b6a7605|01",
+          "time": "16:30 / (予定)",
+          "code": "280A",
+          "name": "ＴＭＨ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3387|16:30 / (予定)|本決算|7cb682a50b|01",
+          "time": "16:30 / (予定)",
+          "code": "3387",
+          "name": "クリエイト・レストランツ・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3547|16:30 / (予定)|1Q|3aa1a7730b|01",
+          "time": "16:30 / (予定)",
+          "code": "3547",
+          "name": "ユニシアホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9388|16:30 / (予定)|本決算|c238b268d1|01",
+          "time": "16:30 / (予定)",
+          "code": "9388",
+          "name": "パパネッツ",
+          "market": "FKO",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|2798|17:00 / (予定)|本決算|6ec8a81456|01",
+          "time": "17:00 / (予定)",
+          "code": "2798",
+          "name": "ワイズテーブルコーポレーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3557|17:00 / (予定)|本決算|0ddd58dee4|01",
+          "time": "17:00 / (予定)",
+          "code": "3557",
+          "name": "ユナイテッド＆コレクティブ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|4198|17:00 / (予定)|3Q|7b8839af31|01",
+          "time": "17:00 / (予定)",
+          "code": "4198",
+          "name": "テンダ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9250|17:00 / (予定)|1Q|dcddbc88a6|01",
+          "time": "17:00 / (予定)",
+          "code": "9250",
+          "name": "ＧＲＣＳ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|8143|17:10 / (予定)|本決算|3d5ce572dc|01",
+          "time": "17:10 / (予定)",
+          "code": "8143",
+          "name": "ラピーヌ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|9215|17:30 / (予定)|1Q|8344362c6b|01",
+          "time": "17:30 / (予定)",
+          "code": "9215",
+          "name": "ＣａＳｙ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-14|3645|20:00 / (予定)|3Q|09b9dae46b|01",
+          "time": "20:00 / (予定)",
+          "code": "3645",
+          "name": "メディカルネット",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-15",
       "count": 5,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-15|2300|14:00 / (予定)|本決算|68447c2a8f|01",
+          "time": "14:00 / (予定)",
+          "code": "2300",
+          "name": "きょくとう",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-15|7847|15:00 / (予定)|本決算|52e1ff4a03|01",
+          "time": "15:00 / (予定)",
+          "code": "7847",
+          "name": "グラファイトデザイン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-15|4250|15:30 / (予定)|1Q|581d4b7507|01",
+          "time": "15:30 / (予定)",
+          "code": "4250",
+          "name": "フロンティア",
+          "market": "FKO",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-15|6866|15:30 / (予定)|1Q|cdfffda581|01",
+          "time": "15:30 / (予定)",
+          "code": "6866",
+          "name": "日置電機",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-15|2884|16:00 / (予定)|本決算|329be15e4d|01",
+          "time": "16:00 / (予定)",
+          "code": "2884",
+          "name": "ヨシムラ・フード・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-16",
@@ -100,8 +4551,49 @@
     {
       "date": "2026-04-17",
       "count": 4,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-17|8617|14:00 / (予定)|本決算|8e2756d4db|01",
+          "time": "14:00 / (予定)",
+          "code": "8617",
+          "name": "光世証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-17|2411|15:30 / (予定)|本決算|15a2c19980|01",
+          "time": "15:30 / (予定)",
+          "code": "2411",
+          "name": "ゲンダイエージェンシー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-17|4929|15:30 / (予定)|本決算|46bba13a36|01",
+          "time": "15:30 / (予定)",
+          "code": "4929",
+          "name": "アジュバンホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-17|6146|16:00 / (予定)|本決算|32689cf9e1|01",
+          "time": "16:00 / (予定)",
+          "code": "6146",
+          "name": "ディスコ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-18",
@@ -130,20 +4622,1143 @@
     {
       "date": "2026-04-22",
       "count": 7,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-22|4733|15:00 / (予定)|本決算|7c2d52cb63|01",
+          "time": "15:00 / (予定)",
+          "code": "4733",
+          "name": "オービックビジネスコンサルタント",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-22|2268|15:30 / (予定)|1Q|92d761c168|01",
+          "time": "15:30 / (予定)",
+          "code": "2268",
+          "name": "Ｂ－Ｒ　サーティワン　アイスクリーム",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-22|3091|15:30 / (予定)|1Q|38b9d802b1|01",
+          "time": "15:30 / (予定)",
+          "code": "3091",
+          "name": "ブロンコビリー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-22|4479|15:30 / (予定)|中間 / 決算|b2ae1b49de|01",
+          "time": "15:30 / (予定)",
+          "code": "4479",
+          "name": "マクアケ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-22|4684|15:30 / (予定)|本決算|f755e9ff2c|01",
+          "time": "15:30 / (予定)",
+          "code": "4684",
+          "name": "オービック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-22|5532|15:30 / (予定)|中間 / 決算|a1c217025a|01",
+          "time": "15:30 / (予定)",
+          "code": "5532",
+          "name": "リアルゲイト",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-22|8218|15:50 / (予定)|本決算|b60758501b|01",
+          "time": "15:50 / (予定)",
+          "code": "8218",
+          "name": "コメリ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-23",
       "count": 18,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-23|296A|11:30 / (予定)|本決算|4f0c8aacca|01",
+          "time": "11:30 / (予定)",
+          "code": "296A",
+          "name": "令和アカウンティング・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|8595|12:00 / (予定)|本決算|623fb580e6|01",
+          "time": "12:00 / (予定)",
+          "code": "8595",
+          "name": "ジャフコ　グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|5204|13:00 / (予定)|本決算|1085d89dd4|01",
+          "time": "13:00 / (予定)",
+          "code": "5204",
+          "name": "石塚硝子",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|7919|15:00 / (予定)|本決算|7c6c92e2fa|01",
+          "time": "15:00 / (予定)",
+          "code": "7919",
+          "name": "野崎印刷紙業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|7931|15:00 / (予定)|本決算|29feca89c5|01",
+          "time": "15:00 / (予定)",
+          "code": "7931",
+          "name": "未来工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|4498|15:30 / (予定)|本決算|84a35d624c|01",
+          "time": "15:30 / (予定)",
+          "code": "4498",
+          "name": "サイバートラスト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6210|15:30 / (予定)|本決算|54dd37c91d|01",
+          "time": "15:30 / (予定)",
+          "code": "6210",
+          "name": "ＴＯＹＯイノベックス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6807|15:30 / (予定)|本決算|786134285f|01",
+          "time": "15:30 / (予定)",
+          "code": "6807",
+          "name": "日本航空電子工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6954|15:30 / (予定)|本決算|b5e55ea80a|01",
+          "time": "15:30 / (予定)",
+          "code": "6954",
+          "name": "ファナック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6955|15:30 / (予定)|本決算|ada2a9f088|01",
+          "time": "15:30 / (予定)",
+          "code": "6955",
+          "name": "ＦＤＫ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|7309|15:30 / (予定)|1Q|61cc87e539|01",
+          "time": "15:30 / (予定)",
+          "code": "7309",
+          "name": "シマノ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|7739|15:30 / (予定)|1Q|96e3cde411|01",
+          "time": "15:30 / (予定)",
+          "code": "7739",
+          "name": "キヤノン電子",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|8060|15:30 / (予定)|1Q|c31ca53357|01",
+          "time": "15:30 / (予定)",
+          "code": "8060",
+          "name": "キヤノンマーケティングジャパン",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6345|15:40 / (予定)|本決算|fddef68737|01",
+          "time": "15:40 / (予定)",
+          "code": "6345",
+          "name": "アイチ　コーポレーション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|5576|16:00 / (予定)|本決算|f3598052c9|01",
+          "time": "16:00 / (予定)",
+          "code": "5576",
+          "name": "オービーシステム",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6999|16:00 / (予定)|本決算|b1287c69d9|01",
+          "time": "16:00 / (予定)",
+          "code": "6999",
+          "name": "ＫＯＡ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|4722|17:00 / (予定)|1Q|658343674b|01",
+          "time": "17:00 / (予定)",
+          "code": "4722",
+          "name": "フューチャー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-23|6653|17:00 / (予定)|1Q|fdeebaa5c5|01",
+          "time": "17:00 / (予定)",
+          "code": "6653",
+          "name": "正興電機製作所",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-24",
       "count": 87,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-24|353A|--|3Q|4dd2ec76ff|01",
+          "time": "--",
+          "code": "353A",
+          "name": "エレベーターコミュニケーションズ",
+          "market": "FKO",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6723|09:00 / (予定)|1Q|3e0e818b16|01",
+          "time": "09:00 / (予定)",
+          "code": "6723",
+          "name": "ルネサスエレクトロニクス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6516|11:00 / (予定)|本決算|cb1fff1d06|01",
+          "time": "11:00 / (予定)",
+          "code": "6516",
+          "name": "山洋電気",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9932|11:00 / (予定)|本決算|06894ba199|01",
+          "time": "11:00 / (予定)",
+          "code": "9932",
+          "name": "杉本商事",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|8706|11:25 / (予定)|本決算|5ca03471e6|01",
+          "time": "11:25 / (予定)",
+          "code": "8706",
+          "name": "極東証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|3003|11:30 / (予定)|1Q|6b50fcac3a|01",
+          "time": "11:30 / (予定)",
+          "code": "3003",
+          "name": "ヒューリック",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4956|11:30 / (予定)|本決算|b85a5f11f4|01",
+          "time": "11:30 / (予定)",
+          "code": "4956",
+          "name": "コニシ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|8892|11:30 / (予定)|本決算|2acc67d9d3|01",
+          "time": "11:30 / (予定)",
+          "code": "8892",
+          "name": "エスコン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4099|12:00 / (予定)|1Q|9eec254412|01",
+          "time": "12:00 / (予定)",
+          "code": "4099",
+          "name": "四国化成ホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4205|12:30 / (予定)|本決算|d5d0cfc1a8|01",
+          "time": "12:30 / (予定)",
+          "code": "4205",
+          "name": "日本ゼオン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2737|13:00 / (予定)|本決算|366ee370b4|01",
+          "time": "13:00 / (予定)",
+          "code": "2737",
+          "name": "トーメンデバイス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|3912|13:00 / (予定)|1Q|87232b0e4d|01",
+          "time": "13:00 / (予定)",
+          "code": "3912",
+          "name": "モバイルファクトリー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4568|13:00 / (予定)|本決算|da4392e9e6|01",
+          "time": "13:00 / (予定)",
+          "code": "4568",
+          "name": "第一三共",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9474|13:00 / (予定)|本決算|616866c921|01",
+          "time": "13:00 / (予定)",
+          "code": "9474",
+          "name": "ゼンリン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2216|13:30 / (予定)|1Q|3a402bb34d|01",
+          "time": "13:30 / (予定)",
+          "code": "2216",
+          "name": "カンロ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5410|13:30 / (予定)|本決算|92484f50f4|01",
+          "time": "13:30 / (予定)",
+          "code": "5410",
+          "name": "合同製鐵",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6858|13:45 / (予定)|1Q|f9b20baef4|01",
+          "time": "13:45 / (予定)",
+          "code": "6858",
+          "name": "小野測器",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|3891|14:00 / (予定)|本決算|089962b5a0|01",
+          "time": "14:00 / (予定)",
+          "code": "3891",
+          "name": "ニッポン高度紙工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4826|14:00 / (予定)|3Q|3dd36707fc|01",
+          "time": "14:00 / (予定)",
+          "code": "4826",
+          "name": "ＣＩＪ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5423|14:00 / (予定)|本決算|f60ed179b3|01",
+          "time": "14:00 / (予定)",
+          "code": "5423",
+          "name": "東京製鐵",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|8708|14:00 / (予定)|本決算|87bb4c2cbd|01",
+          "time": "14:00 / (予定)",
+          "code": "8708",
+          "name": "アイザワ証券グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9412|14:00 / (予定)|本決算|8f72247215|01",
+          "time": "14:00 / (予定)",
+          "code": "9412",
+          "name": "スカパーＪＳＡＴホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6995|14:40 / (予定)|本決算|bcecd2054f|01",
+          "time": "14:40 / (予定)",
+          "code": "6995",
+          "name": "東海理化電機製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|1972|15:00 / (予定)|本決算|9a947cf732|01",
+          "time": "15:00 / (予定)",
+          "code": "1972",
+          "name": "三晃金属工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6382|15:00 / (予定)|本決算|69fe2f9380|01",
+          "time": "15:00 / (予定)",
+          "code": "6382",
+          "name": "トリニティ工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6436|15:00 / (予定)|本決算|2748768dbf|01",
+          "time": "15:00 / (予定)",
+          "code": "6436",
+          "name": "アマノ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7205|15:00 / (予定)|本決算|91fecaeb1c|01",
+          "time": "15:00 / (予定)",
+          "code": "7205",
+          "name": "日野自動車",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7276|15:00 / (予定)|本決算|ac18028677|01",
+          "time": "15:00 / (予定)",
+          "code": "7276",
+          "name": "小糸製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|8707|15:00 / (予定)|本決算|95f8972733|01",
+          "time": "15:00 / (予定)",
+          "code": "8707",
+          "name": "岩井コスモホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9914|15:00 / (予定)|本決算|66a6296089|01",
+          "time": "15:00 / (予定)",
+          "code": "9914",
+          "name": "植松商会",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9962|15:00 / (予定)|本決算|44905646d3|01",
+          "time": "15:00 / (予定)",
+          "code": "9962",
+          "name": "ミスミグループ本社",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9991|15:00 / (予定)|本決算|a39ed20916|01",
+          "time": "15:00 / (予定)",
+          "code": "9991",
+          "name": "ジェコス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|1381|15:30 / (予定)|3Q|7e98c15f71|01",
+          "time": "15:30 / (予定)",
+          "code": "1381",
+          "name": "アクシーズ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|1944|15:30 / (予定)|本決算|79dc28dabf|01",
+          "time": "15:30 / (予定)",
+          "code": "1944",
+          "name": "きんでん",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2211|15:30 / (予定)|1Q|580a67ce3c|01",
+          "time": "15:30 / (予定)",
+          "code": "2211",
+          "name": "不二家",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2212|15:30 / (予定)|1Q|dd25f33516|01",
+          "time": "15:30 / (予定)",
+          "code": "2212",
+          "name": "山崎製パン",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2481|15:30 / (予定)|3Q|8f6fc4c902|01",
+          "time": "15:30 / (予定)",
+          "code": "2481",
+          "name": "タウンニュース社",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2664|15:30 / (予定)|本決算|449b82db5b|01",
+          "time": "15:30 / (予定)",
+          "code": "2664",
+          "name": "カワチ薬品",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|3231|15:30 / (予定)|本決算|43eaaeb7f1|01",
+          "time": "15:30 / (予定)",
+          "code": "3231",
+          "name": "野村不動産ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|3593|15:30 / (予定)|本決算|561244a814|01",
+          "time": "15:30 / (予定)",
+          "code": "3593",
+          "name": "ホギメディカル",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4063|15:30 / (予定)|本決算|a1f485d454|01",
+          "time": "15:30 / (予定)",
+          "code": "4063",
+          "name": "信越化学工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4307|15:30 / (予定)|本決算|019392b319|01",
+          "time": "15:30 / (予定)",
+          "code": "4307",
+          "name": "野村総合研究所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4503|15:30 / (予定)|本決算|daff1fc0d3|01",
+          "time": "15:30 / (予定)",
+          "code": "4503",
+          "name": "アステラス製薬",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4765|15:30 / (予定)|本決算|b4beea6c43|01",
+          "time": "15:30 / (予定)",
+          "code": "4765",
+          "name": "ＳＢＩグローバルアセットマネジメント",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4832|15:30 / (予定)|本決算|3a7da52587|01",
+          "time": "15:30 / (予定)",
+          "code": "4832",
+          "name": "ＪＦＥシステムズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5609|15:30 / (予定)|本決算|883ea54dab|01",
+          "time": "15:30 / (予定)",
+          "code": "5609",
+          "name": "日本鋳造",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5857|15:30 / (予定)|本決算|d74b3e4718|01",
+          "time": "15:30 / (予定)",
+          "code": "5857",
+          "name": "ＡＲＥホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5906|15:30 / (予定)|本決算|128f39ca25|01",
+          "time": "15:30 / (予定)",
+          "code": "5906",
+          "name": "エムケー精工",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6305|15:30 / (予定)|本決算|40f515b073|01",
+          "time": "15:30 / (予定)",
+          "code": "6305",
+          "name": "日立建機",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6455|15:30 / (予定)|本決算|cdeb08972b|01",
+          "time": "15:30 / (予定)",
+          "code": "6455",
+          "name": "モリタホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6504|15:30 / (予定)|本決算|8124f005f9|01",
+          "time": "15:30 / (予定)",
+          "code": "6504",
+          "name": "富士電機",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6594|15:30 / (予定)|本決算|7781a9c72f|01",
+          "time": "15:30 / (予定)",
+          "code": "6594",
+          "name": "ニデック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6663|15:30 / (予定)|1Q|b539c4b83a|01",
+          "time": "15:30 / (予定)",
+          "code": "6663",
+          "name": "太洋テクノレックス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6702|15:30 / (予定)|本決算|6fdeb44846|01",
+          "time": "15:30 / (予定)",
+          "code": "6702",
+          "name": "富士通",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6754|15:30 / (予定)|本決算|642ad74135|01",
+          "time": "15:30 / (予定)",
+          "code": "6754",
+          "name": "アンリツ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6810|15:30 / (予定)|本決算|36f2ee3c3b|01",
+          "time": "15:30 / (予定)",
+          "code": "6810",
+          "name": "マクセル",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6857|15:30 / (予定)|本決算|55a6c5e38c|01",
+          "time": "15:30 / (予定)",
+          "code": "6857",
+          "name": "アドバンテスト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7175|15:30 / (予定)|本決算|625353d779|01",
+          "time": "15:30 / (予定)",
+          "code": "7175",
+          "name": "今村証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7422|15:30 / (予定)|1Q|5eca5900f8|01",
+          "time": "15:30 / (予定)",
+          "code": "7422",
+          "name": "東邦レマック",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7646|15:30 / (予定)|中間 / 決算|7a10e522e2|01",
+          "time": "15:30 / (予定)",
+          "code": "7646",
+          "name": "ＰＬＡＮＴ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7751|15:30 / (予定)|1Q|28a48adc41|01",
+          "time": "15:30 / (予定)",
+          "code": "7751",
+          "name": "キヤノン",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7839|15:30 / (予定)|中間 / 決算|fbfcd89e0e|01",
+          "time": "15:30 / (予定)",
+          "code": "7839",
+          "name": "ＳＨＯＥＩ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7970|15:30 / (予定)|本決算|109aba806e|01",
+          "time": "15:30 / (予定)",
+          "code": "7970",
+          "name": "信越ポリマー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7976|15:30 / (予定)|1Q|e6e2950df4|01",
+          "time": "15:30 / (予定)",
+          "code": "7976",
+          "name": "三菱鉛筆",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|8604|15:30 / (予定)|本決算|be3729ceb3|01",
+          "time": "15:30 / (予定)",
+          "code": "8604",
+          "name": "野村ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|8793|15:30 / (予定)|本決算|fcf3423057|01",
+          "time": "15:30 / (予定)",
+          "code": "8793",
+          "name": "ＮＥＣキャピタルソリューション",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9551|15:30 / (予定)|本決算|8c8f08457e|01",
+          "time": "15:30 / (予定)",
+          "code": "9551",
+          "name": "メタウォーター",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9629|15:30 / (予定)|本決算|725cb12ca4|01",
+          "time": "15:30 / (予定)",
+          "code": "9629",
+          "name": "ピー・シー・エー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9795|15:30 / (予定)|中間 / 決算|483dc19299|01",
+          "time": "15:30 / (予定)",
+          "code": "9795",
+          "name": "ステップ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5990|15:40 / (予定)|本決算|abb2587c3e|01",
+          "time": "15:40 / (予定)",
+          "code": "5990",
+          "name": "スーパーツール",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7250|15:40 / (予定)|本決算|253279a52e|01",
+          "time": "15:40 / (予定)",
+          "code": "7250",
+          "name": "太平洋工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|2208|15:45 / (予定)|本決算|b8143f8549|01",
+          "time": "15:45 / (予定)",
+          "code": "2208",
+          "name": "ブルボン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|3636|16:00 / (予定)|中間 / 決算|e41b808665|01",
+          "time": "16:00 / (予定)",
+          "code": "3636",
+          "name": "三菱総合研究所",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4973|16:00 / (予定)|本決算|03d4e94a74|01",
+          "time": "16:00 / (予定)",
+          "code": "4973",
+          "name": "日本高純度化学",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|5819|16:00 / (予定)|1Q|2c032255d7|01",
+          "time": "16:00 / (予定)",
+          "code": "5819",
+          "name": "カナレ電気",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6617|16:00 / (予定)|本決算|55c7e519f2|01",
+          "time": "16:00 / (予定)",
+          "code": "6617",
+          "name": "東光高岳",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6861|16:00 / (予定)|本決算|f7aef23b06|01",
+          "time": "16:00 / (予定)",
+          "code": "6861",
+          "name": "キーエンス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6988|16:00 / (予定)|本決算|47473b9839|01",
+          "time": "16:00 / (予定)",
+          "code": "6988",
+          "name": "日東電工",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7102|16:00 / (予定)|本決算|3b71fe675f|01",
+          "time": "16:00 / (予定)",
+          "code": "7102",
+          "name": "日本車輌製造",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7278|16:00 / (予定)|本決算|ea125cf1a6|01",
+          "time": "16:00 / (予定)",
+          "code": "7278",
+          "name": "エクセディ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7962|16:00 / (予定)|3Q|b1dff567b6|01",
+          "time": "16:00 / (予定)",
+          "code": "7962",
+          "name": "キングジム",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7984|16:00 / (予定)|1Q|ec8935137b|01",
+          "time": "16:00 / (予定)",
+          "code": "7984",
+          "name": "コクヨ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9679|16:00 / (予定)|中間 / 決算|5d89c2adff|01",
+          "time": "16:00 / (予定)",
+          "code": "9679",
+          "name": "ホウライ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|7897|16:30 / (予定)|本決算|829261c072|01",
+          "time": "16:30 / (予定)",
+          "code": "7897",
+          "name": "ホクシン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|9003|16:30 / (予定)|本決算|cc3261c7fb|01",
+          "time": "16:30 / (予定)",
+          "code": "9003",
+          "name": "相鉄ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|4519|17:00 / (予定)|1Q|3a2d8e2c19|01",
+          "time": "17:00 / (予定)",
+          "code": "4519",
+          "name": "中外製薬",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-24|6923|17:00 / (予定)|本決算|2485204abe|01",
+          "time": "17:00 / (予定)",
+          "code": "6923",
+          "name": "スタンレー電気",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-25",
@@ -160,14 +5775,826 @@
     {
       "date": "2026-04-27",
       "count": 6,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-27|9368|11:00 / (予定)|本決算|871da1ef0e|01",
+          "time": "11:00 / (予定)",
+          "code": "9368",
+          "name": "キムラユニティー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-27|8190|13:00 / (予定)|本決算|0717acb624|01",
+          "time": "13:00 / (予定)",
+          "code": "8190",
+          "name": "ヤマナカ",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-27|6470|14:00 / (予定)|本決算|0c2f94811b|01",
+          "time": "14:00 / (予定)",
+          "code": "6470",
+          "name": "大豊工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-27|5992|14:20 / (予定)|本決算|b3261cb009|01",
+          "time": "14:20 / (予定)",
+          "code": "5992",
+          "name": "中央発條",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-27|7283|15:20 / (予定)|本決算|1a9aaebbcd|01",
+          "time": "15:20 / (予定)",
+          "code": "7283",
+          "name": "愛三工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-27|7241|16:20 / (予定)|本決算|a629c00a11|01",
+          "time": "16:20 / (予定)",
+          "code": "7241",
+          "name": "フタバ産業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-28",
       "count": 75,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-28|4043|09:00 / (予定)|本決算|93fe7003fd|01",
+          "time": "09:00 / (予定)",
+          "code": "4043",
+          "name": "トクヤマ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8609|11:00 / (予定)|本決算|1c5dd2cedb|01",
+          "time": "11:00 / (予定)",
+          "code": "8609",
+          "name": "岡三証券グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9040|11:00 / (予定)|本決算|8acc8c79f6|01",
+          "time": "11:00 / (予定)",
+          "code": "9040",
+          "name": "大宝運輸",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6902|11:10 / (予定)|本決算|3183542790|01",
+          "time": "11:10 / (予定)",
+          "code": "6902",
+          "name": "デンソー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|3778|11:30 / (予定)|本決算|f1ebb60eb6|01",
+          "time": "11:30 / (予定)",
+          "code": "3778",
+          "name": "さくらインターネット",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5834|11:30 / (予定)|本決算|92517295e6|01",
+          "time": "11:30 / (予定)",
+          "code": "5834",
+          "name": "ＳＢＩリーシングサービス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8601|11:30 / (予定)|本決算|4b15766ad9|01",
+          "time": "11:30 / (予定)",
+          "code": "8601",
+          "name": "大和証券グループ本社",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8628|11:30 / (予定)|本決算|3893a0fbfb|01",
+          "time": "11:30 / (予定)",
+          "code": "8628",
+          "name": "松井証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6201|11:40 / (予定)|本決算|b0859ef8ea|01",
+          "time": "11:40 / (予定)",
+          "code": "6201",
+          "name": "豊田自動織機",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8613|12:00 / (予定)|本決算|6f08f92b84|01",
+          "time": "12:00 / (予定)",
+          "code": "8613",
+          "name": "丸三証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8697|12:00 / (予定)|本決算|ae28884bd1|01",
+          "time": "12:00 / (予定)",
+          "code": "8697",
+          "name": "日本取引所グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1934|12:30 / (予定)|本決算|c70d773f0d|01",
+          "time": "12:30 / (予定)",
+          "code": "1934",
+          "name": "ユアテック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6592|12:30 / (予定)|1Q|c11b084f2a|01",
+          "time": "12:30 / (予定)",
+          "code": "6592",
+          "name": "マブチモーター",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8285|12:30 / (予定)|本決算|40c508dbad|01",
+          "time": "12:30 / (予定)",
+          "code": "8285",
+          "name": "三谷産業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8624|12:45 / (予定)|本決算|71a583f5f4|01",
+          "time": "12:45 / (予定)",
+          "code": "8624",
+          "name": "いちよし証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1777|13:00 / (予定)|本決算|e236e96430|01",
+          "time": "13:00 / (予定)",
+          "code": "1777",
+          "name": "川崎設備工業",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1942|13:00 / (予定)|本決算|b1599bfe3a|01",
+          "time": "13:00 / (予定)",
+          "code": "1942",
+          "name": "関電工",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|4345|13:00 / (予定)|本決算|38be91a736|01",
+          "time": "13:00 / (予定)",
+          "code": "4345",
+          "name": "シーティーエス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5449|13:00 / (予定)|本決算|3b52c38891|01",
+          "time": "13:00 / (予定)",
+          "code": "5449",
+          "name": "大阪製鐵",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6023|13:00 / (予定)|本決算|1eb742667e|01",
+          "time": "13:00 / (予定)",
+          "code": "6023",
+          "name": "ダイハツインフィニアース",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|7259|13:00 / (予定)|本決算|5a1748af06|01",
+          "time": "13:00 / (予定)",
+          "code": "7259",
+          "name": "アイシン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9534|13:00 / (予定)|本決算|75f5599a31|01",
+          "time": "13:00 / (予定)",
+          "code": "9534",
+          "name": "北海道瓦斯",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8622|13:20 / (予定)|本決算|73e7c03571|01",
+          "time": "13:20 / (予定)",
+          "code": "8622",
+          "name": "水戸証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1964|14:00 / (予定)|本決算|c191498a3a|01",
+          "time": "14:00 / (予定)",
+          "code": "1964",
+          "name": "中外炉工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|3116|14:00 / (予定)|本決算|6977b7f1dc|01",
+          "time": "14:00 / (予定)",
+          "code": "3116",
+          "name": "トヨタ紡織",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|4045|14:00 / (予定)|1Q|65f0a769a4|01",
+          "time": "14:00 / (予定)",
+          "code": "4045",
+          "name": "東亞合成",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6302|14:00 / (予定)|1Q|0e42239289|01",
+          "time": "14:00 / (予定)",
+          "code": "6302",
+          "name": "住友重機械工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8014|14:00 / (予定)|本決算|aeb99afcc4|01",
+          "time": "14:00 / (予定)",
+          "code": "8014",
+          "name": "蝶理",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9531|14:00 / (予定)|本決算|c8582741b0|01",
+          "time": "14:00 / (予定)",
+          "code": "9531",
+          "name": "東京瓦斯",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|7282|14:20 / (予定)|本決算|7898d662b9|01",
+          "time": "14:20 / (予定)",
+          "code": "7282",
+          "name": "豊田合成",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8076|14:20 / (予定)|本決算|851b295548|01",
+          "time": "14:20 / (予定)",
+          "code": "8076",
+          "name": "カノークス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5659|14:30 / (予定)|本決算|2965f596cd|01",
+          "time": "14:30 / (予定)",
+          "code": "5659",
+          "name": "日本精線",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6301|14:30 / (予定)|本決算|3d74ee6da6|01",
+          "time": "14:30 / (予定)",
+          "code": "6301",
+          "name": "小松製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5482|14:40 / (予定)|本決算|5042cae4b0|01",
+          "time": "14:40 / (予定)",
+          "code": "5482",
+          "name": "愛知製鋼",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1941|15:00 / (予定)|本決算|0d56e05ac2|01",
+          "time": "15:00 / (予定)",
+          "code": "1941",
+          "name": "中電工",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1959|15:00 / (予定)|本決算|b996954ee8|01",
+          "time": "15:00 / (予定)",
+          "code": "1959",
+          "name": "クラフティア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6161|15:00 / (予定)|本決算|42788cd63c|01",
+          "time": "15:00 / (予定)",
+          "code": "6161",
+          "name": "エスティック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6473|15:00 / (予定)|本決算|19ea41d3cd|01",
+          "time": "15:00 / (予定)",
+          "code": "6473",
+          "name": "ジェイテクト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6586|15:00 / (予定)|本決算|2fcad9ac37|01",
+          "time": "15:00 / (予定)",
+          "code": "6586",
+          "name": "マキタ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8071|15:00 / (予定)|本決算|6927fbb8b4|01",
+          "time": "15:00 / (予定)",
+          "code": "8071",
+          "name": "東海エレクトロニクス",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9539|15:00 / (予定)|1Q|a6195e6b2b|01",
+          "time": "15:00 / (予定)",
+          "code": "9539",
+          "name": "京葉瓦斯",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1718|15:30 / (予定)|1Q|27df48f68f|01",
+          "time": "15:30 / (予定)",
+          "code": "1718",
+          "name": "美樹工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|2175|15:30 / (予定)|本決算|5a55e54518|01",
+          "time": "15:30 / (予定)",
+          "code": "2175",
+          "name": "エス・エム・エス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|2327|15:30 / (予定)|本決算|ca5f3a8109|01",
+          "time": "15:30 / (予定)",
+          "code": "2327",
+          "name": "日鉄ソリューションズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|2359|15:30 / (予定)|本決算|a4f661b362|01",
+          "time": "15:30 / (予定)",
+          "code": "2359",
+          "name": "コア",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|2760|15:30 / (予定)|本決算|5474895539|01",
+          "time": "15:30 / (予定)",
+          "code": "2760",
+          "name": "東京エレクトロン　デバイス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|2801|15:30 / (予定)|本決算|92050ed520|01",
+          "time": "15:30 / (予定)",
+          "code": "2801",
+          "name": "キッコーマン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|3426|15:30 / (予定)|3Q|b4e616b5fb|01",
+          "time": "15:30 / (予定)",
+          "code": "3426",
+          "name": "アトムリビンテック",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|3911|15:30 / (予定)|1Q|429feb882f|01",
+          "time": "15:30 / (予定)",
+          "code": "3911",
+          "name": "Ａｉｍｉｎｇ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|4204|15:30 / (予定)|本決算|d31aa2204e|01",
+          "time": "15:30 / (予定)",
+          "code": "4204",
+          "name": "積水化学工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|4318|15:30 / (予定)|本決算|a65b3189ab|01",
+          "time": "15:30 / (予定)",
+          "code": "4318",
+          "name": "クイック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5332|15:30 / (予定)|本決算|f779c529b3|01",
+          "time": "15:30 / (予定)",
+          "code": "5332",
+          "name": "ＴＯＴＯ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5612|15:30 / (予定)|本決算|42d11f0989|01",
+          "time": "15:30 / (予定)",
+          "code": "5612",
+          "name": "日本鋳鉄管",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6501|15:30 / (予定)|本決算|e6e1154e50|01",
+          "time": "15:30 / (予定)",
+          "code": "6501",
+          "name": "日立製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6503|15:30 / (予定)|本決算|ca06485216|01",
+          "time": "15:30 / (予定)",
+          "code": "6503",
+          "name": "三菱電機",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6526|15:30 / (予定)|本決算|608ad086c4|01",
+          "time": "15:30 / (予定)",
+          "code": "6526",
+          "name": "ソシオネクスト",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6701|15:30 / (予定)|本決算|99e2c5f099|01",
+          "time": "15:30 / (予定)",
+          "code": "6701",
+          "name": "日本電気",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6762|15:30 / (予定)|本決算|2c4e338553|01",
+          "time": "15:30 / (予定)",
+          "code": "6762",
+          "name": "ＴＤＫ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6823|15:30 / (予定)|本決算|5baed7682d|01",
+          "time": "15:30 / (予定)",
+          "code": "6823",
+          "name": "リオン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|7949|15:30 / (予定)|本決算|d4cebc0563|01",
+          "time": "15:30 / (予定)",
+          "code": "7949",
+          "name": "小松ウオール工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9023|15:30 / (予定)|本決算|4b97a01e00|01",
+          "time": "15:30 / (予定)",
+          "code": "9023",
+          "name": "東京地下鉄",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9158|15:30 / (予定)|本決算|87997592d0|01",
+          "time": "15:30 / (予定)",
+          "code": "9158",
+          "name": "シーユーシー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9267|15:30 / (予定)|3Q|343a455fcb|01",
+          "time": "15:30 / (予定)",
+          "code": "9267",
+          "name": "Ｇｅｎｋｙ　ＤｒｕｇＳｔｏｒｅｓ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9505|15:30 / (予定)|本決算|96fd4acdfd|01",
+          "time": "15:30 / (予定)",
+          "code": "9505",
+          "name": "北陸電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1946|15:40 / (予定)|本決算|0157cf102a|01",
+          "time": "15:40 / (予定)",
+          "code": "1946",
+          "name": "トーエネック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1850|16:00 / (予定)|本決算|f89d753c79|01",
+          "time": "16:00 / (予定)",
+          "code": "1850",
+          "name": "南海辰村建設",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|1930|16:00 / (予定)|本決算|ba36e86e0b|01",
+          "time": "16:00 / (予定)",
+          "code": "1930",
+          "name": "北陸電気工事",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|4661|16:00 / (予定)|本決算|90c0c57d36|01",
+          "time": "16:00 / (予定)",
+          "code": "4661",
+          "name": "オリエンタルランド",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|4685|16:00 / (予定)|本決算|87ec0d1db0|01",
+          "time": "16:00 / (予定)",
+          "code": "4685",
+          "name": "菱友システムズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|6920|16:00 / (予定)|3Q|2de513c7af|01",
+          "time": "16:00 / (予定)",
+          "code": "6920",
+          "name": "レーザーテック",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|7148|16:00 / (予定)|中間 / 決算|ef038c46e2|01",
+          "time": "16:00 / (予定)",
+          "code": "7148",
+          "name": "ＦＰＧ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|8614|16:00 / (予定)|本決算|cbe7fb5bee|01",
+          "time": "16:00 / (予定)",
+          "code": "8614",
+          "name": "東洋証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|9502|16:00 / (予定)|本決算|845a94fc85|01",
+          "time": "16:00 / (予定)",
+          "code": "9502",
+          "name": "中部電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|5279|16:30 / (予定)|本決算|8f6c90ccb2|01",
+          "time": "16:30 / (予定)",
+          "code": "5279",
+          "name": "日本興業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-28|7908|17:00 / (予定)|本決算|bb3641b957|01",
+          "time": "17:00 / (予定)",
+          "code": "7908",
+          "name": "きもと",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     },
     {
       "date": "2026-04-29",
@@ -178,8 +6605,1249 @@
     {
       "date": "2026-04-30",
       "count": 124,
-      "detail_status": "missing",
-      "items": []
+      "detail_status": "present",
+      "items": [
+        {
+          "event_id": "2026-04-30|4679|10:40 / (予定)|本決算|2c4b833e18|01",
+          "time": "10:40 / (予定)",
+          "code": "4679",
+          "name": "田谷",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8616|11:00 / (予定)|本決算|2943fb5a26|01",
+          "time": "11:00 / (予定)",
+          "code": "8616",
+          "name": "東海東京フィナンシャル・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9533|11:40 / (予定)|本決算|7a681e67ec|01",
+          "time": "11:40 / (予定)",
+          "code": "9533",
+          "name": "東邦瓦斯",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4626|12:00 / (予定)|本決算|9bc3cfd399|01",
+          "time": "12:00 / (予定)",
+          "code": "4626",
+          "name": "太陽ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8914|12:00 / (予定)|1Q|860ec318fc|01",
+          "time": "12:00 / (予定)",
+          "code": "8914",
+          "name": "エリアリンク",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9104|12:00 / (予定)|本決算|0369a9cdad|01",
+          "time": "12:00 / (予定)",
+          "code": "9104",
+          "name": "商船三井",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2892|12:30 / (予定)|本決算|c45b5a6f52|01",
+          "time": "12:30 / (予定)",
+          "code": "2892",
+          "name": "日本食品化工",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3776|12:30 / (予定)|1Q|6595c7e9e9|01",
+          "time": "12:30 / (予定)",
+          "code": "3776",
+          "name": "ブロードバンドタワー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4221|12:30 / (予定)|1Q|8e5e4f462f|01",
+          "time": "12:30 / (予定)",
+          "code": "4221",
+          "name": "大倉工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7600|12:30 / (予定)|本決算|746290fb8d|01",
+          "time": "12:30 / (予定)",
+          "code": "7600",
+          "name": "日本エム・ディ・エム",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2692|13:00 / (予定)|本決算|14ad5b8291|01",
+          "time": "13:00 / (予定)",
+          "code": "2692",
+          "name": "伊藤忠食品",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4410|13:00 / (予定)|本決算|4e9cd5dabb|01",
+          "time": "13:00 / (予定)",
+          "code": "4410",
+          "name": "ハリマ化成グループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5257|13:00 / (予定)|1Q|031e08cfea|01",
+          "time": "13:00 / (予定)",
+          "code": "5257",
+          "name": "ノバシステム",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5440|13:00 / (予定)|本決算|cac9b4363c|01",
+          "time": "13:00 / (予定)",
+          "code": "5440",
+          "name": "共英製鋼",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5444|13:00 / (予定)|本決算|a0568a7604|01",
+          "time": "13:00 / (予定)",
+          "code": "5444",
+          "name": "大和工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7381|13:00 / (予定)|本決算|f7d165749b|01",
+          "time": "13:00 / (予定)",
+          "code": "7381",
+          "name": "ＣＣＩグループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7539|13:00 / (予定)|中間 / 決算|0876e3027e|01",
+          "time": "13:00 / (予定)",
+          "code": "7539",
+          "name": "アイナボホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8133|13:00 / (予定)|本決算|02cab896d2|01",
+          "time": "13:00 / (予定)",
+          "code": "8133",
+          "name": "伊藤忠エネクス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9511|13:00 / (予定)|本決算|f87a7d08fe|01",
+          "time": "13:00 / (予定)",
+          "code": "9511",
+          "name": "沖縄電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9830|13:00 / (予定)|1Q|1ef258480e|01",
+          "time": "13:00 / (予定)",
+          "code": "9830",
+          "name": "トラスコ中山",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7896|13:20 / (予定)|本決算|3b2af5ee37|01",
+          "time": "13:20 / (予定)",
+          "code": "7896",
+          "name": "セブン工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4578|13:30 / (予定)|1Q|e09e1339fa|01",
+          "time": "13:30 / (予定)",
+          "code": "4578",
+          "name": "大塚ホールディングス",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4709|13:30 / (予定)|本決算|99215f7e57|01",
+          "time": "13:30 / (予定)",
+          "code": "4709",
+          "name": "ＩＤホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8103|13:30 / (予定)|本決算|01dd8e1a1a|01",
+          "time": "13:30 / (予定)",
+          "code": "8103",
+          "name": "明和産業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5333|13:40 / (予定)|本決算|eede5e6d19|01",
+          "time": "13:40 / (予定)",
+          "code": "5333",
+          "name": "日本碍子",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4220|14:00 / (予定)|本決算|9d73f60824|01",
+          "time": "14:00 / (予定)",
+          "code": "4220",
+          "name": "リケンテクノス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6888|14:00 / (予定)|3Q|d91b2f5319|01",
+          "time": "14:00 / (予定)",
+          "code": "6888",
+          "name": "アクモス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9044|14:00 / (予定)|本決算|6bdae2644c|01",
+          "time": "14:00 / (予定)",
+          "code": "9044",
+          "name": "南海電気鉄道",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9504|14:00 / (予定)|本決算|119521512c|01",
+          "time": "14:00 / (予定)",
+          "code": "9504",
+          "name": "中国電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7475|14:30 / (予定)|本決算|a4cdd15791|01",
+          "time": "14:30 / (予定)",
+          "code": "7475",
+          "name": "アルビス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9110|14:30 / (予定)|本決算|f7d5ff70a0|01",
+          "time": "14:30 / (予定)",
+          "code": "9110",
+          "name": "ＮＳユナイテッド海運",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6325|14:40 / (予定)|本決算|aeaf0594b5|01",
+          "time": "14:40 / (予定)",
+          "code": "6325",
+          "name": "タカキタ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6623|14:40 / (予定)|本決算|16fadc99b9|01",
+          "time": "14:40 / (予定)",
+          "code": "6623",
+          "name": "愛知電機",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|1911|15:00 / (予定)|1Q|9a31255903|01",
+          "time": "15:00 / (予定)",
+          "code": "1911",
+          "name": "住友林業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4248|15:00 / (予定)|1Q|b5fbcb4108|01",
+          "time": "15:00 / (予定)",
+          "code": "4248",
+          "name": "竹本容器",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7947|15:00 / (予定)|本決算|5d42514d14|01",
+          "time": "15:00 / (予定)",
+          "code": "7947",
+          "name": "エフピコ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8015|15:00 / (予定)|本決算|70677ca15a|01",
+          "time": "15:00 / (予定)",
+          "code": "8015",
+          "name": "豊田通商",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8803|15:00 / (予定)|本決算|be38d8016a|01",
+          "time": "15:00 / (予定)",
+          "code": "8803",
+          "name": "平和不動産",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9506|15:00 / (予定)|本決算|888b105af3|01",
+          "time": "15:00 / (予定)",
+          "code": "9506",
+          "name": "東北電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9507|15:00 / (予定)|本決算|19a6410542|01",
+          "time": "15:00 / (予定)",
+          "code": "9507",
+          "name": "四国電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9687|15:00 / (予定)|本決算|a0f78edae1|01",
+          "time": "15:00 / (予定)",
+          "code": "9687",
+          "name": "ＫＳＫ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2114|15:30 / (予定)|本決算|b431541b09|01",
+          "time": "15:30 / (予定)",
+          "code": "2114",
+          "name": "フジ日本",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2127|15:30 / (予定)|本決算|adce508e60|01",
+          "time": "15:30 / (予定)",
+          "code": "2127",
+          "name": "日本Ｍ＆Ａセンターホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2428|15:30 / (予定)|3Q|0b3b621b14|01",
+          "time": "15:30 / (予定)",
+          "code": "2428",
+          "name": "ウェルネット",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2477|15:30 / (予定)|3Q|2b514a5332|01",
+          "time": "15:30 / (予定)",
+          "code": "2477",
+          "name": "手間いらず",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2492|15:30 / (予定)|1Q|bdd5eea8bf|01",
+          "time": "15:30 / (予定)",
+          "code": "2492",
+          "name": "インフォマート",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2689|15:30 / (予定)|3Q|6f8194db52|01",
+          "time": "15:30 / (予定)",
+          "code": "2689",
+          "name": "オルバヘルスケアホールディングス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2926|15:30 / (予定)|中間 / 決算|3cb0e76dd8|01",
+          "time": "15:30 / (予定)",
+          "code": "2926",
+          "name": "篠崎屋",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3092|15:30 / (予定)|本決算|eddbfc1ff9|01",
+          "time": "15:30 / (予定)",
+          "code": "3092",
+          "name": "ＺＯＺＯ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3137|15:30 / (予定)|本決算|31ba3049ea|01",
+          "time": "15:30 / (予定)",
+          "code": "3137",
+          "name": "ファンデリー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3482|15:30 / (予定)|1Q|2d61701557|01",
+          "time": "15:30 / (予定)",
+          "code": "3482",
+          "name": "ロードスターキャピタル",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3496|15:30 / (予定)|中間 / 決算|911827ba0a|01",
+          "time": "15:30 / (予定)",
+          "code": "3496",
+          "name": "アズーム",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3622|15:30 / (予定)|本決算|8d469878d2|01",
+          "time": "15:30 / (予定)",
+          "code": "3622",
+          "name": "ネットイヤーグループ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3836|15:30 / (予定)|3Q|73810654b6|01",
+          "time": "15:30 / (予定)",
+          "code": "3836",
+          "name": "アバントグループ",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3969|15:30 / (予定)|本決算|6933aa6801|01",
+          "time": "15:30 / (予定)",
+          "code": "3969",
+          "name": "エイトレッド",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4308|15:30 / (予定)|本決算|f9701e86b8|01",
+          "time": "15:30 / (予定)",
+          "code": "4308",
+          "name": "Ｊストリーム",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4373|15:30 / (予定)|本決算|1ac05fa78d|01",
+          "time": "15:30 / (予定)",
+          "code": "4373",
+          "name": "シンプレクス・ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4768|15:30 / (予定)|1Q|ad3111f830|01",
+          "time": "15:30 / (予定)",
+          "code": "4768",
+          "name": "大塚商会",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4812|15:30 / (予定)|1Q|e79becac13|01",
+          "time": "15:30 / (予定)",
+          "code": "4812",
+          "name": "電通総研",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5214|15:30 / (予定)|1Q|5c9d5b5313|01",
+          "time": "15:30 / (予定)",
+          "code": "5214",
+          "name": "日本電気硝子",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5280|15:30 / (予定)|本決算|1fb70bfda8|01",
+          "time": "15:30 / (予定)",
+          "code": "5280",
+          "name": "ヨシコン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5905|15:30 / (予定)|本決算|cf21b38af5|01",
+          "time": "15:30 / (予定)",
+          "code": "5905",
+          "name": "日本製罐",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5938|15:30 / (予定)|本決算|7c8207d7b7|01",
+          "time": "15:30 / (予定)",
+          "code": "5938",
+          "name": "ＬＩＸＩＬ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5959|15:30 / (予定)|1Q|8f36070f13|01",
+          "time": "15:30 / (予定)",
+          "code": "5959",
+          "name": "岡部",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6080|15:30 / (予定)|中間 / 決算|c4af8287d3|01",
+          "time": "15:30 / (予定)",
+          "code": "6080",
+          "name": "Ｍ＆Ａキャピタルパートナーズ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6135|15:30 / (予定)|本決算|d4c7b78f6d|01",
+          "time": "15:30 / (予定)",
+          "code": "6135",
+          "name": "牧野フライス製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6185|15:30 / (予定)|本決算|6a7d894f4b|01",
+          "time": "15:30 / (予定)",
+          "code": "6185",
+          "name": "ＳＭＮ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6189|15:30 / (予定)|中間 / 決算|1e100e0fd5|01",
+          "time": "15:30 / (予定)",
+          "code": "6189",
+          "name": "グローバルキッズＣＯＭＰＡＮＹ",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6196|15:30 / (予定)|中間 / 決算|94c074ecf3|01",
+          "time": "15:30 / (予定)",
+          "code": "6196",
+          "name": "ストライク",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6454|15:30 / (予定)|本決算|c470f2daae|01",
+          "time": "15:30 / (予定)",
+          "code": "6454",
+          "name": "マックス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6770|15:30 / (予定)|本決算|a7a0f70284|01",
+          "time": "15:30 / (予定)",
+          "code": "6770",
+          "name": "アルプスアルパイン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6870|15:30 / (予定)|1Q|561f463669|01",
+          "time": "15:30 / (予定)",
+          "code": "6870",
+          "name": "日本フェンオール",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6961|15:30 / (予定)|本決算|af14da9ac5|01",
+          "time": "15:30 / (予定)",
+          "code": "6961",
+          "name": "エンプラス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6981|15:30 / (予定)|本決算|8f5c571d70|01",
+          "time": "15:30 / (予定)",
+          "code": "6981",
+          "name": "村田製作所",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7172|15:30 / (予定)|1Q|c15b22e99d|01",
+          "time": "15:30 / (予定)",
+          "code": "7172",
+          "name": "ジャパンインベストメントアドバイザー",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7433|15:30 / (予定)|本決算|86355b7b56|01",
+          "time": "15:30 / (予定)",
+          "code": "7433",
+          "name": "伯東",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7510|15:30 / (予定)|本決算|3bdcb386c8|01",
+          "time": "15:30 / (予定)",
+          "code": "7510",
+          "name": "たけびし",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7625|15:30 / (予定)|1Q|d27ee79a64|01",
+          "time": "15:30 / (予定)",
+          "code": "7625",
+          "name": "グローバルダイニング",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7942|15:30 / (予定)|本決算|7ac95983a2|01",
+          "time": "15:30 / (予定)",
+          "code": "7942",
+          "name": "ＪＳＰ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8056|15:30 / (予定)|本決算|c90a731b7c|01",
+          "time": "15:30 / (予定)",
+          "code": "8056",
+          "name": "ＢＩＰＲＯＧＹ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8700|15:30 / (予定)|本決算|47d955fa08|01",
+          "time": "15:30 / (予定)",
+          "code": "8700",
+          "name": "丸八証券",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8704|15:30 / (予定)|本決算|cd9c6f7a44|01",
+          "time": "15:30 / (予定)",
+          "code": "8704",
+          "name": "トレイダーズホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9001|15:30 / (予定)|本決算|9f559ab84e|01",
+          "time": "15:30 / (予定)",
+          "code": "9001",
+          "name": "東武鉄道",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9020|15:30 / (予定)|本決算|e462bba612|01",
+          "time": "15:30 / (予定)",
+          "code": "9020",
+          "name": "東日本旅客鉄道",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9022|15:30 / (予定)|本決算|2197f21294|01",
+          "time": "15:30 / (予定)",
+          "code": "9022",
+          "name": "東海旅客鉄道",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9081|15:30 / (予定)|本決算|afadc41382|01",
+          "time": "15:30 / (予定)",
+          "code": "9081",
+          "name": "神奈川中央交通",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9202|15:30 / (予定)|本決算|b5cb59b95a|01",
+          "time": "15:30 / (予定)",
+          "code": "9202",
+          "name": "ＡＮＡホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9206|15:30 / (予定)|本決算|9dbf6d599f|01",
+          "time": "15:30 / (予定)",
+          "code": "9206",
+          "name": "スターフライヤー",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9219|15:30 / (予定)|3Q|455c76a3a0|01",
+          "time": "15:30 / (予定)",
+          "code": "9219",
+          "name": "ギックス",
+          "market": "TKY",
+          "announcement_type": "3Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9301|15:30 / (予定)|本決算|f1983e0c6d|01",
+          "time": "15:30 / (予定)",
+          "code": "9301",
+          "name": "三菱倉庫",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9508|15:30 / (予定)|本決算|941b68ea89|01",
+          "time": "15:30 / (予定)",
+          "code": "9508",
+          "name": "九州電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9509|15:30 / (予定)|本決算|09e156664f|01",
+          "time": "15:30 / (予定)",
+          "code": "9509",
+          "name": "北海道電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9552|15:30 / (予定)|中間 / 決算|03a130e15b|01",
+          "time": "15:30 / (予定)",
+          "code": "9552",
+          "name": "クオンツ総研ホールディングス",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9715|15:30 / (予定)|本決算|9d17ae0961|01",
+          "time": "15:30 / (予定)",
+          "code": "9715",
+          "name": "トランス・コスモス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9733|15:30 / (予定)|本決算|90b92e4595|01",
+          "time": "15:30 / (予定)",
+          "code": "9733",
+          "name": "ナガセ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9742|15:30 / (予定)|本決算|8366aa8f55|01",
+          "time": "15:30 / (予定)",
+          "code": "9742",
+          "name": "アイネス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2811|15:40 / (予定)|1Q|4f1ceec803|01",
+          "time": "15:40 / (予定)",
+          "code": "2811",
+          "name": "カゴメ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3839|15:40 / (予定)|本決算|4d6c144621|01",
+          "time": "15:40 / (予定)",
+          "code": "3839",
+          "name": "ＯＤＫソリューションズ",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|5334|15:40 / (予定)|本決算|3cb04af8d8|01",
+          "time": "15:40 / (予定)",
+          "code": "5334",
+          "name": "日本特殊陶業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|1950|16:00 / (予定)|本決算|e0a38b0e3b|01",
+          "time": "16:00 / (予定)",
+          "code": "1950",
+          "name": "日本電設工業",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2410|16:00 / (予定)|中間 / 決算|363036f04e|01",
+          "time": "16:00 / (予定)",
+          "code": "2410",
+          "name": "キャリアデザインセンター",
+          "market": "TKY",
+          "announcement_type": "中間 / 決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|3635|16:00 / (予定)|本決算|935744070d|01",
+          "time": "16:00 / (予定)",
+          "code": "3635",
+          "name": "コーエーテクモホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4762|16:00 / (予定)|本決算|28c897791a|01",
+          "time": "16:00 / (予定)",
+          "code": "4762",
+          "name": "エックスネット",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6268|16:00 / (予定)|1Q|dc20dafede|01",
+          "time": "16:00 / (予定)",
+          "code": "6268",
+          "name": "ナブテスコ",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6391|16:00 / (予定)|本決算|a2173e13e9|01",
+          "time": "16:00 / (予定)",
+          "code": "6391",
+          "name": "加地テック",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6817|16:00 / (予定)|1Q|35731c2192|01",
+          "time": "16:00 / (予定)",
+          "code": "6817",
+          "name": "スミダコーポレーション",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6932|16:00 / (予定)|本決算|f6513c6372|01",
+          "time": "16:00 / (予定)",
+          "code": "6932",
+          "name": "遠藤照明",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8035|16:00 / (予定)|本決算|0685d336ff|01",
+          "time": "16:00 / (予定)",
+          "code": "8035",
+          "name": "東京エレクトロン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8699|16:00 / (予定)|本決算|c305bdb0a5|01",
+          "time": "16:00 / (予定)",
+          "code": "8699",
+          "name": "ＨＳホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|8898|16:00 / (予定)|本決算|ca08ee722c|01",
+          "time": "16:00 / (予定)",
+          "code": "8898",
+          "name": "センチュリー２１・ジャパン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9362|16:00 / (予定)|本決算|dc7e8253ff|01",
+          "time": "16:00 / (予定)",
+          "code": "9362",
+          "name": "兵機海運",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|6111|16:20 / (予定)|本決算|22b0760e77|01",
+          "time": "16:20 / (予定)",
+          "code": "6111",
+          "name": "旭精機工業",
+          "market": "NGY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4417|16:25 / (予定)|本決算|490f50cea8|01",
+          "time": "16:25 / (予定)",
+          "code": "4417",
+          "name": "グローバルセキュリティエキスパート",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|1832|16:30 / (予定)|本決算|3bcc648c03|01",
+          "time": "16:30 / (予定)",
+          "code": "1832",
+          "name": "北海電工",
+          "market": "SPR",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|1939|16:30 / (予定)|本決算|0c46afab95|01",
+          "time": "16:30 / (予定)",
+          "code": "1939",
+          "name": "四電工",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4107|16:30 / (予定)|1Q|fac587b3f2|01",
+          "time": "16:30 / (予定)",
+          "code": "4107",
+          "name": "伊勢化学工業",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|4362|16:30 / (予定)|本決算|8842bef578|01",
+          "time": "16:30 / (予定)",
+          "code": "4362",
+          "name": "日本精化",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9307|16:30 / (予定)|本決算|0f288707d2|01",
+          "time": "16:30 / (予定)",
+          "code": "9307",
+          "name": "杉村倉庫",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9503|16:30 / (予定)|本決算|c95773b50f|01",
+          "time": "16:30 / (予定)",
+          "code": "9503",
+          "name": "関西電力",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9536|16:30 / (予定)|本決算|bfab635650|01",
+          "time": "16:30 / (予定)",
+          "code": "9536",
+          "name": "西部ガスホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|2491|17:00 / (予定)|1Q|b29016bf0a|01",
+          "time": "17:00 / (予定)",
+          "code": "2491",
+          "name": "バリューコマース",
+          "market": "TKY",
+          "announcement_type": "1Q",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|7774|17:00 / (予定)|本決算|15510952b6|01",
+          "time": "17:00 / (予定)",
+          "code": "7774",
+          "name": "ジャパン・ティッシュエンジニアリング",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9950|17:00 / (予定)|本決算|caeb3a0e28|01",
+          "time": "17:00 / (予定)",
+          "code": "9950",
+          "name": "ハチバン",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        },
+        {
+          "event_id": "2026-04-30|9501|18:00 / (予定)|本決算|2dac5be268|01",
+          "time": "18:00 / (予定)",
+          "code": "9501",
+          "name": "東京電力ホールディングス",
+          "market": "TKY",
+          "announcement_type": "本決算",
+          "publish_status": "予定",
+          "progress_status": "NODATA"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## 概要
- 決算カレンダーの 4月 month JSON を最新データへ更新

## 変更内容
- `app/tools/earnings-calendar/data/earnings_calendar_domestic_20260401_to_20260430.json` を market_info の最新出力で差し替え
- 各日付の `detail_status` と `items[]`、`event_id` を含む詳細データを反映

## 確認項目
- npm run lint
- npm run build

## 関連 Issue
- Related #106
- Related #119
