### PR TITLE
fix(top): モバイルのツールカード詳細が空だったバグを修正

### DIFF
--- a/app/ToolGridClient.tsx
+++ b/app/ToolGridClient.tsx
@@ -59,8 +59,9 @@ export default function ToolGridClient({ tools, styles }: Props) {
                   {t.statusLabel ?? "準備中"}
                 </div>
 
-                <details style={styles.details} className="toolDetails">
-                  {/* ここ、元ファイルのまま移植（今は “.” になってるので本体があるなら貼る） */}
+                <details style={styles.details} className=”toolDetails”>
+                  <summary style={styles.summary}>詳細を見る</summary>
+                  <div style={styles.detailText}>{t.detail}</div>
                 </details>
 
                 <div className="tooltip" style={styles.tooltip}>
@@ -91,11 +92,12 @@ export default function ToolGridClient({ tools, styles }: Props) {
                     詳細を見る
                   </div>
 
-                  <details style={styles.details} className="toolDetails">
-                    {/* ここ、元ファイルのまま移植（今は “.” になってるので本体があるなら貼る） */}
+                  <details style={styles.details} className=”toolDetails”>
+                    <summary style={styles.summary}>詳細を見る</summary>
+                    <div style={styles.detailText}>{t.detail}</div>
                   </details>
 
-                  <div className="tooltip" style={styles.tooltip}>
+                  <div className=”tooltip” style={styles.tooltip}>
                     {t.detail}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- `ToolGridClient.tsx` の `details` 要素の中身がリファクタリング時に移植されておらず、モバイルで「詳細を見る」をタップしても何も表示されなかった
- 有効カード・disabled カードの両方に `<summary>詳細を見る</summary>` と `<div>{t.detail}</div>` を追加

## Test plan
- [ ] モバイル（またはDevToolsでタッチエミュレート）でTOP画面を開く
- [ ] ツールカードの「詳細を見る」をタップして説明文が展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)