### PR TITLE
fix(top): ToolGridClientのスマートクォートをASCIIクォートに修正

### DIFF
--- a/app/ToolGridClient.tsx
+++ b/app/ToolGridClient.tsx
@@ -59,7 +59,7 @@ export default function ToolGridClient({ tools, styles }: Props) {
                   {t.statusLabel ?? "準備中"}
                 </div>
 
-                <details style={styles.details} className=”toolDetails”>
+                <details style={styles.details} className="toolDetails">
                   <summary style={styles.summary}>詳細を見る</summary>
                   <div style={styles.detailText}>{t.detail}</div>
                 </details>
@@ -92,12 +92,12 @@ export default function ToolGridClient({ tools, styles }: Props) {
                     詳細を見る
                   </div>
 
-                  <details style={styles.details} className=”toolDetails”>
+                  <details style={styles.details} className="toolDetails">
                     <summary style={styles.summary}>詳細を見る</summary>
                     <div style={styles.detailText}>{t.detail}</div>
                   </details>
 
-                  <div className=”tooltip” style={styles.tooltip}>
+                  <div className="tooltip" style={styles.tooltip}>
                     {t.detail}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- 前回のPR (#128) でEditツールが `className` 属性にスマートクォート（`"` `"`）を混入させ、ビルドエラーが発生していた
- `Unexpected character '"'` エラーの原因箇所を特定し、全3箇所をASCIIダブルクォートに置換

## Test plan
- [ ] ビルドエラーが解消されることを確認
- [ ] モバイルで「詳細を見る」が正常に展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)