### PR TITLE
design: globals.css にCSS変数を定義しlayout.tsxでimport

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,43 @@
+/* ============================================================
+   Design tokens — Pattern A: Light Blue
+   パターンを変更する場合は docs/design-color-palette.md を参照
+   ============================================================ */
+:root {
+  /* 背景 */
+  --color-bg:            #f8fafc;
+  --color-bg-card:       #ffffff;
+  --color-bg-input:      #f1f5f9;
+
+  /* テキスト */
+  --color-text:          #0f172a;
+  --color-text-sub:      #475569;
+  --color-text-muted:    #94a3b8;
+
+  /* ボーダー */
+  --color-border:        #e2e8f0;
+  --color-border-strong: #cbd5e1;
+
+  /* アクセント */
+  --color-accent:        #2554ff;
+  --color-accent-sub:    #eef2ff;
+  --color-accent-hover:  #1d44d8;
+
+  /* セマンティック */
+  --color-error:         #dc2626;
+  --color-success:       #16a34a;
+  --color-warning:       #d97706;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, -apple-system, "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@
 import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import Header from "@/components/Header";
+import "./globals.css";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 const SITE_URL =
@@ -66,7 +67,7 @@ export default function RootLayout({
         ) : null}
       </head>
 
-      <body style={{ margin: 0 }}>
+      <body>
         <Header />
         {children}
       </body>


### PR DESCRIPTION
Closes #131

## Summary
- `app/globals.css` を新規作成。Pattern A（ライトブルー）のカラートークンを14変数定義
- `app/layout.tsx` で `globals.css` をimport
- `<body style={{ margin: 0 }}>` を `<body>` に変更（margin は globals.css で管理）

## 定義した変数
`--color-bg` / `--color-bg-card` / `--color-bg-input`
`--color-text` / `--color-text-sub` / `--color-text-muted`
`--color-border` / `--color-border-strong`
`--color-accent` / `--color-accent-sub` / `--color-accent-hover`
`--color-error` / `--color-success` / `--color-warning`

## Test plan
- [ ] `npm run build` が通ること
- [ ] 各ページの背景が `#f8fafc`（薄グレー）になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)