### PR TITLE
design: TOP・合計計算・文字数カウントのカラーをCSS変数に対応

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -38,6 +38,4 @@ body {
   margin: 0;
   background: var(--color-bg);
   color: var(--color-text);
-  font-family: system-ui, -apple-system, "Helvetica Neue", sans-serif;
-  -webkit-font-smoothing: antialiased;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,12 +118,12 @@ const styles: Record<string, React.CSSProperties> = {
     marginTop: 24,
     marginBottom: 12,
     padding: "10px 14px",
-    background: "rgba(0,0,0,0.02)",
-    border: "1px solid rgba(0,0,0,0.06)",
+    background: "var(--color-bg-input)",
+    border: "1px solid var(--color-border)",
     borderRadius: 14,
     fontSize: 13,
     fontWeight: 800,
-    color: "rgba(0,0,0,0.70)",
+    color: "var(--color-text-sub)",
     display: "block",
     width: "100%",
     position: "relative",
@@ -134,8 +134,8 @@ const styles: Record<string, React.CSSProperties> = {
     letterSpacing: 0.2,
     padding: "6px 10px",
     borderRadius: 999,
-    border: "1px solid rgba(0,0,0,0.12)",
-    background: "rgba(0,0,0,0.02)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-input)",
     opacity: 0.85,
     marginBottom: 10,
   },
@@ -153,7 +153,7 @@ const styles: Record<string, React.CSSProperties> = {
   note: {
     marginTop: 10,
     fontSize: 12,
-    opacity: 0.7,
+    color: "var(--color-text-muted)",
   },
 
   section: {
@@ -162,7 +162,7 @@ const styles: Record<string, React.CSSProperties> = {
   sectionTitle: {
     fontSize: 14,
     fontWeight: 700,
-    opacity: 0.85,
+    color: "var(--color-text-sub)",
     marginBottom: 12,
   },
 
@@ -193,11 +193,11 @@ const styles: Record<string, React.CSSProperties> = {
     height: "100%",
     borderRadius: 18,
     padding: 14,
-    border: "3px solid rgba(59,130,246,0.15)",
-    background: "rgba(255,255,255,0.9)",
+    border: "3px solid var(--color-accent-sub)",
+    background: "var(--color-bg-card)",
     overflow: "hidden",
     transition: "transform 0.15s, box-shadow 0.15s",
-    boxShadow: "0 10px 30px rgba(0,0,0,0.10)", // 常時影を残すならここ
+    boxShadow: "0 10px 30px rgba(0,0,0,0.08)",
   },
 
   cardTop: {
@@ -215,8 +215,8 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 14,
     display: "grid",
     placeItems: "center",
-    background: "rgba(0,0,0,0.04)",
-    border: "1px solid rgba(0,0,0,0.06)",
+    background: "var(--color-bg-input)",
+    border: "1px solid var(--color-border)",
   },
 
   arrow: {
@@ -225,8 +225,8 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 14,
     display: "grid",
     placeItems: "center",
-    border: "1px solid rgba(0,0,0,0.08)",
-    background: "rgba(255,255,255,0.9)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-card)",
     fontSize: 18,
     opacity: 0.7,
   },
@@ -240,7 +240,7 @@ const styles: Record<string, React.CSSProperties> = {
 
   cardShort: {
     fontSize: 13,
-    opacity: 0.75,
+    color: "var(--color-text-sub)",
     marginTop: 6,
   },
 
@@ -252,8 +252,8 @@ const styles: Record<string, React.CSSProperties> = {
     opacity: 0.9,
     padding: "8px 10px",
     borderRadius: 12,
-    border: "1px solid rgba(0,0,0,0.10)",
-    background: "rgba(255,255,255,0.92)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-card)",
     display: "inline-flex",
     alignItems: "center",
     gap: 6,
@@ -273,18 +273,18 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12,
     padding: "8px 10px",
     borderRadius: 12,
-    border: "1px solid rgba(0,0,0,0.08)",
-    background: "rgba(255,255,255,0.92)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-card)",
   },
   detailText: {
     marginTop: 8,
     fontSize: 12,
-    opacity: 0.85,
+    color: "var(--color-text-sub)",
     lineHeight: 1.5,
     padding: "10px 12px",
     borderRadius: 12,
-    border: "1px solid rgba(0,0,0,0.08)",
-    background: "rgba(255,255,255,0.92)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-card)",
   },
 
   // デスクトップホバー表示用 tooltip
@@ -295,7 +295,7 @@ const styles: Record<string, React.CSSProperties> = {
     bottom: 14,
     padding: "10px 12px",
     borderRadius: 14,
-    border: "1px solid rgba(0,0,0,0.10)",
+    border: "1px solid var(--color-border-strong)",
     background: "rgba(20,20,20,0.92)",
     color: "#fff",
     fontSize: 12,
@@ -317,12 +317,12 @@ const styles: Record<string, React.CSSProperties> = {
   bottomTitle: {
     fontSize: 14,
     fontWeight: 800,
-    opacity: 0.85,
+    color: "var(--color-text-sub)",
   },
   bottomSub: {
     marginTop: 4,
     fontSize: 12,
-    opacity: 0.65,
+    color: "var(--color-text-muted)",
   },
   bottomGrid: {
     display: "grid",
@@ -332,8 +332,8 @@ const styles: Record<string, React.CSSProperties> = {
   bottomPanel: {
     padding: "14px 14px",
     borderRadius: 16,
-    border: "1px solid rgba(0,0,0,0.08)",
-    background: "rgba(255,255,255,0.75)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-card)",
     boxShadow: "0 10px 26px rgba(0,0,0,0.06)",
   },
   bottomPanelPlain: {
@@ -348,10 +348,10 @@ const styles: Record<string, React.CSSProperties> = {
     width: 44,
     height: 44,
     borderRadius: 14,
-    border: "1px solid rgba(0,0,0,0.12)",
-    background: "rgba(255,255,255,0.9)",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg-card)",
     textDecoration: "none",
-    color: "rgba(0,0,0,0.80)",
+    color: "var(--color-text)",
     fontSize: 18,
     fontWeight: 900,
   },
@@ -361,7 +361,7 @@ const styles: Record<string, React.CSSProperties> = {
 
   hr: {
     height: 1,
-    background: "rgba(0,0,0,0.10)",
+    background: "var(--color-border)",
     width: "100%",
     marginBottom: 24,
   },

--- a/app/tools/charcount/ToolClient.tsx
+++ b/app/tools/charcount/ToolClient.tsx
@@ -175,8 +175,8 @@ export default function ToolClient() {
           gap: 8,
           padding: "4px 10px",
           borderRadius: 999,
-          background: "#f4f7fb",
-          color: "#345",
+          background: "var(--color-accent-sub)",
+          color: "var(--color-accent)",
           fontSize: 12,
           fontWeight: 700,
         }}
@@ -201,8 +201,9 @@ export default function ToolClient() {
             width: "100%",
             padding: 12,
             borderRadius: 12,
-            border: "1px solid #ccc",
+            border: "1px solid var(--color-border)",
             fontSize: 16,
+            background: "var(--color-bg-input)",
           }}
         />
         <div style={{ marginTop: 8, fontSize: 12, opacity: 0.75 }}>
@@ -214,8 +215,9 @@ export default function ToolClient() {
         style={{
           marginTop: 16,
           padding: 14,
-          border: "1px solid #111",
+          border: "1px solid var(--color-border-strong)",
           borderRadius: 14,
+          background: "var(--color-bg-card)",
         }}
       >
         <div
@@ -228,47 +230,47 @@ export default function ToolClient() {
           <div
             style={{
               padding: 12,
-              border: "1px solid #111",
+              border: "1px solid var(--color-accent)",
               borderRadius: 12,
-              background: "#fafafa",
+              background: "var(--color-accent-sub)",
             }}
           >
-            <div style={{ fontSize: 13, opacity: 0.8 }}>X推定文字数</div>
+            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>X推定文字数</div>
             <div style={{ fontSize: 32, fontWeight: 700 }}>{stats.xEstimated}</div>
-            <div style={{ fontSize: 12, opacity: 0.7 }}>
+            <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
               URL=23 / 絵文字=2 / CJK=2 の推定
             </div>
           </div>
 
           <div
-            style={{ padding: 12, border: "1px solid #ddd", borderRadius: 12 }}
+            style={{ padding: 12, border: "1px solid var(--color-border)", borderRadius: 12 }}
           >
-            <div style={{ fontSize: 13, opacity: 0.8 }}>X推定 140字 残り</div>
+            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>X推定 140字 残り</div>
             <div
               style={{
                 fontSize: 32,
                 fontWeight: 700,
-                color: stats.x140Remaining < 0 ? "#b91c1c" : "inherit",
+                color: stats.x140Remaining < 0 ? "var(--color-error)" : "inherit",
               }}
             >
               {stats.x140Remaining}
             </div>
-            <div style={{ fontSize: 12, opacity: 0.7 }}>
+            <div style={{ fontSize: 12, color: stats.x140Remaining < 0 ? "var(--color-error)" : "var(--color-text-muted)" }}>
               {stats.x140Remaining < 0 ? "オーバーしています" : "OK"}
             </div>
           </div>
 
           <div
-            style={{ padding: 12, border: "1px solid #ddd", borderRadius: 12 }}
+            style={{ padding: 12, border: "1px solid var(--color-border)", borderRadius: 12 }}
           >
-            <div style={{ fontSize: 13, opacity: 0.8 }}>文字数（そのまま）</div>
+            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>文字数（そのまま）</div>
             <div style={{ fontSize: 32, fontWeight: 700 }}>{stats.raw}</div>
           </div>
 
           <div
-            style={{ padding: 12, border: "1px solid #ddd", borderRadius: 12 }}
+            style={{ padding: 12, border: "1px solid var(--color-border)", borderRadius: 12 }}
           >
-            <div style={{ fontSize: 13, opacity: 0.8 }}>スペース/改行除外</div>
+            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>スペース/改行除外</div>
             <div style={{ fontSize: 32, fontWeight: 700 }}>{stats.noSpace}</div>
           </div>
         </div>
@@ -280,8 +282,10 @@ export default function ToolClient() {
             onClick={copyText}
             style={{
               padding: "10px 12px",
-              border: "1px solid #111",
+              border: "1px solid var(--color-accent)",
               borderRadius: 10,
+              color: "var(--color-accent)",
+              background: "var(--color-accent-sub)",
             }}
           >
             本文をコピー
@@ -290,8 +294,10 @@ export default function ToolClient() {
             onClick={clearAll}
             style={{
               padding: "10px 12px",
-              border: "1px solid #999",
+              border: "1px solid var(--color-border-strong)",
               borderRadius: 10,
+              color: "var(--color-text-sub)",
+              background: "var(--color-bg-input)",
             }}
           >
             クリア

--- a/app/tools/total/ToolClient.tsx
+++ b/app/tools/total/ToolClient.tsx
@@ -74,8 +74,9 @@ export default function ToolClient() {
             display: "inline-block",
             padding: "8px 10px",
             borderRadius: 10,
-            border: "1px solid #999",
+            border: "1px solid var(--color-border-strong)",
             textDecoration: "none",
+            color: "var(--color-text-sub)",
           }}
         >
           ← ツール一覧へ
@@ -96,8 +97,9 @@ export default function ToolClient() {
             width: "100%",
             padding: 12,
             borderRadius: 12,
-            border: "1px solid #ccc",
+            border: "1px solid var(--color-border)",
             fontSize: 16,
+            background: "var(--color-bg-input)",
           }}
         />
         <div style={{ marginTop: 8, fontSize: 12, opacity: 0.75 }}>
@@ -109,11 +111,12 @@ export default function ToolClient() {
         style={{
           marginTop: 16,
           padding: 14,
-          border: "1px solid #111",
+          border: "1px solid var(--color-border-strong)",
           borderRadius: 14,
+          background: "var(--color-bg-card)",
         }}
       >
-        <div style={{ fontSize: 13, opacity: 0.8 }}>合計</div>
+        <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>合計</div>
         <div style={{ fontSize: 32, fontWeight: 700 }}>
           {total.toLocaleString()}
         </div>
@@ -125,8 +128,10 @@ export default function ToolClient() {
             onClick={copyTotal}
             style={{
               padding: "10px 12px",
-              border: "1px solid #111",
+              border: "1px solid var(--color-accent)",
               borderRadius: 10,
+              color: "var(--color-accent)",
+              background: "var(--color-accent-sub)",
             }}
           >
             合計をコピー
@@ -135,8 +140,10 @@ export default function ToolClient() {
             onClick={clearAll}
             style={{
               padding: "10px 12px",
-              border: "1px solid #999",
+              border: "1px solid var(--color-border-strong)",
               borderRadius: 10,
+              color: "var(--color-text-sub)",
+              background: "var(--color-bg-input)",
             }}
           >
             クリア


### PR DESCRIPTION
Closes #132
Closes #133
Closes #134

## Summary
- app/globals.css のフォント指定を削除（ブラウザデフォルトに戻す）
- app/page.tsx — ハードコードカラーを CSS変数に置き換え
- app/tools/total/ToolClient.tsx — 同上、ボタンにアクセントカラー適用
- app/tools/charcount/ToolClient.tsx — 同上、エラー色を --color-error に統一

## Test plan
- [ ] ビルドエラーなし
- [ ] TOP・合計計算・文字数カウント各ページでカラーが適用されていること
- [ ] 文字数オーバー時に赤色が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)