### PR TITLE
feat(charcount): X投稿文字数カウントをデスクトップ2カラムにリデザイン

### DIFF
--- a/app/tools/charcount/ToolClient.tsx
+++ b/app/tools/charcount/ToolClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import ShareButtons from "@/components/ShareButtonsSuspended";
 import MonetizeBar from "@/components/MonetizeBar";
 import { track } from "@/lib/analytics";
@@ -18,12 +19,10 @@ const graphemeSegmenter =
     ? new Intl.Segmenter("ja", { granularity: "grapheme" })
     : null;
 
-// 絵文字などでlengthズレが出ないように Array.from を使う
 function countChars(text: string): number {
   return Array.from(text).length;
 }
 
-// スペース/改行/タブ + 全角スペースを除外
 function stripSpacesAndNewlines(text: string): string {
   return text.replace(/[\s\u3000]/g, "");
 }
@@ -70,22 +69,18 @@ function splitUrlAndTrailingPunctuation(value: string): {
 
 function countPlainTextForX(text: string): number {
   let total = 0;
-
   for (const grapheme of splitGraphemes(text)) {
     if (!grapheme) continue;
-
     if (isEmojiLikeGrapheme(grapheme)) {
       total += 2;
       continue;
     }
-
     for (const char of grapheme) {
       const codePoint = char.codePointAt(0);
       if (codePoint == null) continue;
       total += isXWeightOne(codePoint) ? 1 : 2;
     }
   }
-
   return total;
 }
 
@@ -93,26 +88,21 @@ function countForX(text: string): number {
   const normalized = normalizeForX(text);
   let total = 0;
   let lastIndex = 0;
-
   URL_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
-
   while ((match = URL_RE.exec(normalized)) !== null) {
     const start = match.index;
     const end = start + match[0].length;
     const { urlPart, trailingPart } = splitUrlAndTrailingPunctuation(match[0]);
-
     total += countPlainTextForX(normalized.slice(lastIndex, start));
     total += X_URL_LENGTH;
     total += countPlainTextForX(trailingPart);
     lastIndex = end;
-
     if (!urlPart) {
       total -= X_URL_LENGTH;
       total += countPlainTextForX(match[0]);
     }
   }
-
   total += countPlainTextForX(normalized.slice(lastIndex));
   return total;
 }
@@ -133,7 +123,6 @@ export default function ToolClient() {
     const xEstimated = countForX(text);
     const x140Remaining = 140 - xEstimated;
     const lines = text.length ? text.split(/\r?\n/).length : 0;
-
     return { raw, noSpace, xEstimated, x140Remaining, lines };
   }, [text]);
 
@@ -166,155 +155,328 @@ export default function ToolClient() {
     }
   };
 
+  const isEmpty = text.trim().length === 0;
+  const isOver = stats.x140Remaining < 0;
+  // 0〜140の進捗バー用 (超過時は100%)
+  const progressPct = isEmpty ? 0 : Math.min((stats.xEstimated / 140) * 100, 100);
+
   return (
-    <main style={{ maxWidth: 760, margin: "0 auto", padding: 16 }}>
-      <div
-        style={{
+    <main style={{ maxWidth: 820, margin: "0 auto", padding: "16px 16px 48px" }}>
+
+      {/* ナビ */}
+      <div style={{ marginBottom: 20 }}>
+        <Link
+          href="/"
+          onClick={() => track("nav_clicked", { to: "home_from_tool" })}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "6px 12px",
+            borderRadius: 999,
+            border: "1px solid var(--color-border-strong)",
+            textDecoration: "none",
+            color: "var(--color-text-sub)",
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+        >
+          ← ツール一覧
+        </Link>
+      </div>
+
+      {/* ヒーロー */}
+      <div style={{ marginBottom: 24 }}>
+        <div style={{
           display: "inline-flex",
           alignItems: "center",
-          gap: 8,
+          gap: 6,
           padding: "4px 10px",
           borderRadius: 999,
           background: "var(--color-accent-sub)",
           color: "var(--color-accent)",
-          fontSize: 12,
-          fontWeight: 700,
-        }}
-      >
-        X投稿向け
+          fontSize: 11,
+          fontWeight: 800,
+          marginBottom: 10,
+        }}>
+          𝕏 X投稿向け
+        </div>
+        <h1 style={{ fontSize: 26, fontWeight: 800, margin: "0 0 6px", letterSpacing: -0.4 }}>
+          X投稿文字数カウント
+        </h1>
+        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--color-text-sub)" }}>
+          140字に収めたい投稿文を貼るだけで確認できます。URL・絵文字も正確に推定。
+        </p>
       </div>
 
-      <h1 style={{ fontSize: 24, margin: "10px 0 6px" }}>X投稿文字数カウント</h1>
-      <p style={{ marginTop: 0, fontSize: 13, lineHeight: 1.5, opacity: 0.72 }}>
-        140字に収めたい投稿文を、そのまま貼るだけで確認できます。
-      </p>
+      {/* 2カラムレイアウト */}
+      <div className="charcount-layout">
 
-      <div style={{ marginTop: 14 }}>
-        <textarea
-          value={text}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={
-            "例:\n日経平均は反発。半導体株が支えた一方で、内需は弱め。\n#日経平均 #日本株"
-          }
-          rows={10}
-          style={{
-            width: "100%",
-            padding: 12,
-            borderRadius: 12,
+        {/* 左: 入力エリア */}
+        <div className="charcount-input-col">
+          <div style={{
+            background: "var(--color-bg-card)",
+            borderRadius: 18,
             border: "1px solid var(--color-border)",
-            fontSize: 16,
-            background: "var(--color-bg-input)",
-          }}
-        />
-        <div style={{ marginTop: 8, fontSize: 12, opacity: 0.75 }}>
-          行数：{stats.lines}
-        </div>
-      </div>
-
-      <div
-        style={{
-          marginTop: 16,
-          padding: 14,
-          border: "1px solid var(--color-border-strong)",
-          borderRadius: 14,
-          background: "var(--color-bg-card)",
-        }}
-      >
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-            gap: 12,
-          }}
-        >
-          <div
-            style={{
-              padding: 12,
-              border: "1px solid var(--color-accent)",
-              borderRadius: 12,
-              background: "var(--color-accent-sub)",
-            }}
-          >
-            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>X推定文字数</div>
-            <div style={{ fontSize: 32, fontWeight: 700 }}>{stats.xEstimated}</div>
-            <div style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
-              URL=23 / 絵文字=2 / CJK=2 の推定
+            boxShadow: "0 8px 24px rgba(15,23,42,0.05)",
+            overflow: "hidden",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+          }}>
+            <div style={{
+              padding: "12px 16px 8px",
+              borderBottom: "1px solid var(--color-border)",
+              fontSize: 11,
+              fontWeight: 800,
+              color: "var(--color-text-muted)",
+              letterSpacing: 0.4,
+            }}>
+              INPUT
             </div>
-          </div>
-
-          <div
-            style={{ padding: 12, border: "1px solid var(--color-border)", borderRadius: 12 }}
-          >
-            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>X推定 140字 残り</div>
-            <div
+            <textarea
+              value={text}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder={"例:\n日経平均は反発。半導体株が支えた一方で、内需は弱め。\n#日経平均 #日本株"}
               style={{
-                fontSize: 32,
-                fontWeight: 700,
-                color: stats.x140Remaining < 0 ? "var(--color-error)" : "inherit",
+                flex: 1,
+                display: "block",
+                width: "100%",
+                minHeight: 200,
+                padding: "14px 16px",
+                border: "none",
+                outline: "none",
+                resize: "none",
+                fontSize: 15,
+                lineHeight: 1.8,
+                background: "transparent",
+                color: "var(--color-text)",
+                boxSizing: "border-box",
               }}
-            >
-              {stats.x140Remaining}
+            />
+            <div style={{
+              padding: "8px 16px 12px",
+              borderTop: "1px solid var(--color-border)",
+              fontSize: 12,
+              color: "var(--color-text-muted)",
+            }}>
+              {stats.lines > 0 ? `${stats.lines} 行` : "テキストを入力してください"}
             </div>
-            <div style={{ fontSize: 12, color: stats.x140Remaining < 0 ? "var(--color-error)" : "var(--color-text-muted)" }}>
-              {stats.x140Remaining < 0 ? "オーバーしています" : "OK"}
-            </div>
-          </div>
-
-          <div
-            style={{ padding: 12, border: "1px solid var(--color-border)", borderRadius: 12 }}
-          >
-            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>文字数（そのまま）</div>
-            <div style={{ fontSize: 32, fontWeight: 700 }}>{stats.raw}</div>
-          </div>
-
-          <div
-            style={{ padding: 12, border: "1px solid var(--color-border)", borderRadius: 12 }}
-          >
-            <div style={{ fontSize: 13, color: "var(--color-text-sub)" }}>スペース/改行除外</div>
-            <div style={{ fontSize: 32, fontWeight: 700 }}>{stats.noSpace}</div>
           </div>
         </div>
 
-        <div
-          style={{ display: "flex", gap: 10, flexWrap: "wrap", marginTop: 12 }}
-        >
-          <button
-            onClick={copyText}
-            style={{
-              padding: "10px 12px",
-              border: "1px solid var(--color-accent)",
-              borderRadius: 10,
-              color: "var(--color-accent)",
-              background: "var(--color-accent-sub)",
-            }}
-          >
-            本文をコピー
-          </button>
-          <button
-            onClick={clearAll}
-            style={{
-              padding: "10px 12px",
-              border: "1px solid var(--color-border-strong)",
-              borderRadius: 10,
-              color: "var(--color-text-sub)",
-              background: "var(--color-bg-input)",
-            }}
-          >
-            クリア
-          </button>
-        </div>
+        {/* 右: 結果エリア */}
+        <div className="charcount-result-col">
+          <div style={{
+            background: "var(--color-bg-card)",
+            borderRadius: 18,
+            border: "1px solid var(--color-border)",
+            boxShadow: "0 8px 24px rgba(15,23,42,0.05)",
+            padding: "20px 20px 16px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+          }}>
 
-        <div style={{ marginTop: 12, fontSize: 12, opacity: 0.75 }}>
-          ※X推定は weighted character counting を参考にした近似です。返信先頭の自動メンションや添付メディア 0カウントは未反映です。
+            {/* X推定文字数 */}
+            <div>
+              <div style={{
+                fontSize: 11,
+                fontWeight: 800,
+                color: "var(--color-text-muted)",
+                letterSpacing: 0.4,
+                marginBottom: 4,
+              }}>
+                X推定文字数
+              </div>
+              <div style={{
+                fontSize: 44,
+                fontWeight: 800,
+                letterSpacing: -1.5,
+                lineHeight: 1,
+                fontFamily: "ui-monospace, monospace",
+                color: isEmpty ? "var(--color-text-muted)" : isOver ? "var(--color-error)" : "var(--color-text)",
+                transition: "color 0.2s",
+              }}>
+                {isEmpty ? "—" : stats.xEstimated}
+              </div>
+              <div style={{ fontSize: 12, color: "var(--color-text-muted)", marginTop: 2 }}>
+                URL=23 / 絵文字=2 / CJK=2 の推定
+              </div>
+            </div>
+
+            {/* プログレスバー */}
+            <div>
+              <div style={{
+                height: 6,
+                borderRadius: 999,
+                background: "var(--color-bg-input)",
+                overflow: "hidden",
+              }}>
+                <div style={{
+                  height: "100%",
+                  width: `${progressPct}%`,
+                  borderRadius: 999,
+                  background: isOver
+                    ? "var(--color-error)"
+                    : progressPct > 80
+                    ? "var(--color-warning)"
+                    : "linear-gradient(90deg, var(--color-accent) 0%, #60a5fa 100%)",
+                  transition: "width 0.2s, background 0.2s",
+                }} />
+              </div>
+            </div>
+
+            {/* 140字残り */}
+            <div style={{
+              padding: "10px 14px",
+              borderRadius: 12,
+              background: isOver ? "#fef2f2" : isEmpty ? "var(--color-bg-input)" : "var(--color-accent-sub)",
+              border: `1px solid ${isOver ? "#fecaca" : isEmpty ? "var(--color-border)" : "#c7d2fe"}`,
+              transition: "background 0.2s, border-color 0.2s",
+            }}>
+              <div style={{
+                fontSize: 11,
+                fontWeight: 700,
+                color: isOver ? "var(--color-error)" : "var(--color-text-muted)",
+                marginBottom: 2,
+              }}>
+                140字 残り
+              </div>
+              <div style={{
+                fontSize: 28,
+                fontWeight: 800,
+                letterSpacing: -0.5,
+                fontFamily: "ui-monospace, monospace",
+                color: isOver ? "var(--color-error)" : isEmpty ? "var(--color-text-muted)" : "var(--color-accent)",
+              }}>
+                {isEmpty ? "—" : stats.x140Remaining}
+              </div>
+              {!isEmpty && (
+                <div style={{ fontSize: 11, color: isOver ? "var(--color-error)" : "var(--color-accent)", fontWeight: 600, marginTop: 2 }}>
+                  {isOver ? `${Math.abs(stats.x140Remaining)}字オーバー` : "OK"}
+                </div>
+              )}
+            </div>
+
+            {/* アクセントライン */}
+            <div style={{
+              height: 2,
+              borderRadius: 999,
+              background: "linear-gradient(90deg, var(--color-accent) 0%, var(--color-accent-sub) 100%)",
+              opacity: isEmpty ? 0.2 : 1,
+              transition: "opacity 0.2s",
+            }} />
+
+            {/* サブ統計 */}
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              <div style={{
+                padding: "10px 12px",
+                borderRadius: 12,
+                background: "var(--color-bg-input)",
+                border: "1px solid var(--color-border)",
+              }}>
+                <div style={{ fontSize: 10, fontWeight: 700, color: "var(--color-text-muted)", letterSpacing: 0.3 }}>
+                  文字数
+                </div>
+                <div style={{ fontSize: 22, fontWeight: 800, fontFamily: "ui-monospace, monospace", marginTop: 2 }}>
+                  {isEmpty ? "—" : stats.raw}
+                </div>
+              </div>
+              <div style={{
+                padding: "10px 12px",
+                borderRadius: 12,
+                background: "var(--color-bg-input)",
+                border: "1px solid var(--color-border)",
+              }}>
+                <div style={{ fontSize: 10, fontWeight: 700, color: "var(--color-text-muted)", letterSpacing: 0.3, lineHeight: 1.3 }}>
+                  スペース除外
+                </div>
+                <div style={{ fontSize: 22, fontWeight: 800, fontFamily: "ui-monospace, monospace", marginTop: 2 }}>
+                  {isEmpty ? "—" : stats.noSpace}
+                </div>
+              </div>
+            </div>
+
+            {/* ボタン */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <button
+                onClick={copyText}
+                disabled={isEmpty}
+                style={{
+                  padding: "11px 16px",
+                  border: "none",
+                  borderRadius: 12,
+                  background: isEmpty ? "var(--color-bg-input)" : "var(--color-accent)",
+                  color: isEmpty ? "var(--color-text-muted)" : "#fff",
+                  fontSize: 14,
+                  fontWeight: 700,
+                  cursor: isEmpty ? "default" : "pointer",
+                  transition: "background 0.15s",
+                  textAlign: "center",
+                }}
+              >
+                本文をコピー
+              </button>
+              <button
+                onClick={clearAll}
+                disabled={isEmpty}
+                style={{
+                  padding: "11px 16px",
+                  border: "1px solid var(--color-border-strong)",
+                  borderRadius: 12,
+                  background: "var(--color-bg-input)",
+                  color: isEmpty ? "var(--color-text-muted)" : "var(--color-text-sub)",
+                  fontSize: 14,
+                  fontWeight: 600,
+                  cursor: isEmpty ? "default" : "pointer",
+                  transition: "background 0.15s",
+                  textAlign: "center",
+                }}
+              >
+                クリア
+              </button>
+            </div>
+
+            {/* 注記 */}
+            <div style={{
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+              lineHeight: 1.6,
+              paddingTop: 4,
+              borderTop: "1px solid var(--color-border)",
+            }}>
+              ※返信先頭の自動メンションや添付メディア 0カウントは未反映です。
+            </div>
+          </div>
         </div>
       </div>
 
-      <ShareButtons text="X投稿文字数カウント：140字に収まるかを確認できる" />
-      <MonetizeBar />
+      <div style={{ marginTop: 32 }}>
+        <ShareButtons text="X投稿文字数カウント：140字に収まるかを確認できる" />
+        <MonetizeBar />
+      </div>
 
-      <div style={{ marginTop: 24, fontSize: 12, opacity: 0.75 }}>
+      <div style={{ marginTop: 16, fontSize: 12, color: "var(--color-text-muted)" }}>
         ※入力はこの端末（ブラウザ）にのみ保存されます（localStorage）。
       </div>
+
+      <style>{`
+        .charcount-layout {
+          display: grid;
+          grid-template-columns: 1fr 260px;
+          gap: 16px;
+          align-items: start;
+        }
+        @media (max-width: 600px) {
+          .charcount-layout {
+            grid-template-columns: 1fr;
+          }
+          .charcount-result-col {
+            order: -1;
+          }
+        }
+      `}</style>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- 左: テキストエリア / 右: 結果パネルの2カラムレイアウト（デスクトップ）
- X推定文字数を44pxで大視認性ヒーロー表示
- 140字残りはカラーフィードバック付き（OK=アクセント青 / 超過=赤）
- グラデーション進捗バー（80%超でオレンジ、超過で赤）
- サブ統計（文字数・スペース除外）を2グリッドで整理
- 数字はすべてモノスペースフォント
- 空のとき「—」表示・ボタンはdisabled
- モバイルは縦積み・結果パネルが上に来るので先に確認可能

## Test plan
- [ ] テキスト入力で各統計が正しく更新される
- [ ] 140字超過時に赤色フィードバックが表示される
- [ ] URLを含むテキストで推定が23字として計算される
- [ ] コピー・クリアボタンが正常動作する
- [ ] モバイル幅（600px以下）で縦積みレイアウトになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)