### PR TITLE
fix(yutai-expiry): remove mobile control overlap

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -1076,12 +1076,6 @@
     padding-right: 14px;
   }
 
-  .compactRow {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 8px;
-  }
-
   .mobileControlRow {
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: stretch;


### PR DESCRIPTION
## 概要
株主優待リストのモバイル操作エリアで、重なっていたコントロールを解消しました。

## 変更内容
- 600px以下で `.compactRow` が再表示されるCSSを削除
- モバイルでPC用コントロールが重なってタップを邪魔する状態を解消

## 確認項目
- npm run lint
- スマホ幅で検索/並び替え/表示切替が押せること

## 関連 Issue
- なし
