### PR TITLE
fix(yutai-expiry): restore mobile controls hit area

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -715,7 +715,9 @@ export default function ToolClient() {
           </div>
 
           <div className={styles.mobileUtilityRow}>
-            <label className={`${styles.controlShell} ${styles.mobileToggle}`}>
+            <label
+              className={`${styles.controlShell} ${styles.toggle} ${styles.mobileToggle}`}
+            >
               <input
                 type="checkbox"
                 checked={showUsed}


### PR DESCRIPTION
概要

- 優待リストのスマホ表示で、検索欄とカード/リスト切替が操作できない不具合を修正しました。

変更内容

- モバイル用の「使用済含む」トグルに `toggle` クラスを追加
- 透明なチェックボックス入力のヒットエリアが広がりすぎて、上部コントロールのタップを奪っていた状態を解消

確認項目

- `npm run lint`
- スマホ表示で検索欄にフォーカスできることを確認
- スマホ表示でカード/リスト切替が反応することを確認

関連 Issue

- なし
