### PR TITLE
style(yutai-memo): redesign UI with modern indigo-based color palette

### DIFF
--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -340,6 +340,7 @@
   padding: 1px 6px;
   border-radius: 5px;
   white-space: nowrap;
+  width: fit-content;
 }
 
 .cardSide {


### PR DESCRIPTION
## Summary

- Primary カラーを黒 → インディゴ (`#4338ca`) に刷新し、全体のトーンを統一
- 取得済みトグルにエメラルドグリーンを採用し、状態の視認性を向上
- 当月バッジにパルスアニメーション追加、通常月バッジはインディゴ淡色に
- 戦略バッジはバイオレット、1株放置トグルはスカイブルーで役割別に色分け
- カードにホバー時の左アクセントバー＋浮き上がりエフェクトを追加
- モーダルオーバーレイに `backdrop-filter: blur` で磨りガラス効果
- inputフォーカスリング、ボタンホバーなど細部の操作感を全体的にポリッシュ

## Test plan

- [ ] 一覧画面でカードのホバーエフェクト（左バー・浮き上がり）が表示される
- [ ] 当月の権利月バッジがアンバー色でパルスする
- [ ] 取得済みトグルがエメラルドグリーンで表示される
- [ ] 削除確認・タグ管理モーダルの背景がブラーされる
- [ ] モバイル幅 (≤640px) でレイアウト崩れがない
- [ ] 編集フォームの月選択・タグチップのON/OFF表示が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)