### PR TITLE
feat(stock-ranking): support external data loader

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,5 +6,5 @@ NEXT_PUBLIC_SITE_URL=
 
 # 株価ランキングの外部データ配信URL（任意）
 # 例: https://pub-b1f1de37018549c8a5ae3e6f9a7a1c6c.r2.dev
-# 内部で /stock-ranking を付けて読むため、通常は prefix なしの base URL を指定
+# prefix なしの public base URL を推奨。JSON 配信ディレクトリ URL を直接指定してもよい
 STOCK_RANKING_DATA_BASE_URL=

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm run dev
 - `STOCK_RANKING_DATA_BASE_URL`
   - `stock-ranking` が外部配信の `manifest.json` / 日次JSON を読むときの基準URL
   - 通常は `https://<public-base-url>` のように prefix なしで指定する
-  - loader 側で `/stock-ranking` を補うため、`.../stock-ranking` を入れても二重にはならない
+  - `.../stock-ranking` のような JSON 配信ディレクトリ URL を直接指定しても動く
   - 未設定時は repo 内の `app/tools/stock-ranking/data/` を読む
   - 参照: `app/tools/stock-ranking/data-loader.ts`
 

--- a/app/tools/stock-ranking/data-loader.ts
+++ b/app/tools/stock-ranking/data-loader.ts
@@ -6,13 +6,13 @@ function getDataDir() {
   return path.join(process.cwd(), "app/tools/stock-ranking/data");
 }
 
-function getExternalDataRootUrl() {
+function getExternalBaseUrl() {
   const baseUrl = process.env.STOCK_RANKING_DATA_BASE_URL?.trim().replace(/\/+$/, "") ?? "";
   if (!baseUrl) {
-    return "";
+    return [];
   }
 
-  return baseUrl.endsWith("/stock-ranking") ? baseUrl : `${baseUrl}/stock-ranking`;
+  return baseUrl.endsWith("/stock-ranking") ? [baseUrl] : [baseUrl, `${baseUrl}/stock-ranking`];
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -52,30 +52,38 @@ async function loadLocalRankingDayData(dateStr: string): Promise<RankingDayData 
 }
 
 export async function loadRankingManifest(): Promise<RankingManifest> {
-  const baseUrl = getExternalDataRootUrl();
+  const baseUrls = getExternalBaseUrl();
 
-  if (!baseUrl) {
+  if (baseUrls.length === 0) {
     return loadLocalRankingManifest();
   }
 
-  try {
-    return await fetchJson<RankingManifest>(`${baseUrl}/manifest.json`);
-  } catch {
-    return loadLocalRankingManifest();
+  for (const baseUrl of baseUrls) {
+    try {
+      return await fetchJson<RankingManifest>(`${baseUrl}/manifest.json`);
+    } catch {
+      continue;
+    }
   }
+
+  return loadLocalRankingManifest();
 }
 
 export async function loadRankingDayData(dateStr: string): Promise<RankingDayData | null> {
   const fileKey = dateStr.replace(/-/g, "");
-  const baseUrl = getExternalDataRootUrl();
+  const baseUrls = getExternalBaseUrl();
 
-  if (!baseUrl) {
+  if (baseUrls.length === 0) {
     return loadLocalRankingDayData(dateStr);
   }
 
-  try {
-    return await fetchJson<RankingDayData>(`${baseUrl}/${fileKey}.json`);
-  } catch {
-    return loadLocalRankingDayData(dateStr);
+  for (const baseUrl of baseUrls) {
+    try {
+      return await fetchJson<RankingDayData>(`${baseUrl}/${fileKey}.json`);
+    } catch {
+      continue;
+    }
   }
+
+  return loadLocalRankingDayData(dateStr);
 }

--- a/docs/decision-log/2026-03-26-stock-ranking-data-update-ops.md
+++ b/docs/decision-log/2026-03-26-stock-ranking-data-update-ops.md
@@ -54,6 +54,7 @@
 ### 2. `mini-tools` 側でやること
 
 - `STOCK_RANKING_DATA_BASE_URL` で公開 base URL を指定する
+- 必要なら `.../stock-ranking` のような JSON 配信ディレクトリ URL を直接指定してもよい
 - loader が外部の `stock-ranking/manifest.json` と `stock-ranking/YYYYMMDD.json` を読む
 - 取得失敗時だけ [`app/tools/stock-ranking/data/`](../../../app/tools/stock-ranking/data/) を fallback として使う
 - `stock-ranking` UI が崩れないことを確認する
@@ -81,6 +82,7 @@
 1. `market_info` 側で当日分のランキングデータを更新する。
 2. `market_info` 側で `manifest.json` と `YYYYMMDD.json` が公開 URL に upload されていることを確認する。
 3. `mini-tools` 側で `STOCK_RANKING_DATA_BASE_URL` を公開 base URL に設定する。
+   - 既存の配信先が `manifest.json` を直下に持つなら、その data-root URL をそのまま設定してよい。
 4. `mini-tools` で `/tools/stock-ranking` を開き、公開 `manifest.json` の `latest` と `dates` が反映されていることを確認する。
 5. `mini-tools` で以下を確認する。
    - `npm run lint`

--- a/docs/stock-ranking-external-data-plan.md
+++ b/docs/stock-ranking-external-data-plan.md
@@ -151,7 +151,8 @@ mini-tools
 `mini-tools` 側でやること:
 
 - [`app/tools/stock-ranking/data-loader.ts`](../app/tools/stock-ranking/data-loader.ts) をローカルファイル読み込みから外部JSON取得へ切り替える
-- `STOCK_RANKING_DATA_BASE_URL` には公開 base URL を設定し、loader 側で `/stock-ranking` prefix を補う
+- `STOCK_RANKING_DATA_BASE_URL` には公開 base URL を設定する
+- loader は `https://<public-base-url>` と `.../stock-ranking` の両方を受けられるようにする
 - 可能なら `fetch` をサーバー側で行う
 - 失敗時の挙動を決める
   - manifest 取得失敗時はエラー表示
@@ -226,7 +227,7 @@ mini-tools
 運用メモ:
 
 - 2026-03-28 時点では `STOCK_RANKING_DATA_BASE_URL=https://<public-base-url>` を推奨する
-- `.../stock-ranking` 付きで設定しても loader 側で二重 prefix にはしない
+- 既存の配信先が data-root URL をそのまま公開している場合は `.../stock-ranking` を直接指定してよい
 
 ## 保留事項
 


### PR DESCRIPTION
## 概要

`stock-ranking` が `market_info` 側で公開した外部 JSON を読めるようにし、R2 の公開 base URL を設定する運用に切り替えます。

## 変更内容

- `app/tools/stock-ranking/data-loader.ts` で `STOCK_RANKING_DATA_BASE_URL` から外部 `manifest.json` / 日次 JSON を読むよう調整
- 環境変数が prefix なしの base URL でも動くように `/stock-ranking` を内部で補完
- 外部取得失敗時は既存のローカル JSON を fallback として利用
- README / env example / decision log / 移行計画を外部公開運用前提に更新

## 確認項目

- `npm run lint`
- `npm run build`
- build 時に外部 R2 の `manifest.json` と `20260327.json` を fetch できることを確認

## 関連 Issue

- なし
