### PR TITLE
chore(gitignore): ignore tsbuildinfo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ public/workbox-*.js
 
 # production build
 dist/
+*.tsbuildinfo
 
 # env files
 .env


### PR DESCRIPTION
## 概要

TypeScript のビルド生成物 `*.tsbuildinfo` を Git 管理対象から外します。

## 変更内容

- `.gitignore` に `*.tsbuildinfo` を追加

## 確認項目

- `npm run lint`

## 関連 Issue

- なし
