### PR TITLE
fix(stock-ranking): remove data source attribution from disclaimer

### DIFF
--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -364,7 +364,7 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
 
       {/* データ注記 */}
       <p style={{ marginTop: 16, fontSize: 11, color: "var(--color-text-muted)", lineHeight: 1.6 }}>
-        ※ データは内藤証券のランキング情報をもとに加工・整形したものです。投資判断の参考情報としてご利用ください。
+        ※ 投資判断の参考情報としてご利用ください。
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- ランキングページのデータ注記から出典（内藤証券）の記載を削除
- 免責文言（投資判断の参考情報としてご利用ください）は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)