### PR TITLE
fix(nikkei-contribution): pick first visible trading day

### DIFF
--- a/app/tools/nikkei-contribution/page.tsx
+++ b/app/tools/nikkei-contribution/page.tsx
@@ -14,9 +14,28 @@ export const metadata: Metadata = {
   },
 };
 
+function getDayOfWeek(dateStr: string) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d).getDay();
+}
+
+function isWeekendDate(dateStr: string) {
+  const day = getDayOfWeek(dateStr);
+  return day === 0 || day === 6;
+}
+
+function isLikelyMarketClosed(dayData: NikkeiContributionPageData["initialDayData"]) {
+  if (!dayData || dayData.records.length === 0) {
+    return false;
+  }
+
+  return !dayData.records.some(
+    (record) => record.chg !== 0 || record.chg_pct !== 0 || record.contribution !== 0,
+  );
+}
+
 async function loadData(): Promise<NikkeiContributionPageData> {
   const manifest = await loadContributionManifest();
-  const initialDayData = manifest.latest_date ? await loadContributionDayData(manifest.latest_date) : null;
   let holidays: JpxMarketClosedResponse | null = null;
 
   try {
@@ -30,7 +49,37 @@ async function loadData(): Promise<NikkeiContributionPageData> {
     holidays = null;
   }
 
-  return { manifest, initialDayData, holidays };
+  const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
+  const visibleDates = manifest.dates.filter((date) => {
+    if (holidayMap.get(date)?.market_closed) {
+      return false;
+    }
+
+    return !isWeekendDate(date);
+  });
+
+  let initialDayData = null;
+  const excludedLeadingDates = new Set<string>();
+
+  for (const date of visibleDates) {
+    const dayData = await loadContributionDayData(date);
+    if (!dayData || isLikelyMarketClosed(dayData)) {
+      excludedLeadingDates.add(date);
+      continue;
+    }
+
+    initialDayData = dayData;
+    break;
+  }
+
+  const filteredDates = visibleDates.filter((date) => !excludedLeadingDates.has(date));
+  const filteredManifest = {
+    ...manifest,
+    dates: filteredDates,
+    latest_date: filteredDates[0] ?? null,
+  };
+
+  return { manifest: filteredManifest, initialDayData, holidays };
 }
 
 export default async function Page() {


### PR DESCRIPTION
## 概要

日経225寄与度ツールの初期表示日を、実際に表示対象となる営業日に合わせます。

## 変更内容

- JPX休場日と土日を除外した候補日をサーバー側で算出
- 先頭側に誤取得日やゼロ変化日が混ざっていても、最初の表示日を有効な営業日に寄せる
- その結果に合わせて `manifest.latest_date` 相当の初期表示対象も補正

## 確認項目

- `npm run lint`

## 関連 Issue

- なし
