### PR TITLE
feat: data-loader を market-info-api 経由に移行

### DIFF
--- a/app/tools/nikkei-contribution/data-loader.ts
+++ b/app/tools/nikkei-contribution/data-loader.ts
@@ -2,9 +2,6 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { NikkeiContributionDayData, NikkeiContributionManifest } from "./types";
 
-const DEFAULT_EXTERNAL_BASE_URL =
-  "https://pub-b1f1de37018549c8a5ae3e6f9a7a1c6c.r2.dev/nikkei-contribution";
-
 const EMPTY_MANIFEST: NikkeiContributionManifest = {
   dates: [],
   latest_date: null,
@@ -14,16 +11,8 @@ function getDataDir() {
   return path.join(process.cwd(), "app/tools/nikkei-contribution/data");
 }
 
-function getExternalBaseUrl() {
-  const baseUrl = (
-    process.env.NIKKEI_CONTRIBUTION_DATA_BASE_URL?.trim().replace(/\/+$/, "") ??
-    DEFAULT_EXTERNAL_BASE_URL
-  ).trim();
-  if (!baseUrl) {
-    return [];
-  }
-
-  return baseUrl.endsWith("/nikkei-contribution") ? [baseUrl] : [baseUrl, `${baseUrl}/nikkei-contribution`];
+function getApiBaseUrl() {
+  return process.env.MARKET_INFO_API_BASE_URL?.trim().replace(/\/+$/, "") ?? "";
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -65,21 +54,17 @@ async function loadLocalDayData(dateStr: string): Promise<NikkeiContributionDayD
 }
 
 export async function loadContributionManifest(): Promise<NikkeiContributionManifest> {
-  const baseUrls = getExternalBaseUrl();
+  const apiBase = getApiBaseUrl();
 
-  if (baseUrls.length === 0) {
+  if (!apiBase) {
     return loadLocalManifest();
   }
 
-  for (const baseUrl of baseUrls) {
-    try {
-      return await fetchJson<NikkeiContributionManifest>(`${baseUrl}/nikkei_contribution_manifest.json`);
-    } catch {
-      continue;
-    }
+  try {
+    return await fetchJson<NikkeiContributionManifest>(`${apiBase}/nikkei/manifest`);
+  } catch {
+    return loadLocalManifest();
   }
-
-  return loadLocalManifest();
 }
 
 export async function loadContributionDayData(dateStr: string): Promise<NikkeiContributionDayData | null> {
@@ -87,19 +72,15 @@ export async function loadContributionDayData(dateStr: string): Promise<NikkeiCo
     return null;
   }
 
-  const baseUrls = getExternalBaseUrl();
+  const apiBase = getApiBaseUrl();
 
-  if (baseUrls.length === 0) {
+  if (!apiBase) {
     return loadLocalDayData(dateStr);
   }
 
-  for (const baseUrl of baseUrls) {
-    try {
-      return await fetchJson<NikkeiContributionDayData>(`${baseUrl}/nikkei_contribution_${dateStr}.json`);
-    } catch {
-      continue;
-    }
+  try {
+    return await fetchJson<NikkeiContributionDayData>(`${apiBase}/nikkei/${dateStr}`);
+  } catch {
+    return loadLocalDayData(dateStr);
   }
-
-  return loadLocalDayData(dateStr);
 }

--- a/app/tools/stock-ranking/data-loader.ts
+++ b/app/tools/stock-ranking/data-loader.ts
@@ -6,13 +6,8 @@ function getDataDir() {
   return path.join(process.cwd(), "app/tools/stock-ranking/data");
 }
 
-function getExternalBaseUrl() {
-  const baseUrl = process.env.STOCK_RANKING_DATA_BASE_URL?.trim().replace(/\/+$/, "") ?? "";
-  if (!baseUrl) {
-    return [];
-  }
-
-  return baseUrl.endsWith("/stock-ranking") ? [baseUrl] : [baseUrl, `${baseUrl}/stock-ranking`];
+function getApiBaseUrl() {
+  return process.env.MARKET_INFO_API_BASE_URL?.trim().replace(/\/+$/, "") ?? "";
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -52,38 +47,29 @@ async function loadLocalRankingDayData(dateStr: string): Promise<RankingDayData 
 }
 
 export async function loadRankingManifest(): Promise<RankingManifest> {
-  const baseUrls = getExternalBaseUrl();
+  const apiBase = getApiBaseUrl();
 
-  if (baseUrls.length === 0) {
+  if (!apiBase) {
     return loadLocalRankingManifest();
   }
 
-  for (const baseUrl of baseUrls) {
-    try {
-      return await fetchJson<RankingManifest>(`${baseUrl}/manifest.json`);
-    } catch {
-      continue;
-    }
+  try {
+    return await fetchJson<RankingManifest>(`${apiBase}/ranking/manifest`);
+  } catch {
+    return loadLocalRankingManifest();
   }
-
-  return loadLocalRankingManifest();
 }
 
 export async function loadRankingDayData(dateStr: string): Promise<RankingDayData | null> {
-  const fileKey = dateStr.replace(/-/g, "");
-  const baseUrls = getExternalBaseUrl();
+  const apiBase = getApiBaseUrl();
 
-  if (baseUrls.length === 0) {
+  if (!apiBase) {
     return loadLocalRankingDayData(dateStr);
   }
 
-  for (const baseUrl of baseUrls) {
-    try {
-      return await fetchJson<RankingDayData>(`${baseUrl}/${fileKey}.json`);
-    } catch {
-      continue;
-    }
+  try {
+    return await fetchJson<RankingDayData>(`${apiBase}/ranking/${dateStr}`);
+  } catch {
+    return loadLocalRankingDayData(dateStr);
   }
-
-  return loadLocalRankingDayData(dateStr);
 }

--- a/app/tools/yutai-candidates/data-loader.ts
+++ b/app/tools/yutai-candidates/data-loader.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import type {
   MonthlyYutaiManifest,
   MonthlyYutaiMonthData,
-  MonthlyYutaiMonthManifest,
   MonthlyYutaiPageData,
 } from "./types";
 
@@ -13,21 +12,8 @@ function getDataDir() {
   return path.join(process.cwd(), "app/tools/yutai-candidates/data");
 }
 
-function getExternalManifestUrls() {
-  const configuredUrl = process.env.MONTHLY_YUTAI_DATA_BASE_URL?.trim() ?? "";
-  if (!configuredUrl) {
-    return [];
-  }
-
-  if (configuredUrl.endsWith(".json")) {
-    return [configuredUrl];
-  }
-
-  return [`${configuredUrl.replace(/\/+$/, "")}/manifest.json`];
-}
-
-function buildExternalMonthDataUrl(manifestUrl: string, monthPath: string) {
-  return new URL(monthPath, manifestUrl).toString();
+function getApiBaseUrl() {
+  return process.env.MARKET_INFO_API_BASE_URL?.trim().replace(/\/+$/, "") ?? "";
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -59,111 +45,55 @@ async function loadLocalManifest(): Promise<MonthlyYutaiManifest | null> {
   }
 }
 
-async function loadLocalMonthData(relativePath: string): Promise<MonthlyYutaiMonthData | null> {
+async function loadLocalMonthData(yearMonth: string): Promise<MonthlyYutaiMonthData | null> {
   try {
-    const raw = await readFile(path.join(getDataDir(), relativePath), "utf-8");
+    const raw = await readFile(path.join(getDataDir(), `${yearMonth}.json`), "utf-8");
     return JSON.parse(raw) as MonthlyYutaiMonthData;
   } catch {
     return null;
   }
 }
 
-function resolveSelectedMonthEntry(
-  manifest: MonthlyYutaiManifest | null,
-  requestedMonthId?: string,
-): MonthlyYutaiMonthManifest | null {
-  if (!manifest?.months?.length) return null;
-
-  const sorted = [...manifest.months].sort((a, b) =>
-    `${a.year}-${`${a.month}`.padStart(2, "0")}`.localeCompare(
-      `${b.year}-${`${b.month}`.padStart(2, "0")}`,
-    ),
-  );
-  const latestEntry = sorted.find((entry) => entry.path === manifest.latest_path);
-  const latestMonthEntry = sorted.find(
-    (entry) => `${entry.year}-${`${entry.month}`.padStart(2, "0")}` === manifest.latest_month,
-  );
-  const requestedEntry = requestedMonthId
-    ? sorted.find(
-        (entry) => `${entry.year}-${`${entry.month}`.padStart(2, "0")}` === requestedMonthId,
-      )
-    : null;
-  return (
-    requestedEntry ??
-    latestEntry ??
-    latestMonthEntry ??
-    sorted.at(-1) ??
-    null
-  );
-}
-
 export async function loadMonthlyYutaiManifest(): Promise<MonthlyYutaiManifest | null> {
-  const manifestUrls = getExternalManifestUrls();
+  const apiBase = getApiBaseUrl();
 
-  if (manifestUrls.length === 0) {
+  if (!apiBase) {
     return loadLocalManifest();
   }
 
-  for (const manifestUrl of manifestUrls) {
-    try {
-      return await fetchJson<MonthlyYutaiManifest>(manifestUrl);
-    } catch {
-      continue;
-    }
+  try {
+    return await fetchJson<MonthlyYutaiManifest>(`${apiBase}/yutai/manifest`);
+  } catch {
+    return loadLocalManifest();
   }
-
-  return loadLocalManifest();
 }
 
-export async function loadMonthlyYutaiMonthData(
-  monthEntry: MonthlyYutaiMonthManifest,
-  manifestUrl?: string | null,
-): Promise<MonthlyYutaiMonthData | null> {
-  const manifestUrls = manifestUrl ? [manifestUrl] : getExternalManifestUrls();
+export async function loadMonthlyYutaiMonthData(yearMonth: string): Promise<MonthlyYutaiMonthData | null> {
+  const apiBase = getApiBaseUrl();
 
-  if (manifestUrls.length === 0) {
-    return loadLocalMonthData(monthEntry.path);
+  if (!apiBase) {
+    return loadLocalMonthData(yearMonth);
   }
 
-  for (const currentManifestUrl of manifestUrls) {
-    try {
-      return await fetchJson<MonthlyYutaiMonthData>(buildExternalMonthDataUrl(currentManifestUrl, monthEntry.path));
-    } catch {
-      continue;
-    }
+  try {
+    return await fetchJson<MonthlyYutaiMonthData>(`${apiBase}/yutai/monthly/${yearMonth}`);
+  } catch {
+    return loadLocalMonthData(yearMonth);
   }
-
-  return loadLocalMonthData(monthEntry.path);
 }
 
 export async function loadMonthlyYutaiPageData(requestedMonthId?: string): Promise<MonthlyYutaiPageData> {
-  const manifestUrls = getExternalManifestUrls();
-  let manifest: MonthlyYutaiManifest | null = null;
-  let resolvedManifestUrl: string | null = null;
+  const manifest = await loadMonthlyYutaiManifest();
 
-  if (manifestUrls.length > 0) {
-    for (const manifestUrl of manifestUrls) {
-      try {
-        manifest = await fetchJson<MonthlyYutaiManifest>(manifestUrl);
-        resolvedManifestUrl = manifestUrl;
-        break;
-      } catch {
-        continue;
-      }
-    }
-  }
+  const availableMonths =
+    manifest?.months?.map((m) => `${m.year}-${String(m.month).padStart(2, "0")}`) ?? [];
 
-  if (!manifest) {
-    manifest = await loadLocalManifest();
-  }
+  const selectedMonthId =
+    requestedMonthId && availableMonths.includes(requestedMonthId)
+      ? requestedMonthId
+      : manifest?.latest_month ?? DEFAULT_MONTH_ID;
 
-  const selectedMonthEntry = resolveSelectedMonthEntry(manifest, requestedMonthId);
-  const selectedMonthId = selectedMonthEntry
-    ? `${selectedMonthEntry.year}-${`${selectedMonthEntry.month}`.padStart(2, "0")}`
-    : manifest?.latest_month ?? DEFAULT_MONTH_ID;
-  const monthData = selectedMonthEntry
-    ? await loadMonthlyYutaiMonthData(selectedMonthEntry, resolvedManifestUrl)
-    : null;
+  const monthData = await loadMonthlyYutaiMonthData(selectedMonthId);
 
   return {
     manifest,


### PR DESCRIPTION
## Summary

- R2 直接アクセスを廃止し、market-info-api（Cloud Run）経由でデータを取得するよう 3 ファイルを変更
- 環境変数を `STOCK_RANKING_DATA_BASE_URL` / `NIKKEI_CONTRIBUTION_DATA_BASE_URL` / `MONTHLY_YUTAI_DATA_BASE_URL` から `MARKET_INFO_API_BASE_URL` に統合
- `nikkei-contribution/data-loader.ts` のハードコード R2 URL（`DEFAULT_EXTERNAL_BASE_URL`）を削除
- `yutai-candidates/data-loader.ts` の manifest 経由パス解決ロジックを `/yutai/monthly/{year_month}` 直接取得に簡略化（`resolveSelectedMonthEntry` / `buildExternalMonthDataUrl` を削除）

## Changed files

- `app/tools/stock-ranking/data-loader.ts` — `/ranking/manifest`, `/ranking/{date}` を使用
- `app/tools/nikkei-contribution/data-loader.ts` — `/nikkei/manifest`, `/nikkei/{date}` を使用
- `app/tools/yutai-candidates/data-loader.ts` — `/yutai/manifest`, `/yutai/monthly/{year_month}` を使用

## Test plan

- [ ] `MARKET_INFO_API_BASE_URL` が設定されている状態でローカル起動し、各ツールが正常にデータ表示されることを確認
- [ ] Vercel Preview デプロイで各ツールが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)