### PR TITLE
feat(nikkei): テーブルヘッダークリックでソート、ローディングUI改善

### DIFF
--- a/app/tools/nikkei-contribution/ToolClient.module.css
+++ b/app/tools/nikkei-contribution/ToolClient.module.css
@@ -75,6 +75,28 @@
   display: none;
 }
 
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(37, 84, 255, 0.15);
+  border-top-color: #2554ff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+.spinnerSmall {
+  width: 16px;
+  height: 16px;
+  border-width: 2px;
+}
+
 @media (min-width: 641px) {
   .summaryGrid,
   .topweightGrid {

--- a/app/tools/nikkei-contribution/ToolClient.tsx
+++ b/app/tools/nikkei-contribution/ToolClient.tsx
@@ -724,7 +724,7 @@ function RecordsTable({ records }: { records: NikkeiContributionRecord[] }) {
 
                   if (column.key === "chg_pct") {
                     return (
-                      <td key={`${record.code}-${column.key}`} style={{ textAlign: "right", whiteSpace: "nowrap" }}>
+                      <td key={`${record.code}-${column.key}`} style={{ textAlign: "right", whiteSpace: "nowrap", color: getBarTone(record.chg_pct).text }}>
                         <span className={styles.desktopOnly}>{fmtPct(record.chg_pct)}</span>
                         <span className={styles.mobileOnly}>{`${sign(record.chg_pct)}${record.chg_pct.toFixed(1)}%`}</span>
                       </td>
@@ -733,7 +733,7 @@ function RecordsTable({ records }: { records: NikkeiContributionRecord[] }) {
 
                   if (column.key === "chg") {
                     return (
-                      <td key={`${record.code}-${column.key}`} className={styles.recordsMobileHidden} style={{ textAlign: "right", whiteSpace: "nowrap" }}>
+                      <td key={`${record.code}-${column.key}`} className={styles.recordsMobileHidden} style={{ textAlign: "right", whiteSpace: "nowrap", color: getBarTone(record.chg).text }}>
                         {sign(record.chg)}{fmtNumber(record.chg)}
                       </td>
                     );
@@ -988,7 +988,9 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
               />
             </svg>
           </button>
-          {dayData?.market_status ? (
+          {isLoading ? (
+            <div className={`${styles.spinner} ${styles.spinnerSmall}`} aria-label="読み込み中" />
+          ) : dayData?.market_status ? (
             <span
               style={{
                 padding: "4px 10px",
@@ -1078,7 +1080,10 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
       {loadError ? (
         <div style={{ padding: "20px 0", color: "var(--color-text-muted)" }}>{loadError}</div>
       ) : isLoading && !dayData ? (
-        <div style={{ padding: "20px 0", color: "var(--color-text-muted)" }}>読み込み中...</div>
+        <div style={{ padding: "56px 0", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+          <div className={styles.spinner} />
+          <span style={{ color: "var(--color-text-muted)", fontSize: 13 }}>読み込み中...</span>
+        </div>
       ) : !dayData ? (
         <div
           style={{


### PR DESCRIPTION
## Summary

**ソート改善**
- 全銘柄テーブルの専用ソートボタン（寄与度順・ウェイト順・騰落率順）を削除
- 全列ヘッダーをクリックでソート切り替え可能に変更
- 銘柄列: 名前順 / コード順をトグル（▲緑）
- 数値列: 降順▼赤 / 昇順▲緑をトグル（符号考慮、絶対値ソート廃止）
- 騰落率・前日比のセル値に正負カラー（緑/赤）を追加

**ローディングUI改善**
- 初回ロード時: 中央揃えのスピナー（ぐるぐる）＋テキスト表示
- 日付切り替え時: 日付セレクタ横に小スピナーを表示（ロード完了後はステータスバッジに戻る）

## Test plan

- [ ] 各列ヘッダーをクリックしてソートが切り替わることを確認
- [ ] 同じ列を再クリックで昇順/降順がトグルすることを確認
- [ ] 銘柄列: 2回クリックで名前順→コード順に切り替わることを確認
- [ ] アクティブな列が青ハイライト＋▼▲インジケーター表示されることを確認
- [ ] 騰落率・前日比の正値が緑、負値が赤で表示されることを確認
- [ ] 初回ロード時にスピナーが表示されることを確認
- [ ] 日付切り替え時に横スピナーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)