### PR TITLE
fix(yutai-candidates): 当月/権利付き最終日後なら翌月をデフォルト表示、TOP説明文から開発用語を除去

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,14 +54,14 @@ const TOOLS: ToolItem[] = [
   {
     title: "優待候補一覧",
     short: "月別の候補を探す",
-    detail: "market_info の月別優待データを一覧で見て、気になる銘柄だけを優待メモへ追加。",
+    detail: "月別の優待銘柄候補を一覧で確認。気になる銘柄をピックして優待メモへ追加できます。",
     href: "/tools/yutai-candidates",
     icon: "🔎",
   },
   {
     title: "決算カレンダー",
     short: "日本株の決算予定を確認",
-    detail: "日本株の決算予定をカレンダーで確認。market_info のデータをもとに表示。",
+    detail: "日本株の決算予定をカレンダーで確認。日付ごとに銘柄と決算種別を一覧表示。",
     href: "/tools/earnings-calendar",
     icon: "🗓️",
   },

--- a/app/tools/yutai-candidates/data-loader.ts
+++ b/app/tools/yutai-candidates/data-loader.ts
@@ -6,7 +6,93 @@ import type {
   MonthlyYutaiPageData,
 } from "./types";
 
-const DEFAULT_MONTH_ID = "2026-04";
+/** JST の今日の年・月・日を返す */
+function getJstToday(): { year: number; month: number; day: number } {
+  const fmt = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = fmt.formatToParts(new Date());
+  return {
+    year: Number(parts.find((p) => p.type === "year")?.value ?? "0"),
+    month: Number(parts.find((p) => p.type === "month")?.value ?? "0"),
+    day: Number(parts.find((p) => p.type === "day")?.value ?? "0"),
+  };
+}
+
+/**
+ * 月末近く（月の後半）に位置する TSE 非営業日。
+ * これ以外の祝日は月末最終営業日の計算に影響しないため対象外。
+ *
+ * - 4/29 昭和の日（固定）: 翌月切替判定に影響する唯一の固定祝日
+ * - 4/30 振替: 4/29 が日曜の年（2029 年）
+ * - 12/31 大納会: TSE 年末休場（固定）
+ *
+ * 2030 年以降に利用する場合は末尾に追記すること。
+ */
+const JP_LATE_MONTH_NON_TRADING = new Set([
+  "2025-04-29",
+  "2026-04-29",
+  "2027-04-29",
+  "2028-04-29",
+  "2029-04-29",
+  "2029-04-30", // 4/29 が日曜のため振替
+  "2025-12-31",
+  "2026-12-31",
+  "2027-12-31",
+  "2028-12-31",
+  "2029-12-31",
+]);
+
+function isBusinessDay(year: number, month: number, day: number): boolean {
+  const dow = new Date(year, month - 1, day).getDay();
+  if (dow === 0 || dow === 6) return false;
+  const key = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  return !JP_LATE_MONTH_NON_TRADING.has(key);
+}
+
+/**
+ * 権利付き最終日（日）を返す。
+ * = 月末最終営業日 - 2 営業日
+ */
+function getKenriLastDay(year: number, month: number): number {
+  const lastCalendarDay = new Date(year, month, 0).getDate();
+  // 月末から遡って最終営業日を探す
+  let day = lastCalendarDay;
+  while (!isBusinessDay(year, month, day)) day--;
+  // そこからさらに 2 営業日戻る
+  let remaining = 2;
+  while (remaining > 0) {
+    day--;
+    if (isBusinessDay(year, month, day)) remaining--;
+  }
+  return day;
+}
+
+/**
+ * 当月 or 権利付き最終日後なら翌月を優先し、availableMonths にある最初の候補を返す。
+ * どちらもなければ fallback を返す。
+ */
+function getSmartDefaultMonthId(availableMonths: string[], fallback: string): string {
+  const { year, month, day } = getJstToday();
+  const kenriLastDay = getKenriLastDay(year, month);
+  const isPastKenri = day > kenriLastDay;
+
+  const candidates: string[] = [];
+  if (isPastKenri) {
+    const nextYear = month === 12 ? year + 1 : year;
+    const nextMonth = month === 12 ? 1 : month + 1;
+    candidates.push(`${nextYear}-${String(nextMonth).padStart(2, "0")}`);
+  }
+  candidates.push(`${year}-${String(month).padStart(2, "0")}`);
+
+  for (const id of candidates) {
+    if (availableMonths.includes(id)) return id;
+  }
+  return fallback;
+}
 
 function getDataDir() {
   return path.join(process.cwd(), "app/tools/yutai-candidates/data");
@@ -91,7 +177,7 @@ export async function loadMonthlyYutaiPageData(requestedMonthId?: string): Promi
   const selectedMonthId =
     requestedMonthId && availableMonths.includes(requestedMonthId)
       ? requestedMonthId
-      : manifest?.latest_month ?? DEFAULT_MONTH_ID;
+      : getSmartDefaultMonthId(availableMonths, manifest?.latest_month ?? "");
 
   const monthData = await loadMonthlyYutaiMonthData(selectedMonthId);
 

--- a/app/tools/yutai-candidates/page.tsx
+++ b/app/tools/yutai-candidates/page.tsx
@@ -5,7 +5,7 @@ import { loadMonthlyYutaiPageData } from "./data-loader";
 export const metadata: Metadata = {
   title: "優待候補一覧 | mini-tools",
   description:
-    "market_info の月別優待データを一覧表示し、気になる銘柄をピックして優待メモへ追加できる候補探索ページです。",
+    "月別の優待銘柄候補を一覧表示し、気になる銘柄をピックして優待メモへ追加できる候補探索ページです。",
   alternates: {
     canonical: "/tools/yutai-candidates",
   },


### PR DESCRIPTION
## 概要

優待候補一覧のデフォルト表示月を「当月（権利付き最終日後なら翌月）」に改善し、TOPページのツール説明から開発用語を除去。

## 変更内容

### 月選択ロジックの改善 (`data-loader.ts`)
- `DEFAULT_MONTH_ID` ハードコードを廃止
- `getSmartDefaultMonthId()` を追加：JST 当日付を取得し、権利付き最終日（月末最終営業日 - 2 営業日）を過ぎていれば翌月、そうでなければ当月を優先選択
- `JP_LATE_MONTH_NON_TRADING` で月末近くに位置する祝日を考慮（4/29 昭和の日・12/31 大納会、2025-2029 年分）

### TOP説明文のクリーンアップ (`app/page.tsx`, `yutai-candidates/page.tsx`)
- 「優待候補一覧」detail: `market_info の月別優待データを一覧で見て...` → `月別の優待銘柄候補を一覧で確認...`
- 「決算カレンダー」detail: `market_info のデータをもとに表示` → `日付ごとに銘柄と決算種別を一覧表示`
- `yutai-candidates/page.tsx` metadata description も同様に修正

## 確認項目

- [x] `npm run lint` パス（既存の nikkei-contribution react-compiler エラーのみ・今回と無関係）
- [x] Codex review 実施（P2: 祝日考慮漏れ → `JP_LATE_MONTH_NON_TRADING` で対応済み）
- [x] `DEFAULT_MONTH_ID` 削除後も型エラーなし

## 動作ロジック

| 今日の日付 | 権利付き最終日 (例: 3月) | 表示月 |
|---|---|---|
| 3/25（権利付き最終日前） | 3/27 | 3月 |
| 3/28（権利付き最終日後） | 3/27 | 4月 |
| availableMonths にない場合 | - | manifest.latest_month にフォールバック |
