### PR TITLE
fix(yutai): 優待候補一覧を優待カレンダーにリネーム・説明文更新

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,7 +40,7 @@ const TOOLS: ToolItem[] = [
   {
     title: "株主優待期限帳",
     short: "優待の期限を管理",
-    detail: "優待の有効期限（使える最終日）を管理。期限が近い順・月別表示対応。データは端末内に保存。",
+    detail: "受け取った優待の使用期限を管理。期限切れを防ぐ、使い忘れゼロへ。",
     href: "/tools/yutai-expiry",
     icon: "🎁",
   },
@@ -52,9 +52,9 @@ const TOOLS: ToolItem[] = [
     icon: "📝",
   },
   {
-    title: "優待候補一覧",
+    title: "優待カレンダー",
     short: "月別の候補を探す",
-    detail: "月別の優待銘柄候補を一覧で確認。気になる銘柄をピックして優待メモへ追加できます。",
+    detail: "権利確定月ごとに優待銘柄を一覧で確認。気になる銘柄をピックして優待メモへ追加できます。",
     href: "/tools/yutai-candidates",
     icon: "🔎",
   },

--- a/app/tools/yutai-candidates/page.tsx
+++ b/app/tools/yutai-candidates/page.tsx
@@ -3,9 +3,9 @@ import ToolClient from "./ToolClient";
 import { loadMonthlyYutaiPageData } from "./data-loader";
 
 export const metadata: Metadata = {
-  title: "優待候補一覧 | mini-tools",
+  title: "優待カレンダー | mini-tools",
   description:
-    "月別の優待銘柄候補を一覧表示し、気になる銘柄をピックして優待メモへ追加できる候補探索ページです。",
+    "権利確定月ごとに優待銘柄を一覧表示し、気になる銘柄をピックして優待メモへ追加できます。",
   alternates: {
     canonical: "/tools/yutai-candidates",
   },


### PR DESCRIPTION
## Summary

- 「優待候補一覧」→「優待カレンダー」にリネーム（title・メタdescription）
- 優待カレンダーの説明文：「候補」を除去し「権利確定月ごとに〜」に変更
- 株主優待期限帳の説明文：「受け取った優待の使用期限を管理。期限切れを防ぐ、使い忘れゼロへ。」に変更

## Test plan

- [ ] トップページで「優待カレンダー」と表示されることを確認
- [ ] `/tools/yutai-candidates` のページタイトルが「優待カレンダー | mini-tools」になっていることを確認
- [ ] 各説明文が意図通りに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)