### PR TITLE
docs(architecture): add market tools system notes

### DIFF
--- a/docs/decision-log/2026-04-04-market-tools-api-unification-plan.md
+++ b/docs/decision-log/2026-04-04-market-tools-api-unification-plan.md
@@ -1,0 +1,174 @@
+# 2026-04-04 market tools の API 統一方針
+
+## 背景
+
+- `mini-tools` では market tools の取得経路が混在している
+  - `MARKET_INFO_API_BASE_URL` を使う loader
+  - 公開 JSON base URL を前提にした env
+  - repo 同梱 JSON fallback
+- 特に次の env は役割が揺れている
+  - `STOCK_RANKING_DATA_BASE_URL`
+  - `NIKKEI_CONTRIBUTION_DATA_BASE_URL`
+  - `MONTHLY_YUTAI_DATA_BASE_URL`
+- 将来的な保守性、拡張性、取得経路の説明しやすさを考えると、market tools は API 経由へ寄せた方が整理しやすい
+
+## 今回決めたこと
+
+- market tools の標準取得入口は `MARKET_INFO_API_BASE_URL` に統一する
+- 既存の公開 JSON base URL 系 env は、今回の整理では削除側で進める
+- 削除前提の env に依存していた取得経路は、`market_info API` 側に必要エンドポイントを追加して吸収する
+- `mini-tools` から `market_info API` への依頼は、「実装してほしい endpoint 一覧」「response contract」「移行順」を明記して出す
+
+## 判断理由
+
+### 1. 入口を一本化したい
+
+- `mini-tools` 側で「この tool は API、これは公開 JSON、これは local fallback」と説明が分かれると、運用判断が難しくなる
+- env の意味も増えすぎると、設定ミスや放置される名残設定が増える
+
+### 2. 将来の拡張に備えたい
+
+- API 経由に寄せると、将来 response を加工しやすい
+- 認可、キャッシュ、監視、versioning を足しやすい
+- upstream の保存先をアプリ側から切り離しやすい
+
+### 3. 公開 URL はセキュリティ改善には直結しない
+
+- 公開データをクライアントに返す以上、JSON 自体は取得可能
+- ただし API に集約すると「どこから取るか」「何を返すか」の責務は整理しやすい
+
+## 削除対象として扱う env
+
+- `STOCK_RANKING_DATA_BASE_URL`
+- `NIKKEI_CONTRIBUTION_DATA_BASE_URL`
+- `MONTHLY_YUTAI_DATA_BASE_URL`
+
+補足:
+
+- すぐに `.env.local.example` から消すかどうかは、移行完了タイミングに合わせる
+- 先に `market_info API` 側で必要 endpoint を揃え、その後 `mini-tools` 側から参照を外す順が安全
+
+## market_info API 側で必要になる endpoint
+
+### 既存前提として維持したいもの
+
+- `GET /topix33/manifest`
+- `GET /topix33/{date}`
+- `GET /nikkei/manifest`
+- `GET /nikkei/{date}`
+- `GET /ranking/manifest`
+- `GET /ranking/{date}`
+- `GET /yutai/manifest`
+- `GET /yutai/monthly/{yearMonth}`
+- `GET /nikko/credit`
+
+### 公開 JSON 依存を外すために追加したいもの
+
+- `GET /market-calendar/jpx-closed`
+  - 返すもの:
+    - `jpx_market_closed_20260101_to_20271231.json` と同等 shape
+  - 用途:
+    - `stock-ranking`
+    - `topix33`
+    - `nikkei-contribution`
+    - 将来的な market tools 共通利用
+
+補足:
+
+- endpoint 名は例であり、`/holidays/jpx-market-closed` などでもよい
+- 重要なのは「休場日 JSON を API から一貫して取得できる」こと
+
+## mini-tools 側の整理方針
+
+### 1. 優先して揃えるもの
+
+- `topix33`
+- `nikkei-contribution`
+- `stock-ranking`
+- `yutai-candidates`
+
+### 2. 後追いで整理するもの
+
+- `earnings-calendar` の API 化
+  - 現時点ではローカル JSON 読みで動いているため、今回の最小移行スコープからは外してよい
+
+### 3. fallback の扱い
+
+- API 未設定時 / fetch 失敗時のローカル fallback は当面残してよい
+- ただし fallback の役割は「開発・緊急退避」に限定し、本番の主経路は API に固定する
+
+## market_info API への依頼の出し方
+
+次の 4 点を必ずセットで伝える。
+
+1. 目的
+2. 必要 endpoint 一覧
+3. response contract
+4. mini-tools 側の移行順
+
+### 依頼テンプレート
+
+```text
+件名:
+feat(api): unify market tools endpoints for mini-tools
+
+背景:
+- mini-tools で market tools の取得経路を MARKET_INFO_API_BASE_URL に統一したい
+- 公開 JSON base URL 依存を減らし、API 経由へ寄せたい
+
+依頼したいこと:
+1. 次の endpoint を提供したい / 維持したい
+   - GET /topix33/manifest
+   - GET /topix33/{date}
+   - GET /nikkei/manifest
+   - GET /nikkei/{date}
+   - GET /ranking/manifest
+   - GET /ranking/{date}
+   - GET /yutai/manifest
+   - GET /yutai/monthly/{yearMonth}
+   - GET /nikko/credit
+   - GET /market-calendar/jpx-closed
+
+2. response は mini-tools の既存 contract と互換を保ちたい
+
+3. /market-calendar/jpx-closed は、現在 mini-tools が参照している
+   jpx_market_closed_20260101_to_20271231.json と同等 shape を返したい
+
+4. mini-tools 側では endpoint 提供確認後に
+   - 公開 JSON base URL 依存を削除
+   - env 整理
+   - docs 更新
+   を進める
+
+補足:
+- endpoint 名は相談可能
+- まずは response shape を確定したい
+```
+
+## 移行の推奨順
+
+1. `market_info API` 側で endpoint 一覧を確認する
+2. 不足 endpoint を追加する
+3. `mini-tools` 側で API 経由に寄せる
+4. 旧 env 参照を削除する
+5. `.env.local.example` と docs を更新する
+
+## 影響範囲
+
+- `mini-tools` の market tools loader
+- `.env.local.example`
+- docs の構成説明
+- `market_info API` の endpoint 設計
+
+## 残課題
+
+- `earnings-calendar` も API 化するか
+- fallback をどこまで残すか
+- API の versioning を先に切るか
+- `market_info API` 側で contract テストを持つか
+
+## 関連
+
+- [Market Tools データ取得経路一覧](../market-tools-data-fetch-paths.md)
+- [mini-tools システム構成概要](../system-architecture-overview.md)
+- [2026-03-26 株価ランキングのデータ連携手順メモ](./2026-03-26-stock-ranking-data-update-ops.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
 - [2026-04-04 premium ログイン導線の暫定実装方針](./decision-log/2026-04-04-premium-login-placeholder-flow.md)
 - [2026-04-03 有料機能プレースホルダーの追加方針](./decision-log/2026-04-03-premium-feature-placeholder.md)
@@ -40,7 +41,10 @@
 ## 📎 Specs（仕様メモ）
 
 - [Docs Writing Workflow](./docs-writing-workflow.md)
+- [mini-tools システム構成概要](./system-architecture-overview.md)
+- [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md)
 - Market Tools 関連:
+- [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
 - [2026-04-04 premium ログイン導線の暫定実装方針](./decision-log/2026-04-04-premium-login-placeholder-flow.md)
 - [2026-03-31 TOPIX33業種データ追加と market tools 導線の方針](./decision-log/2026-03-31-topix33-market-tool-plan.md)

--- a/docs/market-tools-data-fetch-paths.md
+++ b/docs/market-tools-data-fetch-paths.md
@@ -1,0 +1,91 @@
+# Market Tools データ取得経路一覧
+
+このメモは、`mini-tools` 内の各 market tool が
+
+- 初回表示でどこからデータを読むか
+- 画面操作後にどこからデータを読むか
+- どの環境変数を参照するか
+- fallback があるか
+
+を一覧で把握するための参照用 spec です。
+
+## 前提
+
+- 「サーバー側」は `mini-tools` の Next.js サーバーを指す
+  - ローカル開発では手元の Next.js
+  - デプロイ時は Vercel 上の Next.js
+- `process.env.*` は `mini-tools` 実行環境の環境変数を見る
+- `MARKET_INFO_API_BASE_URL` は「どこかの外部 API の base URL」を指す
+  - この repo だけでは、その API の実体が Cloud Run か、別の配信経路か、裏でどのストレージを読んでいるかまでは断定できない
+  - `.env` 例では `https://...run.app` が書かれているため、現時点の想定は Cloud Run API
+- `res.json()` で受けているため、HTTP レスポンス形式は JSON
+  - ただし、その JSON が upstream の保存ファイルそのものか、API が加工して返した JSON かは、この repo だけでは分からない
+
+## 一覧
+
+| Tool | 初回表示 | 画面操作後 | 設定 | Fallback | 備考 |
+| --- | --- | --- | --- | --- | --- |
+| `topix33` | サーバーで `loadTopix33Manifest()` / `loadTopix33DayData()` | クライアントは `/tools/topix33/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/topix33/data` のローカル JSON | 同じデータソースを、SSR と client route の 2 入口で使っている |
+| `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
+| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` のローカル JSON | 日付切り替え時だけ internal route を経由 |
+| `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | sample fallback は誤情報防止のため条件付き |
+| `earnings-calendar` | サーバーで `app/tools/earnings-calendar/data` のローカル JSON を直接読む | クライアント再 fetch なし | なし | ローカルデータ前提 | 現時点では外部 API を直接読まない |
+
+## `topix33` の具体的な流れ
+
+### 初回表示
+
+1. [page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/page.tsx) がサーバー上で実行される
+2. [data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data-loader.ts) の `loadTopix33Manifest()` / `loadTopix33DayData()` を呼ぶ
+3. `MARKET_INFO_API_BASE_URL` があれば `GET {baseUrl}/topix33/...`
+4. 失敗したら `app/tools/topix33/data/*.json` を読む
+
+### 日付切り替え
+
+1. [ToolClient.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/ToolClient.tsx) がブラウザから `GET /tools/topix33/data/{date}` を呼ぶ
+2. [route.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data/[date]/route.ts) が受ける
+3. route 内で `loadTopix33DayData(date)` を呼ぶ
+4. その内部では初回表示時と同じく `MARKET_INFO_API_BASE_URL` またはローカル JSON を使う
+
+つまり `topix33` は、
+
+- 初回表示: `mini-tools server -> external API or local JSON`
+- 日付切替: `browser -> mini-tools route -> external API or local JSON`
+
+という 2 段構成です。
+
+## なぜ route 経由と server fetch が混在しているか
+
+現在の構成では、SSR の初回表示と、ブラウザ上の操作後レスポンスを両立するために入口が分かれています。
+
+- SSR にしたい初回表示は server component から loader を直接呼ぶ
+- ブラウザ操作で差し替えたい日付データは internal route を用意して fetch する
+
+このため、同じデータでも「取り方が違って見える」状態になっています。  
+実際には最終的に参照する loader は同一で、入口だけが分かれています。
+
+## 現状の課題
+
+- tool ごとに「server 直読」「internal route 経由」「ローカル固定」が混在していて把握しづらい
+- `MARKET_INFO_API_BASE_URL` の upstream 実体が repo 単体では見えず、運用境界が曖昧に見えやすい
+- fallback ポリシーが tool ごとに少しずつ異なる
+
+## 今後そろえたい観点
+
+- 初回表示と画面操作後で、取得経路をどこまで統一するか
+- internal route を置く tool / 置かない tool の基準
+- fallback の原則
+- cache-control / `revalidate` の原則
+- 「外部 API の JSON をそのまま返す route」と「加工して返す route」の区別
+
+## 関連ファイル
+
+- [app/tools/topix33/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data-loader.ts)
+- [app/tools/topix33/page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/page.tsx)
+- [app/tools/topix33/data/[date]/route.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data/[date]/route.ts)
+- [app/tools/topix33/ToolClient.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/ToolClient.tsx)
+- [app/tools/nikkei-contribution/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/nikkei-contribution/data-loader.ts)
+- [app/tools/stock-ranking/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/stock-ranking/data-loader.ts)
+- [app/tools/yutai-candidates/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/yutai-candidates/data-loader.ts)
+- [app/tools/earnings-calendar/page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/earnings-calendar/page.tsx)
+- [.env.local.example](/c:/Users/yutaz/dev/mini-tools/.env.local.example)

--- a/docs/system-architecture-overview.md
+++ b/docs/system-architecture-overview.md
@@ -1,0 +1,219 @@
+# mini-tools システム構成概要
+
+このメモは、`mini-tools` 全体を俯瞰するときの入口です。  
+画面、認証、データ取得、外部依存、ローカル保存の役割分担を大づかみに整理します。
+
+## 全体像
+
+`mini-tools` は、Next.js App Router を使った単一アプリです。  
+大きく分けると、次の 5 層で構成されています。
+
+1. UI 層
+2. アプリケーション層
+3. データ取得層
+4. 永続化 / 保存層
+5. 外部依存層
+
+## 構成イメージ
+
+```text
+Browser
+  ├─ React Client Components
+  ├─ localStorage を使うローカル保存系 tool
+  └─ 一部ツールは internal route を fetch
+
+mini-tools (Next.js App Router)
+  ├─ app/* page.tsx
+  │   ├─ server component で初回表示を組み立てる
+  │   └─ client component に初期データを渡す
+  ├─ app/**/route.ts
+  │   ├─ premium login/logout API
+  │   └─ 日付別 JSON を返す internal data route
+  ├─ components/*
+  │   ├─ Header
+  │   ├─ ShareButtons
+  │   └─ 各種 UI 部品
+  ├─ lib/*
+  │   └─ premium 認証などの共通ロジック
+  └─ app/tools/**/data-loader.ts
+      ├─ 外部 API / 公開 JSON / ローカル JSON を切り替える
+      └─ page / route から共有利用される
+
+External / Storage
+  ├─ market-info API
+  ├─ 公開 JSON 配信URL
+  ├─ repo 同梱 JSON
+  └─ Browser localStorage
+```
+
+## 1. UI 層
+
+UI は主に `app/` と `components/` にあります。
+
+- `app/layout.tsx`
+  - 全ページ共通レイアウト
+  - Header 読み込み
+  - GA Script 読み込み
+  - PWA manifest 指定
+- `components/Header.tsx`
+  - 全体ヘッダー
+  - premium 導線の入口
+- `components/ShareButtons.tsx`
+  - 各 tool の共有導線
+
+各 tool は `app/tools/<tool>/page.tsx` を起点に持ち、必要に応じて `ToolClient.tsx` に client-side UI を分けています。
+
+## 2. アプリケーション層
+
+アプリケーション層は、ページごとの組み立てと画面遷移制御を担当します。
+
+### server component の役割
+
+- 初回表示に必要なデータをロードする
+- クライアントに初期データを渡す
+- premium などのアクセス制御を行う
+
+例:
+
+- [app/tools/topix33/page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/page.tsx)
+- [app/tools/stock-ranking/page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/stock-ranking/page.tsx)
+- [app/premium/page.tsx](/c:/Users/yutaz/dev/mini-tools/app/premium/page.tsx)
+
+### client component の役割
+
+- 日付切替
+- 月切替
+- hover / tooltip
+- local state 管理
+- localStorage を使う入力系 tool の操作
+
+## 3. データ取得層
+
+データ取得の中心は各 tool の `data-loader.ts` です。
+
+例:
+
+- [app/tools/topix33/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data-loader.ts)
+- [app/tools/nikkei-contribution/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/nikkei-contribution/data-loader.ts)
+- [app/tools/stock-ranking/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/stock-ranking/data-loader.ts)
+- [app/tools/yutai-candidates/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/yutai-candidates/data-loader.ts)
+
+責務は次の通りです。
+
+- 環境変数を読んで取得先を決める
+- 外部 API / 公開 JSON / ローカル JSON の切替を行う
+- fetch 失敗時の fallback を吸収する
+- `page.tsx` と `route.ts` で同じ取得ロジックを共有する
+
+詳細は [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md) を参照します。
+
+## 4. 永続化 / 保存層
+
+この repo には、保存方法が大きく 3 種類あります。
+
+### 1. repo 同梱 JSON
+
+`app/tools/**/data/*.json` に配置される静的データです。
+
+用途:
+
+- fallback
+- 開発時のローカル確認
+- 外部 API がなくても最低限動かすための同梱データ
+
+### 2. Browser localStorage
+
+入力系・個人用管理系 tool はブラウザ内保存を使います。
+
+例:
+
+- yutai-memo
+- yutai-expiry
+- total
+- charcount
+
+これらはサーバー側 DB を持たず、端末ローカル保存が前提です。
+
+### 3. Cookie
+
+premium 仮ログインは Cookie ベースです。
+
+- Cookie 名: `mini_tools_premium`
+- 署名 / 検証ロジック: [lib/premium-auth.ts](/c:/Users/yutaz/dev/mini-tools/lib/premium-auth.ts)
+- login route: [app/api/premium/login/route.ts](/c:/Users/yutaz/dev/mini-tools/app/api/premium/login/route.ts)
+- logout route: [app/api/premium/logout/route.ts](/c:/Users/yutaz/dev/mini-tools/app/api/premium/logout/route.ts)
+
+## 5. 外部依存層
+
+主な外部依存は次の通りです。
+
+### Next.js / React
+
+- App Router ベース
+- server component と client component を併用
+
+### Google Analytics
+
+- `NEXT_PUBLIC_GA_ID` を [app/layout.tsx](/c:/Users/yutaz/dev/mini-tools/app/layout.tsx) で読む
+- 設定があるときだけ Script を埋め込む
+
+### market-info API
+
+- `MARKET_INFO_API_BASE_URL` を使う tool が参照
+- 主に market tools の日次データ取得に使う
+- 実体がどのインフラかは、この repo 単体では断定しない
+
+### 公開 JSON 配信 URL
+
+一部 tool は公開 base URL を想定しています。
+
+- `STOCK_RANKING_DATA_BASE_URL`
+- `NIKKEI_CONTRIBUTION_DATA_BASE_URL`
+- `MONTHLY_YUTAI_DATA_BASE_URL`
+
+ただし、実装によっては data-loader 側で `MARKET_INFO_API_BASE_URL` を優先している箇所もあり、設計が完全統一されているわけではありません。
+
+### PWA / Service Worker
+
+- `next-pwa` を利用
+- `manifest.webmanifest` を公開
+- build 時に `public/sw.js` が生成される
+
+## premium 機能の位置づけ
+
+premium は現時点では「仮ログイン + preview 画面」です。
+
+- 認証は簡易 Cookie セッション
+- ユーザー管理 DB は未導入
+- 課金 / 会員管理 / 権限テーブルは未実装
+
+そのため、現状の premium は「保護された preview 導線」であり、本格的な会員システムではありません。
+
+## このシステムで今わかること / わからないこと
+
+### わかること
+
+- `mini-tools` は Next.js 単一アプリで動いている
+- tool ごとに server component と client component を使い分けている
+- market tools は外部 API またはローカル JSON fallback を使う
+- premium は Cookie ベースの簡易認証
+
+### この repo だけでは断定できないこと
+
+- `MARKET_INFO_API_BASE_URL` の upstream 実体
+- 外部 API が upstream の JSON をそのまま返しているか
+- 外部 API の裏で Cloud Run / R2 / DB / Worker のどれを使っているか
+
+## 現状の整理ポイント
+
+- market tools のデータ取得経路が少しずつ異なる
+- 外部 API と公開 JSON URL の使い分けが統一されきっていない
+- premium は preview 段階で、会員システムとしては未完成
+- docs を入口別に見ないと全体像が掴みにくい
+
+## 関連 docs
+
+- [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md)
+- [2026-04-04 premium ログイン導線の暫定実装方針](./decision-log/2026-04-04-premium-login-placeholder-flow.md)
+- [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
+- [2026-03-12 SSR / Hydration / localStorage 運用ガイド](./decision-log/2026-03-12-ssr-localstorage-hydration-guidelines.md)


### PR DESCRIPTION
## 概要

market tools まわりの取得経路とシステム構成を俯瞰できる docs を追加しました。

## 変更内容

- market tools のデータ取得経路一覧を追加
- mini-tools 全体のシステム構成概要を追加
- API 統一方針の decision log を追加
- docs index を更新

## 確認項目

- docs のみの更新のためコード実行確認は未実施
- リンクと構成の整合性を目視確認

## 関連 Issue

- Refs #190
