### PR TITLE
docs(market-tools): finalize jpx-closed endpoint usage

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,10 +2,11 @@
 NEXT_PUBLIC_GA_ID=
 
 # market-info-api の base URL（任意）
-# 設定するとデイリー更新データを API 経由で取得する。未設定時はローカル JSON fallback。
+# 設定すると market tools のデータを API 経由で取得する。未設定時はローカル JSON fallback。
 # 例: https://market-info-api-619599800912.asia-northeast1.run.app
 # 対象 tool: nikkei-contribution, topix33, stock-ranking, yutai-candidates
-# 休場日 API の想定 endpoint: /market-calendar/jpx-closed
+# 休場日も /market-calendar/jpx-closed から取得する
+# response shape: as_of_date, from, to, days[] (date, market_closed, label)
 MARKET_INFO_API_BASE_URL=
 
 # 共有リンク / QR 用の公開URL（任意）

--- a/README.md
+++ b/README.md
@@ -64,32 +64,34 @@ npm run dev
 - `NEXT_PUBLIC_SITE_URL`
   - 共有URL（QR/コピー/SNS）の基準URLに使用
   - 参照: `components/ShareButtons.tsx`
-- `STOCK_RANKING_DATA_BASE_URL`
-  - `stock-ranking` が外部配信の `manifest.json` / 日次JSON を読むときの基準URL
-  - 通常は `https://<public-base-url>` のように prefix なしで指定する
-  - `.../stock-ranking` のような JSON 配信ディレクトリ URL を直接指定しても動く
-  - 未設定時は repo 内の `app/tools/stock-ranking/data/` を読む
-  - 参照: `app/tools/stock-ranking/data-loader.ts`
-- `NIKKEI_CONTRIBUTION_DATA_BASE_URL`
-  - `nikkei-contribution` が外部配信の `nikkei_contribution_manifest.json` / 日次JSON を読むときの基準URL
-  - 通常は `https://<public-base-url>` のように prefix なしで指定する
-  - `.../nikkei-contribution` のような JSON 配信ディレクトリ URL を直接指定しても動く
-  - 未設定時はコード内の既定公開 URL を読む
-  - Vercel でも配信先を明示するため、公開 URL を env に設定しておく運用を推奨
-  - 参照: `app/tools/nikkei-contribution/data-loader.ts`
-- `MONTHLY_YUTAI_DATA_BASE_URL`
-  - `yutai-candidates` が外部配信の `manifest.json` / 月別JSON を読むときの入口URL
-  - `.../yutai/monthly` のようなディレクトリURLと `.../yutai/monthly/manifest.json` のような manifest URL 直指定の両方に対応
-  - 月別JSONは `manifest.months[].path` を正として解決する
-  - 未設定時は repo 内の `app/tools/yutai-candidates/data/` を読む
-  - 参照: `app/tools/yutai-candidates/data-loader.ts`
+- `MARKET_INFO_API_BASE_URL`
+  - market tools の標準取得入口
+  - 対象 endpoint:
+    - `/topix33/manifest`
+    - `/topix33/{date}`
+    - `/nikkei/manifest`
+    - `/nikkei/{date}`
+    - `/ranking/manifest`
+    - `/ranking/{date}`
+    - `/yutai/manifest`
+    - `/yutai/monthly/{yearMonth}`
+    - `/nikko/credit`
+    - `/market-calendar/jpx-closed`
+  - `jpx-closed` の response shape は従来の thin JSON と互換
+  - `as_of_date`, `from`, `to`, `days[]`
+  - `days[]` は `date`, `market_closed`, `label`
+  - 未設定時は各 tool の同梱 JSON / sample fallback を使う
+  - 参照:
+    - `app/tools/topix33/data-loader.ts`
+    - `app/tools/nikkei-contribution/data-loader.ts`
+    - `app/tools/stock-ranking/data-loader.ts`
+    - `app/tools/yutai-candidates/data-loader.ts`
+    - `lib/jpx-market-closed.ts`
 
 Vercel では次の env を設定しておく運用を推奨します。
 
 - `NEXT_PUBLIC_SITE_URL`
-- `STOCK_RANKING_DATA_BASE_URL`
-- `NIKKEI_CONTRIBUTION_DATA_BASE_URL`
-- `MONTHLY_YUTAI_DATA_BASE_URL`
+- `MARKET_INFO_API_BASE_URL`
 - `NEXT_PUBLIC_GA_ID`（GA を使う場合のみ）
 
 これらは公開 URL や公開 ID 用であり、アクセスキーや secret のような機密情報は含めません。

--- a/app/tools/stock-ranking/types.ts
+++ b/app/tools/stock-ranking/types.ts
@@ -34,6 +34,7 @@ export type JpxMarketClosedDay = {
 };
 
 export type JpxMarketClosedResponse = {
+  as_of_date: string;
   from: string;
   to: string;
   days: JpxMarketClosedDay[];

--- a/docs/decision-log/2026-04-05-jpx-closed-endpoint-finalization.md
+++ b/docs/decision-log/2026-04-05-jpx-closed-endpoint-finalization.md
@@ -1,0 +1,49 @@
+# 2026-04-05 jpx-closed endpoint の確定事項
+
+## 背景
+
+- market tools の休場日取得は `MARKET_INFO_API_BASE_URL` に寄せる方針で整理している
+- 直前までは `JPX_CLOSED_OBJECT_KEY` や period 付き filename 前提の運用確認が必要という前提が混ざっていた
+- `market-info-api` 側で内部実装が stable alias 方式に切り替わり、mini-tools からは内部キーや filename を意識しなくてよくなった
+
+## 今回決めたこと
+
+- mini-tools は `GET /market-calendar/jpx-closed` をそのまま使ってよい
+- `JPX_CLOSED_OBJECT_KEY` の設定有無を mini-tools 側で意識しない
+- period 付き filename を mini-tools 側の docs や code に持ち込まない
+- response shape は従来の thin JSON と互換を前提にする
+  - `as_of_date`
+  - `from`
+  - `to`
+  - `days[]`
+  - `days[]` の各要素は `date`, `market_closed`, `label`
+
+## 判断理由
+
+### 1. 入口を一本化したい
+
+- market tools の説明を endpoint 単位で統一できる
+- upstream の保存方式変更が mini-tools の docs や code に漏れにくくなる
+
+### 2. 休場日だけ別運用にしない
+
+- `topix33` / `nikkei` / `ranking` / `yutai` / `nikko` と同じく、`MARKET_INFO_API_BASE_URL` 配下の endpoint として扱える
+- 「休場日だけ direct JSON filename を知っている必要がある」状態を避けられる
+
+## mini-tools 側の実装方針
+
+- `lib/jpx-market-closed.ts` は API を主経路にし、失敗時のみローカル JSON fallback を使う
+- docs から `JPX_CLOSED_OBJECT_KEY` や direct filename 前提の説明は外す
+- fallback は開発・緊急退避用途としてのみ残し、本番の標準入口は `/market-calendar/jpx-closed` とする
+
+## 影響範囲
+
+- `lib/jpx-market-closed.ts`
+- `README.md`
+- `docs/market-tools-data-fetch-paths.md`
+- `docs/system-architecture-overview.md`
+
+## 関連
+
+- [2026-04-04 market tools の API 統一方針](./2026-04-04-market-tools-api-unification-plan.md)
+- [Market Tools データ取得経路一覧](../market-tools-data-fetch-paths.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 設計・方針・トレードオフの判断理由を記録します。
 
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
+- [2026-04-05 jpx-closed endpoint の確定事項](./decision-log/2026-04-05-jpx-closed-endpoint-finalization.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
 - [2026-04-04 premium ログイン導線の暫定実装方針](./decision-log/2026-04-04-premium-login-placeholder-flow.md)
 - [2026-04-03 有料機能プレースホルダーの追加方針](./decision-log/2026-04-03-premium-feature-placeholder.md)
@@ -45,6 +46,7 @@
 - [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md)
 - Market Tools 関連:
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
+- [2026-04-05 jpx-closed endpoint の確定事項](./decision-log/2026-04-05-jpx-closed-endpoint-finalization.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
 - [2026-04-04 premium ログイン導線の暫定実装方針](./decision-log/2026-04-04-premium-login-placeholder-flow.md)
 - [2026-03-31 TOPIX33業種データ追加と market tools 導線の方針](./decision-log/2026-03-31-topix33-market-tool-plan.md)

--- a/docs/market-tools-data-fetch-paths.md
+++ b/docs/market-tools-data-fetch-paths.md
@@ -15,9 +15,9 @@
   - ローカル開発では手元の Next.js
   - デプロイ時は Vercel 上の Next.js
 - `process.env.*` は `mini-tools` 実行環境の環境変数を見る
-- `MARKET_INFO_API_BASE_URL` は「どこかの外部 API の base URL」を指す
-  - この repo だけでは、その API の実体が Cloud Run か、別の配信経路か、裏でどのストレージを読んでいるかまでは断定できない
-  - `.env` 例では `https://...run.app` が書かれているため、現時点の想定は Cloud Run API
+- `MARKET_INFO_API_BASE_URL` は market tools の標準 API 入口
+  - mini-tools は upstream の内部実装や period 付き filename を意識しない
+  - `jpx-closed` も `GET {baseUrl}/market-calendar/jpx-closed` に統一する
 - `res.json()` で受けているため、HTTP レスポンス形式は JSON
   - ただし、その JSON が upstream の保存ファイルそのものか、API が加工して返した JSON かは、この repo だけでは分からない
 
@@ -27,7 +27,7 @@
 | --- | --- | --- | --- | --- | --- |
 | `topix33` | サーバーで `loadTopix33Manifest()` / `loadTopix33DayData()` | クライアントは `/tools/topix33/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/topix33/data` のローカル JSON | 同じデータソースを、SSR と client route の 2 入口で使っている |
 | `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
-| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | 休場日も API 経由へ寄せた |
+| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | 休場日 API は `GET /market-calendar/jpx-closed` を使う |
 | `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | UI 文言も API 基準に寄せた |
 | `earnings-calendar` | サーバーで `app/tools/earnings-calendar/data` のローカル JSON を直接読む | クライアント再 fetch なし | なし | ローカルデータ前提 | 現時点では外部 API を直接読まない |
 
@@ -67,7 +67,7 @@
 ## 現状の課題
 
 - tool ごとに「server 直読」「internal route 経由」「ローカル固定」が混在していて把握しづらい
-- `MARKET_INFO_API_BASE_URL` の upstream 実体が repo 単体では見えず、運用境界が曖昧に見えやすい
+- `MARKET_INFO_API_BASE_URL` の upstream 実体は repo 単体では見えないが、mini-tools 側の入口は endpoint 単位で固定される
 - fallback ポリシーが tool ごとに少しずつ異なる
 
 ## 今後そろえたい観点

--- a/docs/system-architecture-overview.md
+++ b/docs/system-architecture-overview.md
@@ -36,7 +36,7 @@ mini-tools (Next.js App Router)
   ├─ lib/*
   │   └─ premium 認証などの共通ロジック
   └─ app/tools/**/data-loader.ts
-      ├─ 外部 API / 公開 JSON / ローカル JSON を切り替える
+      ├─ 外部 API / ローカル JSON fallback を切り替える
       └─ page / route から共有利用される
 
 External / Storage
@@ -100,7 +100,7 @@ UI は主に `app/` と `components/` にあります。
 責務は次の通りです。
 
 - 環境変数を読んで取得先を決める
-- 外部 API / 公開 JSON / ローカル JSON の切替を行う
+- 外部 API / ローカル JSON fallback の切替を行う
 - fetch 失敗時の fallback を吸収する
 - `page.tsx` と `route.ts` で同じ取得ロジックを共有する
 

--- a/lib/jpx-market-closed.ts
+++ b/lib/jpx-market-closed.ts
@@ -39,20 +39,15 @@ async function loadLocalJpxMarketClosedData(): Promise<JpxMarketClosedResponse |
 }
 
 export async function loadJpxMarketClosedData(): Promise<JpxMarketClosedResponse | null> {
-  const localData = await loadLocalJpxMarketClosedData();
   const apiBase = getApiBaseUrl();
 
   if (!apiBase) {
-    return localData;
-  }
-
-  if (localData) {
-    return localData;
+    return loadLocalJpxMarketClosedData();
   }
 
   try {
     return await fetchJson<JpxMarketClosedResponse>(`${apiBase}/market-calendar/jpx-closed`);
   } catch {
-    return null;
+    return loadLocalJpxMarketClosedData();
   }
 }


### PR DESCRIPTION
## 概要

`jpx-closed` の取得方針を `MARKET_INFO_API_BASE_URL` 配下の API endpoint に統一し、mini-tools 側の docs と型を最新 contract に合わせます。

## 変更内容

- `lib/jpx-market-closed.ts` を API 優先・ローカル fallback に変更
- `stock-ranking` 側の `JpxMarketClosedResponse` に `as_of_date` を追加
- `README.md` / `.env.local.example` / docs を `MARKET_INFO_API_BASE_URL` 一本の説明に更新
- `jpx-closed` の確定事項を decision log に追加

## 確認項目

- `npm run lint`
- `npm run build`
- `MARKET_INFO_API_BASE_URL/market-calendar/jpx-closed` への live fetch
- Codex CLI review はネットワーク timeout で完走できず、差分レビューは手動確認で代替

## 関連 Issue

Closes #106
