### PR TITLE
docs(market-tools): add production verification notes

### DIFF
--- a/docs/decision-log/2026-03-26-stock-ranking-data-update-ops.md
+++ b/docs/decision-log/2026-03-26-stock-ranking-data-update-ops.md
@@ -1,5 +1,11 @@
 # 2026-03-26 株価ランキングのデータ連携手順メモ
 
+> Note
+> このメモは 2026-03-26 時点の運用整理です。
+> 現行の標準取得入口は `STOCK_RANKING_DATA_BASE_URL` ではなく `MARKET_INFO_API_BASE_URL` です。
+> 最新方針は [2026-04-04 market tools の API 統一方針](./2026-04-04-market-tools-api-unification-plan.md) と
+> [2026-04-05 jpx-closed endpoint の確定事項](./2026-04-05-jpx-closed-endpoint-finalization.md) を参照します。
+
 ## 背景
 
 `stock-ranking` は、`mini-tools` 側で [`app/tools/stock-ranking/data/manifest.json`](../../../app/tools/stock-ranking/data/manifest.json) を起点に利用可能日を判断し、各日付の JSON を読み込んで表示している。  

--- a/docs/decision-log/2026-03-28-nikkei-contribution-data-and-ui.md
+++ b/docs/decision-log/2026-03-28-nikkei-contribution-data-and-ui.md
@@ -1,5 +1,10 @@
 # 2026-03-28 日経225寄与度ツールのデータ連携と UI 判断
 
+> Note
+> このメモの UI 判断は引き続き有効ですが、取得入口の説明は当時の前提です。
+> 現行の標準取得入口は `NIKKEI_CONTRIBUTION_DATA_BASE_URL` ではなく `MARKET_INFO_API_BASE_URL/nikkei/*` です。
+> 最新方針は [2026-04-04 market tools の API 統一方針](./2026-04-04-market-tools-api-unification-plan.md) を参照します。
+
 ## 背景
 
 `market_info` 側で生成した `nikkei_contribution_YYYY-MM-DD.json` と

--- a/docs/devlog/2026-04-05-market-tools-production-verification.md
+++ b/docs/devlog/2026-04-05-market-tools-production-verification.md
@@ -1,0 +1,44 @@
+# 2026-04-05 market tools 本番確認メモ
+
+## 目的
+
+- `MARKET_INFO_API_BASE_URL` 前提に寄せた market tools の本番疎通を確認する
+- `/market-calendar/jpx-closed` を含む運用整理後に、`mini-tools` 側の実応答を残す
+
+## 確認日時
+
+- 2026-04-05 JST
+
+## 確認対象
+
+- 本番 URL: `https://mini-tools-rho.vercel.app`
+- API URL: `https://market-info-api-619599800912.asia-northeast1.run.app`
+
+## 確認内容
+
+### 1. market-info-api の live fetch
+
+- `GET /market-calendar/jpx-closed`
+  - `as_of_date`: `2026-04-05`
+  - `from`: `2026-01-01`
+  - `to`: `2027-12-31`
+  - `days` 先頭要素: `2026-01-01 / true / 元日`
+
+### 2. mini-tools 本番ページ
+
+- `GET /tools/topix33` -> `200`
+- `GET /tools/nikkei-contribution` -> `200`
+- `GET /tools/stock-ranking` -> `200`
+- `GET /tools/yutai-candidates` -> `200`
+
+### 3. mini-tools internal data route
+
+- `GET /tools/topix33/data/2026-04-03` -> `200`
+- `GET /tools/nikkei-contribution/data/2026-04-02` -> `200`
+- `GET /tools/stock-ranking/data/2026-04-03` -> `200`
+
+## メモ
+
+- 実動作確認時点で、対象 market tools のページ応答と data route 応答は問題なし
+- `jpx-closed` は `MARKET_INFO_API_BASE_URL/market-calendar/jpx-closed` で取得できることを確認済み
+- 画面の人手目視は別途必要なら追加で行うが、少なくとも SSR / route 応答レベルでは運用可能

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@
 
 日々の開発作業や試行錯誤の記録です。
 
+- [2026-04-05 market tools 本番確認メモ](./devlog/2026-04-05-market-tools-production-verification.md)
 - [2026-01-11 QR 共有 UI 改善ログ](./devlog/2026-01-11-qr-share-ui-improvement.md)
 - [2026-01-10 Git 学習ログ](./devlog/2026-01-10_git-learning-log.md)
 

--- a/docs/stock-ranking-external-data-plan.md
+++ b/docs/stock-ranking-external-data-plan.md
@@ -2,6 +2,11 @@
 
 Last-Updated: 2026-03-26 JST
 
+> Note
+> このメモは 2026-03-26 時点の外部公開 JSON 前提の移行計画です。
+> 現行方針は [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md) を優先し、
+> `stock-ranking` の標準取得入口は `MARKET_INFO_API_BASE_URL/ranking/*` を使います。
+
 ## 目的
 
 `stock-ranking` を、`mini-tools` リポジトリ内の静的JSON更新運用から、`market_info` が生成した外部公開JSONを読む運用へ移行する。  


### PR DESCRIPTION
## 概要

market tools の本番確認結果を docs に残し、旧 env / 旧取得入口を前提にした historical docs に現行方針への注記を追加します。

## 変更内容

- market tools 本番確認メモを devlog に追加
- `stock-ranking` / `nikkei-contribution` の旧取得前提 docs に現行方針への note を追加
- `docs/index.md` に本番確認メモへのリンクを追加

## 確認項目

- `npm run lint`
- 本番 URL `https://mini-tools-rho.vercel.app`
- live fetch: `https://market-info-api-619599800912.asia-northeast1.run.app/market-calendar/jpx-closed`

## 関連 Issue

Refs #106
