### PR TITLE
fix(yutai-candidates): use sbi short handling only

### DIFF
--- a/app/tools/yutai-candidates/ToolClient.tsx
+++ b/app/tools/yutai-candidates/ToolClient.tsx
@@ -78,11 +78,14 @@ function renderSbiCreditBadge(
 ): React.ReactNode {
   if (!sbiCredit) return null;
   const record = sbiCredit.by_code[code];
-  if (!record || record.position_status === "unavailable") return null;
-  if (record.position_status === "limited") {
-    return <span style={styles.sbiCreditChipLimited}>SBI残少</span>;
-  }
-  return <span style={styles.sbiCreditChipAvailable}>SBI売可</span>;
+  if (!isHandledBySbiShort(record)) return null;
+  return <span style={styles.sbiCreditChipAvailable}>SBI短期対象</span>;
+}
+
+function isHandledBySbiShort(
+  record: import("./types").SbiCreditData["by_code"][string] | undefined,
+) {
+  return Boolean(record?.is_short);
 }
 
 function hasOfficialLink(item: MonthlyYutaiCandidate) {
@@ -172,7 +175,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
 
         if (sbiFilter === "sbi_any" && data.sbiCredit) {
           const sbi = data.sbiCredit.by_code[item.code];
-          if (!sbi || sbi.position_status === "unavailable") return false;
+          if (!isHandledBySbiShort(sbi)) return false;
         }
 
         if (!normalizedQuery) return true;
@@ -349,7 +352,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
               {data.sbiCredit && (
                 <select value={sbiFilter} onChange={(e) => setSbiFilter(e.target.value as SbiFilter)} style={styles.select}>
                   <option value="all">SBI: すべて</option>
-                  <option value="sbi_any">SBI: 売建可</option>
+                  <option value="sbi_any">SBI: 短期対象あり</option>
                 </select>
               )}
               <select value={sortKey} onChange={(e) => setSortKey(e.target.value as SortKey)} style={styles.select}>

--- a/docs/decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md
+++ b/docs/decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md
@@ -1,0 +1,36 @@
+# 2026-04-05 yutai-candidates の SBI 短期対象表示ルール
+
+## 背景
+
+- `yutai-candidates` で SBI 一般信用データを表示しているが、`latest.json` には日計り・ハイパー・短期・長期が混在している。
+- 画面では「15営業日短期売りとして扱っているか」を知りたい一方、在庫は日々変動するため、在庫状態まで表示条件に入れると月別候補の見え方が不安定になる。
+- 実際に `is_short=true` の銘柄でも `position_status=unavailable` の日に画面から消えてしまい、利用意図とズレていた。
+
+## 今回決めたこと
+
+- `yutai-candidates` では SBI データの扱い有無を `is_short=true` だけで判定する。
+- `position_status` による在庫あり・残少・在庫なしの違いは、表示条件にもフィルタ条件にも使わない。
+- UI 上の SBI 表示は「SBI短期対象」の 1 種類だけにし、「扱っているか / 扱っていないか」だけを示す。
+
+## 判断理由
+
+- ユーザーが確認したいのは、その銘柄を SBI の短期売り対象として扱っているかどうかであり、当日の在庫変動ではない。
+- 在庫状態を表示条件に含めると、同じ月の候補一覧が日によって増減し、月次候補比較やピック作業の一貫性が落ちる。
+- 在庫状態は変動値なので、扱い有無のような安定した属性と分けて扱う方が UI の意味が明確になる。
+
+## 影響範囲
+
+- [ToolClient.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/yutai-candidates/ToolClient.tsx)
+- `SBI` フィルタ文言は「売建可」ではなく「短期対象あり」に変更する。
+- `SBI` バッジは在庫状態を区別せず、「SBI短期対象」のみ表示する。
+
+## 残課題
+
+- API の `position_status` 文字列は `available` / `unavailable` 以外に API 依存値を返すことがあるため、将来 UI で在庫状態を再度扱う場合は contract を別途固定する。
+
+## 関連
+
+- Issue:
+- PR:
+- 参照 docs:
+  - [Market Tools データ取得経路一覧](/c:/Users/yutaz/dev/mini-tools/docs/market-tools-data-fetch-paths.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
 - [2026-04-05 jpx-closed endpoint の確定事項](./decision-log/2026-04-05-jpx-closed-endpoint-finalization.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
@@ -46,6 +47,7 @@
 - [mini-tools システム構成概要](./system-architecture-overview.md)
 - [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md)
 - Market Tools 関連:
+- [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
 - [2026-04-05 jpx-closed endpoint の確定事項](./decision-log/2026-04-05-jpx-closed-endpoint-finalization.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)

--- a/docs/market-tools-data-fetch-paths.md
+++ b/docs/market-tools-data-fetch-paths.md
@@ -28,7 +28,7 @@
 | `topix33` | サーバーで `loadTopix33Manifest()` / `loadTopix33DayData()` | クライアントは `/tools/topix33/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/topix33/data` のローカル JSON | 同じデータソースを、SSR と client route の 2 入口で使っている |
 | `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
 | `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | 休場日 API は `GET /market-calendar/jpx-closed` を使う |
-| `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | UI 文言も API 基準に寄せた |
+| `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | SBI は `is_short=true` の扱い有無だけを表示し、在庫状態では除外しない |
 | `earnings-calendar` | サーバーで `app/tools/earnings-calendar/data` のローカル JSON を直接読む | クライアント再 fetch なし | なし | ローカルデータ前提 | 現時点では外部 API を直接読まない |
 
 ## `topix33` の具体的な流れ


### PR DESCRIPTION
## 概要
SBI一般信用の表示を、在庫状態ではなく `is_short=true` の扱い有無だけで判定するように変更します。

## 変更内容
- yutai-candidates の SBI バッジを `SBI短期対象` のみ表示に変更
- SBI フィルタ文言を `短期対象あり` に変更
- 在庫状態で候補を除外しない仕様を decision log と spec に追記

## 確認項目
- `npm run lint`
- 4月候補で `is_short=true` の 16件が在庫状態に関係なく対象になることをコード上で確認
- docs へ判断理由を記録

## 関連 Issue
- なし
