### PR TITLE
feat: add overseas earnings calendar view

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,8 +4,9 @@ NEXT_PUBLIC_GA_ID=
 # market-info-api の base URL（任意）
 # 設定すると market tools のデータを API 経由で取得する。未設定時はローカル JSON fallback。
 # 例: https://market-info-api-619599800912.asia-northeast1.run.app
-# 対象 tool: nikkei-contribution, topix33, stock-ranking, yutai-candidates
+# 対象 tool: nikkei-contribution, topix33, stock-ranking, yutai-candidates, earnings-calendar(海外)
 # 休場日も /market-calendar/jpx-closed から取得する
+# 海外決算は /earnings-calendar/overseas/latest, /manifest, /monthly/{YYYY-MM} を使う
 # response shape: as_of_date, from, to, days[] (date, market_closed, label)
 MARKET_INFO_API_BASE_URL=
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,20 @@ npm run dev
     - `/yutai/monthly/{yearMonth}`
     - `/nikko/credit`
     - `/market-calendar/jpx-closed`
+    - `/earnings-calendar/overseas/latest`
+    - `/earnings-calendar/overseas/manifest`
+    - `/earnings-calendar/overseas/monthly/{yearMonth}`
   - `jpx-closed` の response shape は従来の thin JSON と互換
   - `as_of_date`, `from`, `to`, `days[]`
   - `days[]` は `date`, `market_closed`, `label`
+  - `earnings-calendar/overseas` は `manifest + monthly` を主導線として使い、`latest` は補助表示に使う
   - 未設定時は各 tool の同梱 JSON / sample fallback を使う
   - 参照:
     - `app/tools/topix33/data-loader.ts`
     - `app/tools/nikkei-contribution/data-loader.ts`
     - `app/tools/stock-ranking/data-loader.ts`
     - `app/tools/yutai-candidates/data-loader.ts`
+    - `app/tools/earnings-calendar/data-loader.ts`
     - `lib/jpx-market-closed.ts`
 
 Vercel では次の env を設定しておく運用を推奨します。

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,8 +60,8 @@ const TOOLS: ToolItem[] = [
   },
   {
     title: "決算カレンダー",
-    short: "日本株の決算予定を確認",
-    detail: "日本株の決算予定をカレンダーで確認。日付ごとに銘柄と決算種別を一覧表示。",
+    short: "国内 / 海外の決算予定を確認",
+    detail: "国内株と海外株の決算予定をカレンダーで確認。日付ごとに銘柄と決算種別を一覧表示。",
     href: "/tools/earnings-calendar",
     icon: "🗓️",
   },

--- a/app/tools/earnings-calendar/ToolClient.tsx
+++ b/app/tools/earnings-calendar/ToolClient.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import type { CSSProperties } from "react";
 import type {
   EarningsCalendarDay,
   EarningsCalendarItem,
+  EarningsCalendarMarket,
+  EarningsCalendarMarketData,
+  EarningsCalendarManifest,
   EarningsCalendarManifestMonth,
   EarningsCalendarPageData,
   JpxMarketClosedDay,
@@ -31,6 +35,13 @@ type CalendarMonth = {
   cells: CalendarCell[];
 };
 
+type MarketOption = {
+  key: EarningsCalendarMarket;
+  label: string;
+  shortLabel: string;
+  data: EarningsCalendarMarketData;
+};
+
 const WEEK_LABELS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
 function parseDateKey(key: string) {
@@ -47,11 +58,6 @@ function getWeekdayJa(year: number, month: number, day: number) {
   return ["日", "月", "火", "水", "木", "金", "土"][
     new Date(Date.UTC(year, month - 1, day)).getUTCDay()
   ];
-}
-
-function formatSelectedLabel(key: string) {
-  const { year, month, day } = parseDateKey(key);
-  return `${month}/${day}（${getWeekdayJa(year, month, day)}）`;
 }
 
 function formatSelectedTitle(key: string) {
@@ -266,13 +272,17 @@ function buildMonth(
   };
 }
 
-function buildMonths(data: EarningsCalendarPageData, initialFocusDate: string): CalendarMonth[] {
-  const holidayMap = new Map(data.holidays.days.map((day) => [day.date, day]));
+function buildMonths(data: EarningsCalendarMarketData, initialFocusDate: string): CalendarMonth[] {
+  if (!data.manifest) {
+    return [];
+  }
+
+  const holidayMap = new Map((data.holidays?.days ?? []).map((day) => [day.date, day]));
   const built = data.manifest.months
     .map((entry) => {
       const source = data.monthData[entry.id];
       if (!source) return null;
-      return buildMonth(entry, source.calendar, holidayMap, data.manifest.as_of_date, initialFocusDate);
+      return buildMonth(entry, source.calendar, holidayMap, data.manifest!.as_of_date, initialFocusDate);
     })
     .filter((month): month is CalendarMonth => month !== null);
 
@@ -293,13 +303,18 @@ function buildMonths(data: EarningsCalendarPageData, initialFocusDate: string): 
   const rangeStart = earliestLoaded
     ? { year: earliestLoaded.year, month: earliestLoaded.month }
     : { year: asOfYear, month: asOfMonth };
-  const requestedRangeEnd = addMonths(asOfYear, asOfMonth, 12);
-  const { year: holidayToYear, month: holidayToMonth } = parseDateKey(data.holidays.to);
-  const rangeEnd =
-    requestedRangeEnd.year < holidayToYear ||
-    (requestedRangeEnd.year === holidayToYear && requestedRangeEnd.month <= holidayToMonth)
-      ? requestedRangeEnd
-      : { year: holidayToYear, month: holidayToMonth };
+  const rangeEnd = data.holidays
+    ? (() => {
+        const requestedRangeEnd = addMonths(asOfYear, asOfMonth, 12);
+        const { year: holidayToYear, month: holidayToMonth } = parseDateKey(data.holidays.to);
+        return requestedRangeEnd.year < holidayToYear ||
+          (requestedRangeEnd.year === holidayToYear && requestedRangeEnd.month <= holidayToMonth)
+          ? requestedRangeEnd
+          : { year: holidayToYear, month: holidayToMonth };
+      })()
+    : latestLoaded
+      ? { year: latestLoaded.year, month: latestLoaded.month }
+      : { year: asOfYear, month: asOfMonth };
 
   const months: CalendarMonth[] = [];
   let cursor = { ...rangeStart };
@@ -326,12 +341,12 @@ function buildMonths(data: EarningsCalendarPageData, initialFocusDate: string): 
   return months;
 }
 
-function getEmptyStateMessage(day: CalendarCell) {
+function getEmptyStateMessage(day: CalendarCell, market: EarningsCalendarMarket) {
   if (day.marketClosed) {
     return day.marketClosedLabel ? `JPX休場日です（${day.marketClosedLabel}）` : "JPX休場日です";
   }
   if (day.detailStatus === "missing" || (day.count > 0 && day.items.length === 0)) {
-    return "個別銘柄のデータは未反映です";
+    return market === "overseas" ? "個別銘柄データはまだ反映されていません" : "個別銘柄のデータは未反映です";
   }
   return "決算予定はありません";
 }
@@ -346,46 +361,91 @@ function getEmptyStateTitle(day: CalendarCell) {
   return "決算一覧はありません";
 }
 
+function getInitialFocusDate(data: EarningsCalendarMarketData) {
+  if (!data.manifest) {
+    return todayJstKey();
+  }
+
+  const today = todayJstKey();
+  const todayMonth = today.slice(0, 7);
+  return data.manifest.months.some((month) => month.id === todayMonth) ? today : data.manifest.as_of_date;
+}
+
 export default function ToolClient({ data }: { data: EarningsCalendarPageData }) {
-  const initialFocusDate = useMemo(() => {
-    const today = todayJstKey();
-    const todayMonth = today.slice(0, 7);
-    return data.manifest.months.some((month) => month.id === todayMonth) ? today : data.manifest.as_of_date;
-  }, [data.manifest.as_of_date, data.manifest.months]);
-  const months = useMemo(() => buildMonths(data, initialFocusDate), [data, initialFocusDate]);
-  const initialMonthIndex = useMemo(() => {
-    const targetMonth = initialFocusDate.slice(0, 7);
-    const found = months.findIndex((month) => month.id === targetMonth);
-    return found >= 0 ? found : 0;
-  }, [initialFocusDate, months]);
-  const [monthIndex, setMonthIndex] = useState(initialMonthIndex);
-  const month = months[monthIndex] ?? null;
-  const [selectedKey, setSelectedKey] = useState(months[initialMonthIndex]?.selectedKey ?? "");
+  const markets = useMemo<MarketOption[]>(
+    () =>
+      ([
+        {
+          key: "domestic",
+          label: "国内",
+          shortLabel: "日本株",
+          data: data.domestic,
+        },
+        {
+          key: "overseas",
+          label: "海外",
+          shortLabel: "海外株",
+          data: data.overseas,
+        },
+      ] satisfies MarketOption[]).filter((market) => market.data.manifest),
+    [data],
+  );
 
-  const selectedDay = useMemo(() => {
-    if (!month) return null;
-    return (
-      month.cells.find((cell) => cell.key === selectedKey) ??
-      month.cells.find((cell) => cell.key === month.selectedKey) ??
-      month.cells.find((cell) => !cell.muted && cell.count > 0) ??
-      month.cells.find((cell) => !cell.muted) ??
-      month.cells[0]
-    );
-  }, [month, selectedKey]);
+  const marketMonths = useMemo(
+    () =>
+      Object.fromEntries(
+        ([
+          ["domestic", data.domestic],
+          ["overseas", data.overseas],
+        ] as const).map(([key, marketData]) => [key, buildMonths(marketData, getInitialFocusDate(marketData))]),
+      ) as Record<EarningsCalendarMarket, CalendarMonth[]>,
+    [data],
+  );
 
-  if (!month || !selectedDay) {
+  const initialStates = useMemo(
+    () =>
+      ([
+        ["domestic", data.domestic],
+        ["overseas", data.overseas],
+      ] as const).reduce(
+        (acc, [key, marketData]) => {
+          const focusDate = getInitialFocusDate(marketData);
+          const months = marketMonths[key];
+          const initialMonthIndex = Math.max(
+            0,
+            months.findIndex((month) => month.id === focusDate.slice(0, 7)),
+          );
+          acc[key] = {
+            monthIndex: initialMonthIndex >= 0 ? initialMonthIndex : 0,
+            selectedKey: months[initialMonthIndex]?.selectedKey ?? "",
+          };
+          return acc;
+        },
+        {} as Record<EarningsCalendarMarket, { monthIndex: number; selectedKey: string }>,
+      ),
+    [data, marketMonths],
+  );
+
+  const [selectedMarket, setSelectedMarket] = useState<EarningsCalendarMarket>(markets[0]?.key ?? "domestic");
+  const [marketState, setMarketState] = useState(initialStates);
+  const activeMarket = markets.find((market) => market.key === selectedMarket) ?? null;
+  const months = activeMarket ? marketMonths[activeMarket.key] : [];
+  const activeState = activeMarket ? marketState[activeMarket.key] : null;
+  const month = activeMarket && activeState ? months[activeState.monthIndex] ?? null : null;
+
+  const selectedDay =
+    !month || !activeState
+      ? null
+      : month.cells.find((cell) => cell.key === activeState.selectedKey) ??
+        month.cells.find((cell) => cell.key === month.selectedKey) ??
+        month.cells.find((cell) => !cell.muted && cell.count > 0) ??
+        month.cells.find((cell) => !cell.muted) ??
+        month.cells[0];
+
+  if (!activeMarket || !month || !selectedDay) {
     return (
       <main style={styles.page}>
         <div style={styles.mobileShell}>
-          <header style={styles.headerRow}>
-            <div style={styles.brandRow}>
-              <div style={styles.brandMark} aria-hidden>
-                ■
-              </div>
-              <div style={styles.brandName}>mini-tools</div>
-            </div>
-          </header>
-
           <section style={styles.heroBlock}>
             <div style={styles.heroEyebrow}>決算カレンダー beta</div>
             <h1 style={styles.heroTitle}>決算カレンダー</h1>
@@ -397,7 +457,7 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
           <article style={styles.emptyCard}>
             <div style={styles.emptyTitle}>決算データがまだありません</div>
             <div style={styles.emptyNote}>
-              market_info 側の出力が空だった場合に備えた空状態です。データが更新されたらここに月間カレンダーが表示されます。
+              国内版は同梱 JSON、海外版は market-info API を参照します。データ取得先が整うとここに月間カレンダーが表示されます。
             </div>
           </article>
         </div>
@@ -408,14 +468,37 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
   const selectedItems = selectedDay.items;
   const selectedCount = selectedDay.count;
 
+  function updateMarketState(
+    marketKey: EarningsCalendarMarket,
+    updater: (current: { monthIndex: number; selectedKey: string }) => {
+      monthIndex: number;
+      selectedKey: string;
+    },
+  ) {
+    setMarketState((current) => ({
+      ...current,
+      [marketKey]: updater(current[marketKey]),
+    }));
+  }
+
   function moveMonth(direction: -1 | 1) {
-    if (months.length <= 1) return;
-    setMonthIndex((current) => {
-      const next = Math.min(months.length - 1, Math.max(0, current + direction));
-      if (next === current) return current;
-      setSelectedKey(months[next].selectedKey);
-      return next;
+    if (!activeMarket || months.length <= 1) return;
+    updateMarketState(activeMarket.key, (current) => {
+      const nextIndex = Math.min(months.length - 1, Math.max(0, current.monthIndex + direction));
+      if (nextIndex === current.monthIndex) return current;
+      return {
+        monthIndex: nextIndex,
+        selectedKey: months[nextIndex]?.selectedKey ?? current.selectedKey,
+      };
     });
+  }
+
+  function selectDay(nextKey: string) {
+    if (!activeMarket) return;
+    updateMarketState(activeMarket.key, (current) => ({
+      ...current,
+      selectedKey: nextKey,
+    }));
   }
 
   return (
@@ -425,9 +508,31 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
           <div style={styles.heroEyebrow}>決算カレンダー beta</div>
           <h1 style={styles.heroTitle}>決算カレンダー</h1>
           <p style={styles.heroNote}>
-            月ごとの予定を見ながら、気になる日の決算銘柄を下で確認できます。
+            国内株と海外株の決算予定を月ごとに見ながら、気になる日の銘柄を下で確認できます。
           </p>
         </section>
+
+        {markets.length > 1 ? (
+          <section style={styles.tabRow}>
+            {markets.map((market) => {
+              const isActive = market.key === selectedMarket;
+              return (
+                <button
+                  key={market.key}
+                  type="button"
+                  style={{
+                    ...styles.tabButton,
+                    ...(isActive ? styles.tabButtonActive : {}),
+                  }}
+                  onClick={() => setSelectedMarket(market.key)}
+                >
+                  <span style={styles.tabTitle}>{market.label}</span>
+                  <span style={styles.tabNote}>{market.shortLabel}</span>
+                </button>
+              );
+            })}
+          </section>
+        ) : null}
 
         <section style={styles.calendarCard}>
           <div style={styles.calendarTop}>
@@ -435,10 +540,10 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
               type="button"
               style={{
                 ...styles.navBtn,
-                ...(monthIndex <= 0 ? styles.navBtnDisabled : {}),
+                ...(activeState && activeState.monthIndex <= 0 ? styles.navBtnDisabled : {}),
               }}
               onClick={() => moveMonth(-1)}
-              disabled={monthIndex <= 0}
+              disabled={!activeState || activeState.monthIndex <= 0}
               aria-label="前月へ"
             >
               ‹
@@ -448,10 +553,10 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
               type="button"
               style={{
                 ...styles.navBtn,
-                ...(monthIndex >= months.length - 1 ? styles.navBtnDisabled : {}),
+                ...(activeState && activeState.monthIndex >= months.length - 1 ? styles.navBtnDisabled : {}),
               }}
               onClick={() => moveMonth(1)}
-              disabled={monthIndex >= months.length - 1}
+              disabled={!activeState || activeState.monthIndex >= months.length - 1}
               aria-label="次月へ"
             >
               ›
@@ -459,9 +564,10 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
           </div>
 
           <div style={styles.calendarMeta}>
-            <span style={styles.metaChip}>日本株</span>
+            <span style={styles.metaChip}>{activeMarket.shortLabel}</span>
             <span style={styles.metaChipMuted}>月間ビュー</span>
             <span style={styles.metaChipStrong}>今月 {month.totalCount}件</span>
+            {month.partial ? <span style={styles.metaChipWarn}>一部反映</span> : null}
           </div>
 
           <div style={styles.weekHeader}>
@@ -490,7 +596,7 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
                     ...(isClickable ? styles.dayClickable : {}),
                   }}
                   disabled={!isClickable}
-                  onClick={() => setSelectedKey(item.key)}
+                  onClick={() => selectDay(item.key)}
                 >
                   <div style={styles.dayNumber}>{item.day}</div>
                   {item.count > 0 ? (
@@ -529,7 +635,7 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
           {selectedItems.length === 0 ? (
             <article style={styles.emptyCard}>
               <div style={styles.emptyTitle}>{getEmptyStateTitle(selectedDay)}</div>
-              <div style={styles.emptyNote}>{getEmptyStateMessage(selectedDay)}</div>
+              <div style={styles.emptyNote}>{getEmptyStateMessage(selectedDay, activeMarket.key)}</div>
             </article>
           ) : (
             selectedItems.map((item, index) => (
@@ -564,7 +670,7 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
   );
 }
 
-const styles: Record<string, React.CSSProperties> = {
+const styles: Record<string, CSSProperties> = {
   page: {
     minHeight: "100vh",
     padding: "18px 12px 56px",
@@ -626,6 +732,41 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 13,
     lineHeight: 1.6,
     color: "#667085",
+  },
+  tabRow: {
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: 10,
+    marginBottom: 12,
+  },
+  tabButton: {
+    border: "1px solid rgba(15, 23, 42, 0.08)",
+    borderRadius: 16,
+    background: "rgba(255, 255, 255, 0.84)",
+    padding: "8px 14px 7px",
+    textAlign: "left",
+    cursor: "pointer",
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    minHeight: 0,
+  },
+  tabButtonActive: {
+    background: "#f3f7ff",
+    border: "1px solid rgba(37, 84, 255, 0.2)",
+    boxShadow: "0 10px 26px rgba(37, 84, 255, 0.08)",
+  },
+  tabTitle: {
+    fontSize: 13,
+    fontWeight: 800,
+    color: "#1f2937",
+    lineHeight: 1.2,
+  },
+  tabNote: {
+    fontSize: 10,
+    color: "#64748b",
+    fontWeight: 700,
+    lineHeight: 1.2,
   },
   calendarCard: {
     background: "#fff",
@@ -696,6 +837,16 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: 999,
     background: "#e7edff",
     color: "#2f47ca",
+    fontSize: 11,
+    fontWeight: 800,
+  },
+  metaChipWarn: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "4px 8px",
+    borderRadius: 999,
+    background: "#fff7ed",
+    color: "#c2410c",
     fontSize: 11,
     fontWeight: 800,
   },

--- a/app/tools/earnings-calendar/data-loader.ts
+++ b/app/tools/earnings-calendar/data-loader.ts
@@ -1,0 +1,196 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  EarningsCalendarManifest,
+  EarningsCalendarItem,
+  EarningsCalendarMarketData,
+  EarningsCalendarDay,
+  EarningsCalendarPageData,
+  EarningsCalendarResponse,
+  JpxMarketClosedResponse,
+  OverseasEarningsCalendarItem,
+  OverseasEarningsCalendarResponse,
+} from "./types";
+
+function getDataDir() {
+  return path.join(process.cwd(), "app/tools/earnings-calendar/data");
+}
+
+function getApiBaseUrl() {
+  return process.env.MARKET_INFO_API_BASE_URL?.trim().replace(/\/+$/, "") ?? "";
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      next: { revalidate: 300 },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+    }
+
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function loadLocalDomesticManifest(): Promise<EarningsCalendarManifest> {
+  const raw = await readFile(path.join(getDataDir(), "manifest.json"), "utf-8");
+  return JSON.parse(raw) as EarningsCalendarManifest;
+}
+
+async function loadLocalDomesticMonthDataByPath(filePath: string): Promise<EarningsCalendarResponse> {
+  const raw = await readFile(path.join(getDataDir(), filePath), "utf-8");
+  return JSON.parse(raw) as EarningsCalendarResponse;
+}
+
+async function loadLocalDomesticLatest(): Promise<EarningsCalendarResponse | null> {
+  try {
+    const raw = await readFile(path.join(getDataDir(), "latest.json"), "utf-8");
+    return JSON.parse(raw) as EarningsCalendarResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function loadLocalDomesticHolidays(): Promise<JpxMarketClosedResponse | null> {
+  try {
+    const raw = await readFile(
+      path.join(getDataDir(), "jpx_market_closed_20260101_to_20271231.json"),
+      "utf-8",
+    );
+    return JSON.parse(raw) as JpxMarketClosedResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function loadDomesticData(): Promise<EarningsCalendarMarketData> {
+  const manifest = await loadLocalDomesticManifest();
+  const monthEntries = await Promise.all(
+    manifest.months.map(async (entry) => {
+      const monthData = await loadLocalDomesticMonthDataByPath(entry.path);
+      return [entry.id, monthData] as const;
+    }),
+  );
+  const [latest, holidays] = await Promise.all([
+    loadLocalDomesticLatest(),
+    loadLocalDomesticHolidays(),
+  ]);
+
+  return {
+    manifest,
+    monthData: Object.fromEntries(monthEntries),
+    latest,
+    holidays,
+  };
+}
+
+async function loadOverseasManifest(): Promise<EarningsCalendarManifest | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<EarningsCalendarManifest>(`${apiBase}/earnings-calendar/overseas/manifest`);
+  } catch {
+    return null;
+  }
+}
+
+async function loadOverseasLatest(): Promise<EarningsCalendarResponse | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    const raw = await fetchJson<OverseasEarningsCalendarResponse>(`${apiBase}/earnings-calendar/overseas/latest`);
+    return normalizeOverseasResponse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function loadOverseasMonthData(yearMonth: string): Promise<EarningsCalendarResponse | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    const raw = await fetchJson<OverseasEarningsCalendarResponse>(
+      `${apiBase}/earnings-calendar/overseas/monthly/${yearMonth}`,
+    );
+    return normalizeOverseasResponse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeOverseasItem(item: OverseasEarningsCalendarItem): EarningsCalendarItem {
+  return {
+    event_id: item.event_id,
+    time: item.local_time ?? "",
+    code: item.ticker ?? "",
+    name: item.stock_name ?? "",
+    market: item.exchange_code ?? item.country_code ?? "",
+    announcement_type: item.fiscal_term_name ?? item.fiscal_term ?? "",
+    publish_status: item.sch_flg === "1" ? "予定" : "発表予定",
+    progress_status: item.country_code ?? "",
+  };
+}
+
+function normalizeOverseasDay(day: OverseasEarningsCalendarResponse["calendar"][number]): EarningsCalendarDay {
+  return {
+    date: day.date,
+    count: day.count,
+    detail_status: day.detail_status,
+    items: day.items.map(normalizeOverseasItem),
+  };
+}
+
+function normalizeOverseasResponse(response: OverseasEarningsCalendarResponse): EarningsCalendarResponse {
+  return {
+    as_of_date: response.as_of_date,
+    calendar: response.calendar.map(normalizeOverseasDay),
+  };
+}
+
+async function loadOverseasData(): Promise<EarningsCalendarMarketData> {
+  const manifest = await loadOverseasManifest();
+  const latest = await loadOverseasLatest();
+
+  if (!manifest) {
+    return {
+      manifest: null,
+      monthData: {},
+      latest,
+      holidays: null,
+    };
+  }
+
+  const monthEntries = await Promise.all(
+    manifest.months.map(async (entry) => {
+      const monthData = await loadOverseasMonthData(entry.id);
+      return monthData ? ([entry.id, monthData] as const) : null;
+    }),
+  );
+
+  return {
+    manifest,
+    monthData: Object.fromEntries(monthEntries.filter((entry) => entry !== null)),
+    latest,
+    holidays: null,
+  };
+}
+
+export async function loadEarningsCalendarPageData(): Promise<EarningsCalendarPageData> {
+  const [domestic, overseas] = await Promise.all([loadDomesticData(), loadOverseasData()]);
+
+  return {
+    domestic,
+    overseas,
+  };
+}

--- a/app/tools/earnings-calendar/page.tsx
+++ b/app/tools/earnings-calendar/page.tsx
@@ -1,49 +1,17 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import type { Metadata } from "next";
 import ToolClient from "./ToolClient";
-import type {
-  EarningsCalendarManifest,
-  EarningsCalendarPageData,
-  EarningsCalendarResponse,
-  JpxMarketClosedResponse,
-} from "./types";
+import { loadEarningsCalendarPageData } from "./data-loader";
 
 export const metadata: Metadata = {
   title: "決算カレンダー | mini-tools",
   description:
-    "日本株の決算予定を日付ベースで確認できる決算カレンダー。market_info の整形データをもとに、月間カレンダーと日別一覧で見やすく表示します。",
+    "国内株と海外株の決算予定を日付ベースで確認できる決算カレンダー。market_info の整形データをもとに、月間カレンダーと日別一覧で見やすく表示します。",
   alternates: {
     canonical: "/tools/earnings-calendar",
   },
 };
 
-async function loadCalendarData(): Promise<EarningsCalendarPageData> {
-  const dataDir = path.join(process.cwd(), "app/tools/earnings-calendar/data");
-  const manifestPath = path.join(dataDir, "manifest.json");
-  const manifestRaw = await readFile(manifestPath, "utf-8");
-  const manifest = JSON.parse(manifestRaw) as EarningsCalendarManifest;
-
-  const monthEntries = await Promise.all(
-    manifest.months.map(async (entry) => {
-      const raw = await readFile(path.join(dataDir, entry.path), "utf-8");
-      return [entry.id, JSON.parse(raw) as EarningsCalendarResponse] as const;
-    }),
-  );
-  const holidayRaw = await readFile(
-    path.join(dataDir, "jpx_market_closed_20260101_to_20271231.json"),
-    "utf-8",
-  );
-  const holidays = JSON.parse(holidayRaw) as JpxMarketClosedResponse;
-
-  return {
-    manifest,
-    monthData: Object.fromEntries(monthEntries),
-    holidays,
-  };
-}
-
 export default async function Page() {
-  const data = await loadCalendarData();
+  const data = await loadEarningsCalendarPageData();
   return <ToolClient data={data} />;
 }

--- a/app/tools/earnings-calendar/types.ts
+++ b/app/tools/earnings-calendar/types.ts
@@ -23,6 +23,30 @@ export type EarningsCalendarResponse = {
   calendar: EarningsCalendarDay[];
 };
 
+export type OverseasEarningsCalendarItem = {
+  event_id?: string;
+  local_time?: string;
+  ticker?: string;
+  stock_name?: string;
+  exchange_code?: string;
+  fiscal_term_name?: string;
+  fiscal_term?: string;
+  sch_flg?: string;
+  country_code?: string;
+};
+
+export type OverseasEarningsCalendarDay = {
+  date: string;
+  count: number;
+  detail_status: EarningsCalendarDetailStatus;
+  items: OverseasEarningsCalendarItem[];
+};
+
+export type OverseasEarningsCalendarResponse = {
+  as_of_date: string;
+  calendar: OverseasEarningsCalendarDay[];
+};
+
 export type EarningsCalendarManifestMonth = {
   id: string;
   year: number;
@@ -41,10 +65,18 @@ export type EarningsCalendarManifest = {
   months: EarningsCalendarManifestMonth[];
 };
 
-export type EarningsCalendarPageData = {
-  manifest: EarningsCalendarManifest;
+export type EarningsCalendarMarket = "domestic" | "overseas";
+
+export type EarningsCalendarMarketData = {
+  manifest: EarningsCalendarManifest | null;
   monthData: Record<string, EarningsCalendarResponse>;
-  holidays: JpxMarketClosedResponse;
+  latest: EarningsCalendarResponse | null;
+  holidays: JpxMarketClosedResponse | null;
+};
+
+export type EarningsCalendarPageData = {
+  domestic: EarningsCalendarMarketData;
+  overseas: EarningsCalendarMarketData;
 };
 
 export type JpxMarketClosedDay = {

--- a/docs/decision-log/2026-04-05-overseas-earnings-calendar-integration.md
+++ b/docs/decision-log/2026-04-05-overseas-earnings-calendar-integration.md
@@ -1,0 +1,100 @@
+# 2026-04-05 海外決算カレンダー統合方針
+
+## 背景
+
+`market-info-api` 側で海外決算カレンダー API が `main` にマージされた。  
+`mini-tools` 側では既存の国内決算カレンダーがあり、別 tool に分けるか、同一画面に統合するかを決める必要があった。
+
+利用可能になった endpoint:
+
+- `GET /earnings-calendar/overseas/latest`
+- `GET /earnings-calendar/overseas/manifest`
+- `GET /earnings-calendar/overseas/monthly/{YYYY-MM}`
+
+## 決めたこと
+
+### 1. UI は既存の決算カレンダーに統合する
+
+- `mini-tools` 側では `/tools/earnings-calendar` を維持し、画面内で `国内 / 海外` を切り替える
+- 「国内版と海外版で別 tool を増やす」よりも、比較しやすさと導線の少なさを優先する
+
+### 2. 主導線は `manifest + monthly` にする
+
+海外版でも、国内版と同じく UI の主導線は次で統一する。
+
+- `manifest`
+  - 利用可能月一覧を決める
+  - `current_window` を確認する
+  - 月タブ / 月移動の対象範囲を決める
+- `monthly/{YYYY-MM}`
+  - 月間カレンダーと日別一覧の本体データとして使う
+
+### 3. `latest` は補助用途として扱う
+
+- `latest` は「最新スナップショット全体」を素早く出したい用途に向いている
+- ただし月間 UI の主経路には使わず、最新件数や補助情報の表示に留める
+
+### 4. `year_month` は mini-tools 側でも `YYYY-MM` を正とする
+
+- route / loader / UI いずれも `YYYY-MM` 前提で扱う
+- 不正形式は upstream で `422`
+- 存在しない月は upstream で `404`
+- UI ではユーザーに raw error を見せず、「その月のデータはまだありません」に寄せて扱う
+
+### 5. 海外 monthly item は mini-tools 側で UI 用 shape に正規化する
+
+live API 確認の結果、海外 `monthly/{YYYY-MM}` の `items[]` は国内版と別 field 名で返っていた。
+
+- 海外:
+  - `local_time`
+  - `ticker`
+  - `stock_name`
+  - `exchange_code`
+  - `fiscal_term_name`
+- 国内 UI が期待する shape:
+  - `time`
+  - `code`
+  - `name`
+  - `market`
+  - `announcement_type`
+
+このため `mini-tools` 側の loader で次の対応を行う。
+
+- `local_time` -> `time`
+- `ticker` -> `code`
+- `stock_name` -> `name`
+- `exchange_code` -> `market`
+- `fiscal_term_name` -> `announcement_type`
+
+補足:
+
+- `event_id` はそのまま利用する
+- `publish_status` は `sch_flg` から画面表示用に補完する
+- `progress_status` は海外版では UI 主用途がないため、`country_code` を退避的に保持する
+
+## 理由
+
+### 1. 既存の国内版とデータ構造が近い
+
+国内版もすでに `manifest + month JSON` を前提にしているため、海外版だけ別の導線にすると実装も説明も増える。
+
+### 2. market tools の API 統一方針と相性が良い
+
+`mini-tools` では market tools の取得入口を `MARKET_INFO_API_BASE_URL` に寄せていく方針を採っている。  
+海外決算もこの流れに乗せることで、loader の責務を揃えやすい。
+
+### 3. `latest` 直読より月単位 UI の方が自然
+
+`latest` は current window 全体把握には便利だが、月切替・過去月参照・空月表示を考えると、UI の基準は `manifest + monthly` の方が扱いやすい。
+
+## 影響範囲
+
+- `app/tools/earnings-calendar`
+- `README.md`
+- `docs/system-architecture-overview.md`
+- `docs/market-tools-data-fetch-paths.md`
+
+## 補足
+
+現時点では国内版の元データは repo 同梱 JSON を維持し、海外版のみ `market-info-api` から取得する。  
+将来的に国内版も API 化する場合は、同じ page / client 構成のまま loader の取得先だけ差し替える。

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 設計・方針・トレードオフの判断理由を記録します。
 
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
+- [2026-04-05 海外決算カレンダー統合方針](./decision-log/2026-04-05-overseas-earnings-calendar-integration.md)
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
 - [2026-04-05 jpx-closed endpoint の確定事項](./decision-log/2026-04-05-jpx-closed-endpoint-finalization.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)
@@ -48,6 +49,7 @@
 - [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md)
 - Market Tools 関連:
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
+- [2026-04-05 海外決算カレンダー統合方針](./decision-log/2026-04-05-overseas-earnings-calendar-integration.md)
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
 - [2026-04-05 jpx-closed endpoint の確定事項](./decision-log/2026-04-05-jpx-closed-endpoint-finalization.md)
 - [2026-04-04 TOPIX33 premium 可視化の見せ方方針](./decision-log/2026-04-04-topix33-premium-visualization-plan.md)

--- a/docs/market-tools-data-fetch-paths.md
+++ b/docs/market-tools-data-fetch-paths.md
@@ -29,7 +29,7 @@
 | `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
 | `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | 休場日 API は `GET /market-calendar/jpx-closed` を使う |
 | `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | SBI は `is_short=true` の扱い有無だけを表示し、在庫状態では除外しない |
-| `earnings-calendar` | サーバーで `app/tools/earnings-calendar/data` のローカル JSON を直接読む | クライアント再 fetch なし | なし | ローカルデータ前提 | 現時点では外部 API を直接読まない |
+| `earnings-calendar` | サーバーで `loadEarningsCalendarPageData()` を呼ぶ | クライアント再 fetch なし | `MARKET_INFO_API_BASE_URL` | あり。国内は同梱 JSON、海外は API 未設定/失敗時は非表示 | 国内は repo 同梱 JSON、海外は `earnings-calendar/overseas/*` API を読む |
 
 ## `topix33` の具体的な流れ
 

--- a/docs/system-architecture-overview.md
+++ b/docs/system-architecture-overview.md
@@ -96,6 +96,7 @@ UI は主に `app/` と `components/` にあります。
 - [app/tools/nikkei-contribution/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/nikkei-contribution/data-loader.ts)
 - [app/tools/stock-ranking/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/stock-ranking/data-loader.ts)
 - [app/tools/yutai-candidates/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/yutai-candidates/data-loader.ts)
+- [app/tools/earnings-calendar/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/earnings-calendar/data-loader.ts)
 
 責務は次の通りです。
 
@@ -185,6 +186,7 @@ premium は現時点では「仮ログイン + preview 画面」です。
 - `mini-tools` は Next.js 単一アプリで動いている
 - tool ごとに server component と client component を使い分けている
 - market tools は外部 API またはローカル JSON fallback を使う
+- 決算カレンダーは国内版を同梱 JSON、海外版を market-info API で読み分ける
 - premium は Cookie ベースの簡易認証
 
 ### この repo だけでは断定できないこと


### PR DESCRIPTION
## 概要

`mini-tools` の決算カレンダーに海外タブを追加し、`market-info-api` の海外決算 API を使って月間カレンダーと日別一覧を表示できるようにしました。

## 変更内容

- `earnings-calendar` に国内 / 海外タブを追加
- 海外 `manifest` / `monthly` / `latest` を読む loader を追加
- 海外 `items` の field 名差分を UI 共通 shape に正規化
- ノイズになっていた補助表示を削除し、タブ UI の縦幅を圧縮
- API 利用方針と item shape 差分を docs に追記

## 確認項目

- `npm run lint`
- `npm run build`
- live API で `GET /earnings-calendar/overseas/manifest` を確認
- live API で `GET /earnings-calendar/overseas/monthly/2026-04` を確認

## 関連 Issue

- なし
