### PR TITLE
feat(ux): add loading.tsx and parallelize manifest fetch

### DIFF
--- a/app/tools/earnings-calendar/loading.tsx
+++ b/app/tools/earnings-calendar/loading.tsx
@@ -1,0 +1,83 @@
+export default function Loading() {
+  return (
+    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+      <div style={{ padding: "32px 0 24px" }}>
+        <div style={{
+          width: 160,
+          height: 28,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          marginBottom: 8,
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+        <div style={{
+          width: 200,
+          height: 14,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[80, 80].map((w, i) => (
+          <div key={i} style={{
+            width: w,
+            height: 32,
+            borderRadius: 8,
+            background: "var(--color-border)",
+            animation: "skeleton-pulse 1.4s ease-in-out infinite",
+          }} />
+        ))}
+      </div>
+
+      <div style={{
+        borderRadius: 12,
+        border: "1px solid var(--color-border)",
+        background: "var(--color-bg-card)",
+        overflow: "hidden",
+      }}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "14px 16px",
+            borderBottom: i < 7 ? "1px solid var(--color-border)" : "none",
+          }}>
+            <div style={{
+              width: 48,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              flex: 1,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              width: 56,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/tools/nikkei-contribution/loading.tsx
+++ b/app/tools/nikkei-contribution/loading.tsx
@@ -1,0 +1,84 @@
+export default function Loading() {
+  return (
+    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+      <div style={{ padding: "32px 0 24px" }}>
+        <div style={{
+          width: 180,
+          height: 28,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          marginBottom: 8,
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+        <div style={{
+          width: 260,
+          height: 14,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[100, 80].map((w, i) => (
+          <div key={i} style={{
+            width: w,
+            height: 32,
+            borderRadius: 8,
+            background: "var(--color-border)",
+            animation: "skeleton-pulse 1.4s ease-in-out infinite",
+          }} />
+        ))}
+      </div>
+
+      <div style={{
+        borderRadius: 12,
+        border: "1px solid var(--color-border)",
+        background: "var(--color-bg-card)",
+        overflow: "hidden",
+        marginBottom: 20,
+      }}>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "12px 16px",
+            borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
+          }}>
+            <div style={{
+              width: 24,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              flex: 1,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              width: 72,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/tools/nikkei-contribution/page.tsx
+++ b/app/tools/nikkei-contribution/page.tsx
@@ -34,8 +34,10 @@ function isLikelyMarketClosed(dayData: NikkeiContributionPageData["initialDayDat
 }
 
 async function loadData(): Promise<NikkeiContributionPageData> {
-  const manifest = await loadContributionManifest();
-  const holidays = await loadJpxMarketClosedData();
+  const [manifest, holidays] = await Promise.all([
+    loadContributionManifest(),
+    loadJpxMarketClosedData(),
+  ]);
 
   const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
   const visibleDates = manifest.dates.filter((date) => {

--- a/app/tools/stock-ranking/loading.tsx
+++ b/app/tools/stock-ranking/loading.tsx
@@ -1,0 +1,95 @@
+export default function Loading() {
+  return (
+    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+      <div style={{ padding: "32px 0 24px" }}>
+        <div style={{
+          width: 160,
+          height: 28,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          marginBottom: 8,
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+        <div style={{
+          width: 240,
+          height: 14,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[80, 100, 80].map((w, i) => (
+          <div key={i} style={{
+            width: w,
+            height: 32,
+            borderRadius: 8,
+            background: "var(--color-border)",
+            animation: "skeleton-pulse 1.4s ease-in-out infinite",
+          }} />
+        ))}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[90, 110, 72].map((w, i) => (
+          <div key={i} style={{
+            width: w,
+            height: 32,
+            borderRadius: 8,
+            background: "var(--color-border)",
+            animation: "skeleton-pulse 1.4s ease-in-out infinite",
+          }} />
+        ))}
+      </div>
+
+      <div style={{
+        borderRadius: 12,
+        border: "1px solid var(--color-border)",
+        background: "var(--color-bg-card)",
+        overflow: "hidden",
+      }}>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "12px 16px",
+            borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
+          }}>
+            <div style={{
+              width: 24,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              flex: 1,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              width: 60,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/tools/stock-ranking/page.tsx
+++ b/app/tools/stock-ranking/page.tsx
@@ -24,8 +24,10 @@ function isWeekendDate(dateStr: string) {
 }
 
 async function loadData(): Promise<RankingPageData> {
-  const manifest = await loadRankingManifest();
-  const holidays = await loadJpxMarketClosedData();
+  const [manifest, holidays] = await Promise.all([
+    loadRankingManifest(),
+    loadJpxMarketClosedData(),
+  ]);
 
   const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
   const visibleDates = manifest.dates.filter((date) => {

--- a/app/tools/topix33/loading.tsx
+++ b/app/tools/topix33/loading.tsx
@@ -1,0 +1,83 @@
+export default function Loading() {
+  return (
+    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+      <div style={{ padding: "32px 0 24px" }}>
+        <div style={{
+          width: 160,
+          height: 28,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          marginBottom: 8,
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+        <div style={{
+          width: 220,
+          height: 14,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[100, 80].map((w, i) => (
+          <div key={i} style={{
+            width: w,
+            height: 32,
+            borderRadius: 8,
+            background: "var(--color-border)",
+            animation: "skeleton-pulse 1.4s ease-in-out infinite",
+          }} />
+        ))}
+      </div>
+
+      <div style={{
+        borderRadius: 12,
+        border: "1px solid var(--color-border)",
+        background: "var(--color-bg-card)",
+        overflow: "hidden",
+      }}>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div key={i} style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "12px 16px",
+            borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
+          }}>
+            <div style={{
+              width: 24,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              flex: 1,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              width: 64,
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              flexShrink: 0,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/tools/topix33/page.tsx
+++ b/app/tools/topix33/page.tsx
@@ -24,8 +24,10 @@ function isWeekendDate(dateStr: string) {
 }
 
 async function loadData(): Promise<Topix33PageData> {
-  const manifest = await loadTopix33Manifest();
-  const holidays = await loadJpxMarketClosedData();
+  const [manifest, holidays] = await Promise.all([
+    loadTopix33Manifest(),
+    loadJpxMarketClosedData(),
+  ]);
 
   const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
   const visibleDates = manifest.dates.filter((date) => {

--- a/app/tools/yutai-candidates/loading.tsx
+++ b/app/tools/yutai-candidates/loading.tsx
@@ -1,0 +1,73 @@
+export default function Loading() {
+  return (
+    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+      <div style={{ padding: "32px 0 24px" }}>
+        <div style={{
+          width: 160,
+          height: 28,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          marginBottom: 8,
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+        <div style={{
+          width: 200,
+          height: 14,
+          borderRadius: 6,
+          background: "var(--color-border)",
+          animation: "skeleton-pulse 1.4s ease-in-out infinite",
+        }} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[56, 56, 56, 56].map((w, i) => (
+          <div key={i} style={{
+            width: w,
+            height: 32,
+            borderRadius: 8,
+            background: "var(--color-border)",
+            animation: "skeleton-pulse 1.4s ease-in-out infinite",
+          }} />
+        ))}
+      </div>
+
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+        gap: 10,
+      }}>
+        {Array.from({ length: 12 }).map((_, i) => (
+          <div key={i} style={{
+            borderRadius: 10,
+            border: "1px solid var(--color-border)",
+            background: "var(--color-bg-card)",
+            padding: "12px 14px",
+          }}>
+            <div style={{
+              width: 40,
+              height: 12,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              marginBottom: 8,
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+            <div style={{
+              width: "80%",
+              height: 16,
+              borderRadius: 4,
+              background: "var(--color-border)",
+              animation: "skeleton-pulse 1.4s ease-in-out infinite",
+            }} />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/docs/decision-log/2026-04-07-loading-ui-and-parallel-fetch.md
+++ b/docs/decision-log/2026-04-07-loading-ui-and-parallel-fetch.md
@@ -1,0 +1,60 @@
+# 2026-04-07 loading.tsx 追加と並列 fetch 化
+
+## 背景
+
+- TOP から「株価ランキング」等の market tools をタップすると、画面遷移が始まる前に一瞬止まって見える問題が報告された
+- 原因を調査した結果、2 つの要因が重なっていた：
+  1. `loading.tsx` が存在せず、サーバー側の `loadData()` が完了するまで Next.js が旧画面を維持し続ける
+  2. `loadRankingManifest()` と `loadJpxMarketClosedData()` などの独立した fetch が直列 `await` で実行されていた
+
+## 今回決めたこと
+
+### loading.tsx の追加対象
+
+`async` Server Component をもつ全 5 ページに `loading.tsx` を追加する。
+
+| ページ | loading.tsx | 備考 |
+|---|---|---|
+| `stock-ranking` | ✅ 追加 | |
+| `nikkei-contribution` | ✅ 追加 | |
+| `topix33` | ✅ 追加 | |
+| `earnings-calendar` | ✅ 追加 | |
+| `yutai-candidates` | ✅ 追加 | searchParams あり、同様に効果あり |
+| `total` | — 不要 | Client Component のみ |
+| `charcount` | — 不要 | Client Component のみ |
+| `yutai-memo` | — 不要 | Client Component のみ |
+| `yutai-expiry` | — 不要 | Client Component のみ |
+
+### Promise.all 化の対象
+
+manifest fetch と jpx-closed fetch の 2 つを並列化できる 3 ページに適用。
+
+| ページ | 変更 |
+|---|---|
+| `stock-ranking` | `loadRankingManifest()` + `loadJpxMarketClosedData()` を `Promise.all` 化 |
+| `nikkei-contribution` | `loadContributionManifest()` + `loadJpxMarketClosedData()` を `Promise.all` 化 |
+| `topix33` | `loadTopix33Manifest()` + `loadJpxMarketClosedData()` を `Promise.all` 化 |
+| `earnings-calendar` | fetch が 1 つのみ → 変更なし |
+| `yutai-candidates` | fetch が 1 つのみ → 変更なし |
+
+## 判断理由
+
+- `loading.tsx` を置くだけで Next.js App Router が即時ローディング UI を表示する仕組みになる。実装コストが最小で、体感の改善効果が最大
+- Client Component ページは SSR fetch がなく遷移が即座に始まるため対象外
+- `nikkei-contribution` の先頭日付ループ（有効データ探索）は件数が少ない通常時は問題ないため今回は変更しない
+
+## 影響範囲
+
+- 各 `loading.tsx` は pure Server Component として扱われる（`"use client"` 不要）
+- ローディング中は旧画面ではなく `loading.tsx` のスケルトン UI が表示される
+- `Promise.all` 化により manifest + jpx-closed の fetch が並列実行されるため、API レスポンス待機時間が短縮される
+
+## 残課題
+
+- `nikkei-contribution` の先頭日付ループは API レスポンスが遅い場合に積み重なる可能性がある。件数増加時に要再検討
+- `loading.tsx` のスケルトンは実際のレイアウトとの差分が大きい場合は見直す
+
+## 関連
+
+- PR: （このコミットの PR を参照）
+- 参照 docs: [Market Tools データ取得経路一覧](../market-tools-data-fetch-paths.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
 - [2026-04-05 海外決算カレンダー統合方針](./decision-log/2026-04-05-overseas-earnings-calendar-integration.md)
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)
@@ -48,6 +49,7 @@
 - [mini-tools システム構成概要](./system-architecture-overview.md)
 - [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md)
 - Market Tools 関連:
+- [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
 - [2026-04-05 海外決算カレンダー統合方針](./decision-log/2026-04-05-overseas-earnings-calendar-integration.md)
 - [2026-04-04 market tools の API 統一方針](./decision-log/2026-04-04-market-tools-api-unification-plan.md)


### PR DESCRIPTION
## 概要

TOP から market tools へ遷移する際に「画面が止まって見える」問題を解消する。

## 変更内容

### loading.tsx 追加（5 ページ）

`async` Server Component を持つ全ページに `loading.tsx` スケルトン UI を追加。
クリック直後から Next.js が即時ローディング UI を表示するようになる。

| ページ | 対応 |
|---|---|
| `stock-ranking` | ✅ 追加 |
| `nikkei-contribution` | ✅ 追加 |
| `topix33` | ✅ 追加 |
| `earnings-calendar` | ✅ 追加 |
| `yutai-candidates` | ✅ 追加 |

### Promise.all 化（3 ページの page.tsx）

manifest fetch と `loadJpxMarketClosedData` が独立しているページで並列化。

- `stock-ranking/page.tsx`
- `nikkei-contribution/page.tsx`
- `topix33/page.tsx`

### docs

- `docs/decision-log/2026-04-07-loading-ui-and-parallel-fetch.md` 追加
- `docs/index.md` にリンク追記

## 確認項目

- [x] `npm run lint` パス
- [ ] TOP → 各 market tool への遷移でスケルトン UI が即時表示されること
- [ ] 各ページがデータ読み込み後に正常に表示されること
