### PR TITLE
refactor(ShareButtons): URL生成を resolveShareUrl に統合し window 依存を整理

### DIFF
--- a/components/ShareButtons.tsx
+++ b/components/ShareButtons.tsx
@@ -37,12 +37,14 @@ function resolveShareUrl(
   const qs = searchParams?.toString();
   const pathWithQuery = `${pathname}${qs ? `?${qs}` : ""}`;
   const base =
-    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim().replace(/\/+$/, "") ||
     (typeof window !== "undefined" ? window.location.origin : "");
 
   try {
     return new URL(pathWithQuery, base).href;
   } catch {
+    // base が取得できない SSR 初期レンダリング時は相対パスにフォールバック。
+    // クライアント再レンダリング時には window.location.origin が base に入るため絶対 URL になる。
     return pathWithQuery;
   }
 }

--- a/components/ShareButtons.tsx
+++ b/components/ShareButtons.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { track } from "@/lib/analytics";
 import { QRCodeCanvas } from "qrcode.react";
@@ -22,6 +22,31 @@ type Props = {
 
 const DEFAULT_METHODS: ShareMethod[] = ["x", "facebook", "email", "copy"];
 
+/**
+ * pathname + searchParams から共有用の絶対 URL を生成する。
+ * NEXT_PUBLIC_SITE_URL があればそれを base にし、なければ window.location.origin にフォールバックする。
+ * url prop が渡された場合はそれをそのまま使う。
+ */
+function resolveShareUrl(
+  urlProp: string | undefined,
+  pathname: string,
+  searchParams: URLSearchParams | null
+): string {
+  if (urlProp) return urlProp;
+
+  const qs = searchParams?.toString();
+  const pathWithQuery = `${pathname}${qs ? `?${qs}` : ""}`;
+  const base =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
+    (typeof window !== "undefined" ? window.location.origin : "");
+
+  try {
+    return new URL(pathWithQuery, base).href;
+  } catch {
+    return pathWithQuery;
+  }
+}
+
 export default function ShareButtons({
   text,
   url,
@@ -37,42 +62,13 @@ export default function ShareButtons({
 
   const [qrOpen, setQrOpen] = useState(false);
 
-  const currentUrl = useMemo(() => {
-    if (url) return url;
-
-    const qs = searchParams?.toString();
-    const base = (process.env.NEXT_PUBLIC_SITE_URL ?? "").replace(/\/$/, "");
-
-    // base があるなら絶対URL、なければ相対URLでフォールバック
-    const pathWithQuery = `${pathname}${qs ? `?${qs}` : ""}`;
-    return base ? `${base}${pathWithQuery}` : pathWithQuery;
-  }, [url, pathname, searchParams]);
-
-  type ShareUrlMode = "public" | "current";
-
-  const getShareUrl = useCallback(
-    (mode: ShareUrlMode = "public") => {
-      // public: 共有用（本番URL優先）
-      if (mode === "public") {
-        try {
-          // NEXT_PUBLIC_SITE_URL があればそれを優先
-          const base =
-            process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
-          return new URL(currentUrl || "", base).href;
-        } catch {
-          return process.env.NEXT_PUBLIC_SITE_URL || window.location.href;
-        }
-      }
-
-      // current: 今見ているURL（開発・検証向け）
-      return window.location.href;
-    },
-    [currentUrl]
+  const shareUrl = useMemo(
+    () => resolveShareUrl(url, pathname, searchParams),
+    [url, pathname, searchParams]
   );
 
   const shareLinks = useMemo(() => {
-    const u = getShareUrl();
-    const encUrl = encodeURIComponent(u);
+    const encUrl = encodeURIComponent(shareUrl);
     const encText = encodeURIComponent(text ?? "");
 
     return {
@@ -80,16 +76,16 @@ export default function ShareButtons({
       facebook: `https://www.facebook.com/sharer/sharer.php?u=${encUrl}`,
       email: `mailto:?subject=${encText}&body=${encUrl}`,
     };
-  }, [getShareUrl, text]);
+  }, [shareUrl, text]);
 
   const onShare = (method: ShareMethod) => {
     track("share_clicked", { method });
   };
 
-  const onCopy = async (url: string) => {
+  const onCopy = async () => {
     onShare("copy");
     try {
-      await navigator.clipboard.writeText(url);
+      await navigator.clipboard.writeText(shareUrl);
       alert("リンクをコピーしました！");
     } catch {
       alert("コピーに失敗しました（ブラウザ設定をご確認ください）");
@@ -173,19 +169,7 @@ export default function ShareButtons({
   };
 
   const renderQrModal = () => {
-    if (!qrOpen) return null;
     if (typeof document === "undefined") return null; // createPortal は SSR 環境では使えないためガード
-
-    const raw = currentUrl || "";
-    let u = raw;
-
-    try {
-      // rawが相対でも絶対でもOK。最終的に絶対URLへ正規化
-      u = new URL(raw, window.location.origin).href;
-    } catch {
-      // 念のためフォールバック
-      u = window.location.href;
-    }
 
     return createPortal(
       <div className={styles.overlay} onClick={() => setQrOpen(false)}>
@@ -193,13 +177,13 @@ export default function ShareButtons({
           <div className={styles.modalLabel}>このページを共有</div>
 
           <div className={styles.modalQrWrapper}>
-            <QRCodeCanvas value={u} size={180} />
+            <QRCodeCanvas value={shareUrl} size={180} />
           </div>
 
           <div className={styles.modalActions}>
             <button
               type="button"
-              onClick={() => onCopy(u)}
+              onClick={() => onCopy()}
               className={styles.modalBtn}
             >
               URLコピー
@@ -245,7 +229,7 @@ export default function ShareButtons({
               <button
                 key={m}
                 type="button"
-                onClick={() => onCopy(getShareUrl())}
+                onClick={onCopy}
                 aria-label="リンクをコピー"
                 title="リンクをコピー"
                 className={styles.iconButton}


### PR DESCRIPTION
## 概要

`currentUrl`（useMemo）→ `getShareUrl()`（useCallback）の2段階だったURL生成を `resolveShareUrl()` 関数に一本化。

## 変更内容

### Before
```
currentUrl (useMemo) ← pathname + searchParams から組み立て
  └─ getShareUrl() (useCallback) ← window.location を参照して絶対URL化
       ├─ shareLinks (useMemo)
       └─ copy ボタン onClick
  └─ QR モーダル ← currentUrl を直接参照（経路が別）
```

### After
```
shareUrl (useMemo) ← resolveShareUrl() で一度だけ解決
  ├─ shareLinks (useMemo)
  ├─ copy ボタン onClick
  └─ QR モーダル
```

### 具体的な変更
- `resolveShareUrl()` をコンポーネント外のピュア関数として定義（テスト可能）
- `useCallback` を削除、`useMemo` のみに統一
- `window` 依存を `resolveShareUrl` 内に集約（SSRガード済み）
- `onCopy` の引数を削除（`shareUrl` を直接参照）
- QR モーダルも `shareUrl` を使うよう統一（以前は `currentUrl` を直接参照していた）

## 確認項目

- [x] `npm run lint` パス
- [x] `npm run build` パス
- [x] 既存の呼び出し元（`app/page.tsx`, `charcount`, `total`, `yutai-expiry`）の props は変更なし

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)