### PR TITLE
UI(loading): スケルトン UI を各ページの実レイアウトに合わせて改善 (#201)

### DIFF
--- a/app/tools/earnings-calendar/loading.tsx
+++ b/app/tools/earnings-calendar/loading.tsx
@@ -1,75 +1,55 @@
 export default function Loading() {
+  const sk = {
+    background: "var(--color-border)",
+    animation: "skeleton-pulse 1.4s ease-in-out infinite",
+  } as const;
+
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
-      <div style={{ padding: "32px 0 24px" }}>
-        <div style={{
-          width: 160,
-          height: 28,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          marginBottom: 8,
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-        <div style={{
-          width: 200,
-          height: 14,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-      </div>
+    <main style={{ minHeight: "100vh", padding: "18px 12px 56px" }}>
+      <div style={{ width: "100%", maxWidth: 440, margin: "0 auto", padding: "0 8px 24px" }}>
+        {/* Hero block */}
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ ...sk, display: "inline-block", width: 110, height: 20, borderRadius: 999, marginBottom: 10 }} />
+          <div style={{ ...sk, width: 140, height: 24, borderRadius: 6, marginBottom: 8 }} />
+          <div style={{ ...sk, width: "90%", height: 13, borderRadius: 4 }} />
+        </div>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {[80, 80].map((w, i) => (
-          <div key={i} style={{
-            width: w,
-            height: 32,
-            borderRadius: 8,
-            background: "var(--color-border)",
-            animation: "skeleton-pulse 1.4s ease-in-out infinite",
-          }} />
-        ))}
-      </div>
+        {/* Market tab row: 国内 / 海外 */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10, marginBottom: 12 }}>
+          {[0, 1].map((i) => (
+            <div key={i} style={{ ...sk, height: 52, borderRadius: 16 }} />
+          ))}
+        </div>
 
-      <div style={{
-        borderRadius: 12,
-        border: "1px solid var(--color-border)",
-        background: "var(--color-bg-card)",
-        overflow: "hidden",
-      }}>
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 12,
-            padding: "14px 16px",
-            borderBottom: i < 7 ? "1px solid var(--color-border)" : "none",
-          }}>
-            <div style={{
-              width: 48,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              flex: 1,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              width: 56,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
+        {/* Calendar card */}
+        <div style={{
+          background: "rgba(255,255,255,0.8)",
+          borderRadius: 22,
+          padding: 16,
+          boxShadow: "0 10px 30px rgba(15,23,42,0.06)",
+          border: "1px solid rgba(15,23,42,0.04)",
+        }}>
+          {/* Month nav: ‹ YYYY年M月 › */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14 }}>
+            <div style={{ ...sk, width: 38, height: 38, borderRadius: 999 }} />
+            <div style={{ ...sk, width: 110, height: 18, borderRadius: 6 }} />
+            <div style={{ ...sk, width: 38, height: 38, borderRadius: 999 }} />
           </div>
-        ))}
+
+          {/* Week header: SUN MON TUE WED THU FRI SAT */}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 2, marginBottom: 4 }}>
+            {Array.from({ length: 7 }).map((_, i) => (
+              <div key={i} style={{ ...sk, height: 20, borderRadius: 4, opacity: 0.5 }} />
+            ))}
+          </div>
+
+          {/* Calendar grid: 5 rows × 7 cols */}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 2 }}>
+            {Array.from({ length: 35 }).map((_, i) => (
+              <div key={i} style={{ ...sk, height: 42, borderRadius: 6 }} />
+            ))}
+          </div>
+        </div>
       </div>
 
       <style>{`
@@ -78,6 +58,6 @@ export default function Loading() {
           50% { opacity: 0.4; }
         }
       `}</style>
-    </div>
+    </main>
   );
 }

--- a/app/tools/nikkei-contribution/loading.tsx
+++ b/app/tools/nikkei-contribution/loading.tsx
@@ -1,74 +1,63 @@
 export default function Loading() {
+  const sk = {
+    background: "var(--color-border)",
+    animation: "skeleton-pulse 1.4s ease-in-out infinite",
+  } as const;
+
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+    <main style={{ maxWidth: 1180, margin: "0 auto", padding: "0 16px 64px" }}>
+      {/* Header */}
       <div style={{ padding: "32px 0 24px" }}>
-        <div style={{
-          width: 180,
-          height: 28,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          marginBottom: 8,
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-        <div style={{
-          width: 260,
-          height: 14,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
+        <div style={{ ...sk, width: 180, height: 28, borderRadius: 6, marginBottom: 8 }} />
+        <div style={{ ...sk, width: 280, height: 14, borderRadius: 4 }} />
       </div>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {[100, 80].map((w, i) => (
-          <div key={i} style={{
-            width: w,
-            height: 32,
-            borderRadius: 8,
-            background: "var(--color-border)",
-            animation: "skeleton-pulse 1.4s ease-in-out infinite",
-          }} />
-        ))}
+      {/* Control card: date nav + summary 2×2 */}
+      <div style={{
+        background: "#fff",
+        border: "1px solid rgba(15,23,42,0.04)",
+        borderRadius: 22,
+        boxShadow: "0 10px 30px rgba(15,23,42,0.06)",
+        padding: 16,
+        marginBottom: 16,
+      }}>
+        {/* Date nav: ← date → */}
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, marginBottom: 12 }}>
+          <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+          <div style={{ ...sk, width: 160, height: 34, borderRadius: 8 }} />
+          <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+        </div>
+
+        {/* Summary cards: 2×2 grid */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 4 }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} style={{ ...sk, height: 76, borderRadius: 8 }} />
+          ))}
+        </div>
       </div>
 
+      {/* ImpactMap (treemap) placeholder */}
+      <div style={{ ...sk, width: "100%", height: 420, borderRadius: 12, marginBottom: 16 }} />
+
+      {/* Full records table */}
       <div style={{
         borderRadius: 12,
         border: "1px solid var(--color-border)",
         background: "var(--color-bg-card)",
         overflow: "hidden",
-        marginBottom: 20,
       }}>
-        {Array.from({ length: 10 }).map((_, i) => (
+        {Array.from({ length: 12 }).map((_, i) => (
           <div key={i} style={{
             display: "flex",
             alignItems: "center",
             gap: 12,
             padding: "12px 16px",
-            borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
+            borderBottom: i < 11 ? "1px solid var(--color-border)" : "none",
           }}>
-            <div style={{
-              width: 24,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              flex: 1,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              width: 72,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
+            <div style={{ ...sk, width: 36, height: 14, borderRadius: 4, flexShrink: 0 }} />
+            <div style={{ ...sk, flex: 1, height: 14, borderRadius: 4 }} />
+            <div style={{ ...sk, width: 64, height: 14, borderRadius: 4, flexShrink: 0 }} />
+            <div style={{ ...sk, width: 64, height: 14, borderRadius: 4, flexShrink: 0 }} />
           </div>
         ))}
       </div>
@@ -79,6 +68,6 @@ export default function Loading() {
           50% { opacity: 0.4; }
         }
       `}</style>
-    </div>
+    </main>
   );
 }

--- a/app/tools/stock-ranking/loading.tsx
+++ b/app/tools/stock-ranking/loading.tsx
@@ -1,48 +1,45 @@
 export default function Loading() {
+  const sk = {
+    background: "var(--color-border)",
+    animation: "skeleton-pulse 1.4s ease-in-out infinite",
+  } as const;
+
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
+      {/* Header */}
       <div style={{ padding: "32px 0 24px" }}>
-        <div style={{
-          width: 160,
-          height: 28,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          marginBottom: 8,
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-        <div style={{
-          width: 240,
-          height: 14,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
+        <div style={{ ...sk, width: 160, height: 28, borderRadius: 6, marginBottom: 8 }} />
+        <div style={{ ...sk, width: 240, height: 14, borderRadius: 4 }} />
       </div>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {[80, 100, 80].map((w, i) => (
-          <div key={i} style={{
-            width: w,
-            height: 32,
-            borderRadius: 8,
-            background: "var(--color-border)",
-            animation: "skeleton-pulse 1.4s ease-in-out infinite",
-          }} />
+      {/* Date nav: ← date select → */}
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 8,
+        marginBottom: 16,
+      }}>
+        <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+        <div style={{ ...sk, width: 160, height: 34, borderRadius: 8 }} />
+        <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+      </div>
+
+      {/* Market tabs: プライム / スタンダード / グロース */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" }}>
+        {[88, 108, 80].map((w, i) => (
+          <div key={i} style={{ ...sk, width: w, height: 32, borderRadius: 8 }} />
         ))}
       </div>
 
+      {/* Ranking tabs: 値上がり率 / 値下がり率 / 売買高 */}
       <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {[90, 110, 72].map((w, i) => (
-          <div key={i} style={{
-            width: w,
-            height: 32,
-            borderRadius: 8,
-            background: "var(--color-border)",
-            animation: "skeleton-pulse 1.4s ease-in-out infinite",
-          }} />
+        {[92, 96, 72].map((w, i) => (
+          <div key={i} style={{ ...sk, width: w, height: 32, borderRadius: 8 }} />
         ))}
       </div>
 
+      {/* Ranking table */}
       <div style={{
         borderRadius: 12,
         border: "1px solid var(--color-border)",
@@ -57,29 +54,10 @@ export default function Loading() {
             padding: "12px 16px",
             borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
           }}>
-            <div style={{
-              width: 24,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              flex: 1,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              width: 60,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
+            <div style={{ ...sk, width: 24, height: 16, borderRadius: 4, flexShrink: 0 }} />
+            <div style={{ ...sk, flex: 1, height: 16, borderRadius: 4 }} />
+            <div style={{ ...sk, width: 60, height: 16, borderRadius: 4, flexShrink: 0 }} />
+            <div style={{ ...sk, width: 60, height: 16, borderRadius: 4, flexShrink: 0 }} />
           </div>
         ))}
       </div>

--- a/app/tools/topix33/loading.tsx
+++ b/app/tools/topix33/loading.tsx
@@ -1,73 +1,107 @@
 export default function Loading() {
+  const sk = {
+    background: "var(--color-border)",
+    animation: "skeleton-pulse 1.4s ease-in-out infinite",
+  } as const;
+
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
+    <main style={{ maxWidth: 960, margin: "0 auto", padding: "0 16px 64px" }}>
+      {/* Header */}
       <div style={{ padding: "32px 0 24px" }}>
-        <div style={{
-          width: 160,
-          height: 28,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          marginBottom: 8,
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-        <div style={{
-          width: 220,
-          height: 14,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
+        <div style={{ ...sk, width: 160, height: 28, borderRadius: 6, marginBottom: 8 }} />
+        <div style={{ ...sk, width: 220, height: 14, borderRadius: 4 }} />
       </div>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {[100, 80].map((w, i) => (
-          <div key={i} style={{
-            width: w,
-            height: 32,
-            borderRadius: 8,
-            background: "var(--color-border)",
-            animation: "skeleton-pulse 1.4s ease-in-out infinite",
-          }} />
+      {/* Date nav card: ← date → */}
+      <div style={{
+        background: "#fff",
+        border: "1px solid rgba(15,23,42,0.04)",
+        borderRadius: 22,
+        boxShadow: "0 10px 30px rgba(15,23,42,0.06)",
+        padding: 16,
+        marginBottom: 16,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 8,
+      }}>
+        <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+        <div style={{ ...sk, width: 160, height: 34, borderRadius: 8 }} />
+        <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+      </div>
+
+      {/* Summary: 上昇業種 / 下落業種 / 変わらず (3 cols) */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, marginBottom: 16 }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ ...sk, height: 64, borderRadius: 12 }} />
         ))}
       </div>
 
+      {/* Ranking: 上昇 / 下落 (2 cols) */}
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+        gap: 12,
+        marginBottom: 16,
+      }}>
+        {[0, 1].map((col) => (
+          <div key={col} style={{
+            borderRadius: 12,
+            border: "1px solid var(--color-border)",
+            background: "var(--color-bg-card)",
+            overflow: "hidden",
+          }}>
+            <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--color-border)" }}>
+              <div style={{ ...sk, width: 100, height: 16, borderRadius: 4 }} />
+            </div>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "10px 16px",
+                borderBottom: i < 4 ? "1px solid var(--color-border)" : "none",
+              }}>
+                <div style={{ ...sk, width: 24, height: 14, borderRadius: 4, flexShrink: 0 }} />
+                <div style={{ ...sk, flex: 1, height: 14, borderRadius: 4 }} />
+                <div style={{ ...sk, width: 56, height: 14, borderRadius: 4, flexShrink: 0 }} />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Sectors table: 業種 / 変化率 / 値 (3 cols, 10 rows preview) */}
       <div style={{
         borderRadius: 12,
         border: "1px solid var(--color-border)",
         background: "var(--color-bg-card)",
         overflow: "hidden",
       }}>
+        {/* Column header row */}
+        <div style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 80px 80px",
+          gap: 12,
+          padding: "10px 16px",
+          borderBottom: "2px solid var(--color-border)",
+        }}>
+          <div style={{ ...sk, width: 40, height: 12, borderRadius: 3 }} />
+          <div style={{ ...sk, width: 48, height: 12, borderRadius: 3, marginLeft: "auto" }} />
+          <div style={{ ...sk, width: 32, height: 12, borderRadius: 3, marginLeft: "auto" }} />
+        </div>
         {Array.from({ length: 10 }).map((_, i) => (
           <div key={i} style={{
-            display: "flex",
+            display: "grid",
+            gridTemplateColumns: "1fr 80px 80px",
             alignItems: "center",
             gap: 12,
-            padding: "12px 16px",
+            padding: "11px 16px",
             borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
           }}>
-            <div style={{
-              width: 24,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              flex: 1,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              width: 64,
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              flexShrink: 0,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
+            <div style={{ ...sk, height: 14, borderRadius: 4 }} />
+            <div style={{ ...sk, width: 60, height: 14, borderRadius: 4, marginLeft: "auto" }} />
+            <div style={{ ...sk, width: 44, height: 14, borderRadius: 4, marginLeft: "auto" }} />
           </div>
         ))}
       </div>
@@ -78,6 +112,6 @@ export default function Loading() {
           50% { opacity: 0.4; }
         }
       `}</style>
-    </div>
+    </main>
   );
 }

--- a/app/tools/yutai-candidates/loading.tsx
+++ b/app/tools/yutai-candidates/loading.tsx
@@ -1,65 +1,75 @@
 export default function Loading() {
+  const sk = {
+    background: "var(--color-border)",
+    animation: "skeleton-pulse 1.4s ease-in-out infinite",
+  } as const;
+
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto", padding: "0 16px 64px" }}>
-      <div style={{ padding: "32px 0 24px" }}>
-        <div style={{
-          width: 160,
-          height: 28,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          marginBottom: 8,
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-        <div style={{
-          width: 200,
-          height: 14,
-          borderRadius: 6,
-          background: "var(--color-border)",
-          animation: "skeleton-pulse 1.4s ease-in-out infinite",
-        }} />
-      </div>
+    <main style={{ minHeight: "100vh", padding: "24px 16px 72px" }}>
+      <div style={{ width: "100%", maxWidth: 980, margin: "0 auto" }}>
+        {/* Hero block */}
+        <div style={{ marginBottom: 28 }}>
+          <div style={{ ...sk, display: "inline-block", width: 130, height: 22, borderRadius: 999, marginBottom: 12 }} />
+          <div style={{ ...sk, width: 220, height: 26, borderRadius: 6, marginBottom: 8 }} />
+          <div style={{ ...sk, width: "70%", height: 13, borderRadius: 4 }} />
+        </div>
 
-      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
-        {[56, 56, 56, 56].map((w, i) => (
-          <div key={i} style={{
-            width: w,
-            height: 32,
-            borderRadius: 8,
-            background: "var(--color-border)",
-            animation: "skeleton-pulse 1.4s ease-in-out infinite",
-          }} />
-        ))}
-      </div>
-
-      <div style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-        gap: 10,
-      }}>
-        {Array.from({ length: 12 }).map((_, i) => (
-          <div key={i} style={{
-            borderRadius: 10,
-            border: "1px solid var(--color-border)",
-            background: "var(--color-bg-card)",
-            padding: "12px 14px",
-          }}>
-            <div style={{
-              width: 40,
-              height: 12,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              marginBottom: 8,
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
-            <div style={{
-              width: "80%",
-              height: 16,
-              borderRadius: 4,
-              background: "var(--color-border)",
-              animation: "skeleton-pulse 1.4s ease-in-out infinite",
-            }} />
+        {/* Panel */}
+        <div style={{
+          background: "#ffffff",
+          borderRadius: 28,
+          padding: "20px 20px 24px",
+          boxShadow: "0 1px 3px rgba(15,23,42,0.04), 0 8px 24px rgba(15,23,42,0.06)",
+          border: "1px solid rgba(15,23,42,0.06)",
+        }}>
+          {/* Month chips */}
+          <div style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid rgba(15,23,42,0.06)" }}>
+            <div style={{ ...sk, width: 40, height: 11, borderRadius: 3, marginBottom: 10 }} />
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {[56, 56, 56, 56, 56, 56].map((w, i) => (
+                <div key={i} style={{ ...sk, width: w, height: 32, borderRadius: 999 }} />
+              ))}
+            </div>
           </div>
-        ))}
+
+          {/* Search bar */}
+          <div style={{ ...sk, width: "100%", height: 40, borderRadius: 10, marginBottom: 10 }} />
+
+          {/* Filter selects */}
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 16 }}>
+            {[160, 140, 120, 120].map((w, i) => (
+              <div key={i} style={{ ...sk, width: w, height: 34, borderRadius: 8 }} />
+            ))}
+          </div>
+
+          {/* Card grid */}
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(400px, 1fr))",
+            gap: 10,
+          }}>
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} style={{
+                borderRadius: 12,
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderLeft: "3px solid rgba(15,23,42,0.10)",
+                padding: "14px 16px",
+              }}>
+                <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 10 }}>
+                  <div>
+                    <div style={{ ...sk, width: 40, height: 11, borderRadius: 3, marginBottom: 6 }} />
+                    <div style={{ ...sk, width: 140, height: 16, borderRadius: 4 }} />
+                  </div>
+                  <div style={{ ...sk, width: 64, height: 32, borderRadius: 8 }} />
+                </div>
+                <div style={{ display: "flex", gap: 6 }}>
+                  <div style={{ ...sk, width: 60, height: 20, borderRadius: 999 }} />
+                  <div style={{ ...sk, width: 80, height: 20, borderRadius: 999 }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
 
       <style>{`
@@ -68,6 +78,6 @@ export default function Loading() {
           50% { opacity: 0.4; }
         }
       `}</style>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## 概要

スケルトン UI を各ページの実レイアウトに合わせて修正。
従来は全ページが汎用リスト行のみで、実際のページ構成と大きく乖離していた。

## 変更内容

| ページ | 変更内容 |
|---|---|
| earnings-calendar | リスト行 → 7列カレンダーグリッド＋月ナビ＋国内/海外タブ |
| nikkei-contribution | treemap プレースホルダー追加、2×2サマリーカード、4列テーブル行 |
| topix33 | 3列テーブルヘッダー、上昇/下落3枠サマリー、2列ランキングセクション追加 |
| stock-ranking | 日付ナビ（← select →）追加、テーブルを4カラムに調整 |
| yutai-candidates | 検索バー、フィルター選択欄、カードグリッドを実レイアウトに合わせて再現 |

## 確認項目

- [x] `npm run lint` パス
- [ ] 各ページでスケルトンが実レイアウトに近い見た目で表示されること
- [ ] ダークモード対応（`var(--color-border)` 使用）

## 関連 Issue

Closes #201
