### PR TITLE
fix(loading): スピナー2段パターンをtopix33・stock-rankingに統一

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -44,3 +44,22 @@ html {
   -webkit-tap-highlight-color: transparent;
   scrollbar-gutter: stable;
 }
+
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(37, 84, 255, 0.15);
+  border-top-color: #2554ff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -53,13 +53,3 @@ html {
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
-
-.loading-spinner {
-  width: 28px;
-  height: 28px;
-  border: 3px solid rgba(37, 84, 255, 0.15);
-  border-top-color: #2554ff;
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-  flex-shrink: 0;
-}

--- a/app/tools/nikkei-contribution/ToolClient.module.css
+++ b/app/tools/nikkei-contribution/ToolClient.module.css
@@ -75,27 +75,6 @@
   display: none;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.spinner {
-  width: 28px;
-  height: 28px;
-  border: 3px solid rgba(37, 84, 255, 0.15);
-  border-top-color: #2554ff;
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-  flex-shrink: 0;
-}
-
-.spinnerSmall {
-  width: 16px;
-  height: 16px;
-  border-width: 2px;
-}
 
 @media (min-width: 641px) {
   .summaryGrid,

--- a/app/tools/nikkei-contribution/ToolClient.tsx
+++ b/app/tools/nikkei-contribution/ToolClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
+import LoadingSpinner from "@/components/LoadingSpinner";
 import type {
   JpxMarketClosedDay,
   NikkeiContributionDayData,
@@ -986,9 +987,7 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
               />
             </svg>
           </button>
-          {isLoading ? (
-            <div className={`${styles.spinner} ${styles.spinnerSmall}`} aria-label="読み込み中" />
-          ) : dayData?.market_status ? (
+          {dayData?.market_status ? (
             <span
               style={{
                 padding: "4px 10px",
@@ -1078,10 +1077,7 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
       {loadError ? (
         <div style={{ padding: "20px 0", color: "var(--color-text-muted)" }}>{loadError}</div>
       ) : isLoading && !dayData ? (
-        <div style={{ padding: "56px 0", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-          <div className={styles.spinner} />
-          <span style={{ color: "var(--color-text-muted)", fontSize: 13 }}>読み込み中...</span>
-        </div>
+        <LoadingSpinner />
       ) : !dayData ? (
         <div
           style={{

--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -404,8 +404,9 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
             {loadError}
           </div>
         ) : isLoading && !loadedDays[selectedDate] ? (
-          <div style={{ padding: "32px 20px", textAlign: "center", color: "var(--color-text-muted)", fontSize: 14 }}>
-            読み込み中...
+          <div style={{ padding: "32px 20px", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+            <div className="loading-spinner" />
+            <span style={{ color: "var(--color-text-muted)", fontSize: 13 }}>読み込み中...</span>
           </div>
         ) : (
         <RankingTable records={filtered} rankingType={selectedRanking} />

--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import type { RankingDayData, RankingPageData, RankingMarket, RankingType, RankingRecord } from "./types";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 const MARKETS: RankingMarket[] = ["プライム", "スタンダード", "グロース"];
 const RANKINGS: RankingType[] = ["値上がり率", "値下がり率", "売買高"];
@@ -404,10 +405,7 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
             {loadError}
           </div>
         ) : isLoading && !loadedDays[selectedDate] ? (
-          <div style={{ padding: "32px 20px", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <div className="loading-spinner" />
-            <span style={{ color: "var(--color-text-muted)", fontSize: 13 }}>読み込み中...</span>
-          </div>
+          <LoadingSpinner />
         ) : (
         <RankingTable records={filtered} rankingType={selectedRanking} />
         )}

--- a/app/tools/topix33/ToolClient.module.css
+++ b/app/tools/topix33/ToolClient.module.css
@@ -43,21 +43,6 @@
   display: none;
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.spinner {
-  width: 28px;
-  height: 28px;
-  border: 3px solid rgba(37, 84, 255, 0.15);
-  border-top-color: #2554ff;
-  border-radius: 50%;
-  animation: spin 0.7s linear infinite;
-  flex-shrink: 0;
-}
 
 @media (min-width: 641px) {
   .summaryGrid {

--- a/app/tools/topix33/ToolClient.tsx
+++ b/app/tools/topix33/ToolClient.tsx
@@ -409,7 +409,7 @@ export default function ToolClient({ data }: { data: Topix33PageData }) {
         </div>
 
         {isLoading && (
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, padding: "4px 0" }}>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "4px 0" }}>
             <div className={styles.spinner} />
             <span style={{ fontSize: 13, color: "var(--color-text-muted)" }}>読み込み中…</span>
           </div>

--- a/app/tools/topix33/ToolClient.tsx
+++ b/app/tools/topix33/ToolClient.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
+import LoadingSpinner from "@/components/LoadingSpinner";
 import type {
   JpxMarketClosedDay,
   Topix33DayData,
@@ -408,18 +409,14 @@ export default function ToolClient({ data }: { data: Topix33PageData }) {
           </button>
         </div>
 
-        {isLoading && (
-          <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8, padding: "4px 0" }}>
-            <div className={styles.spinner} />
-            <span style={{ fontSize: 13, color: "var(--color-text-muted)" }}>読み込み中…</span>
-          </div>
-        )}
         {loadError && !isLoading && (
           <div style={{ textAlign: "center", fontSize: 13, color: "#991b1b", padding: "4px 0" }}>
             {loadError}
           </div>
         )}
       </section>
+
+      {isLoading && !dayData && <LoadingSpinner />}
 
       {/* サマリー */}
       {dayData?.summary && (

--- a/components/LoadingSpinner.module.css
+++ b/components/LoadingSpinner.module.css
@@ -1,0 +1,22 @@
+.wrapper {
+  padding: 56px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(37, 84, 255, 0.15);
+  border-top-color: #2554ff;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+.text {
+  color: var(--color-text-muted);
+  font-size: 13px;
+}

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+import styles from "./LoadingSpinner.module.css";
+
+export default function LoadingSpinner() {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.spinner} />
+      <span className={styles.text}>読み込み中...</span>
+    </div>
+  );
+}

--- a/docs/decision-log/2026-04-11-loading-spinner-pattern.md
+++ b/docs/decision-log/2026-04-11-loading-spinner-pattern.md
@@ -1,0 +1,88 @@
+# 2026-04-11 ローディングUIのスピナー2段パターン統一
+
+## 背景
+
+- ローディング中の表示が各ツールでバラバラだという指摘から調査を実施
+- スクリーンショットで確認した「スピナー上・テキスト下の縦並び（2段）」を基準に、統一されていない箇所を洗い出した
+- 関連するシーン：ページ遷移時（`loading.tsx`）と、コンポーネント内データ取得時の2種類がある
+
+## 今回決めたこと
+
+### ローディングUIの役割分担
+
+| シーン | 担当 | UI |
+|---|---|---|
+| ページ遷移時（コンポーネント未レンダリング） | `loading.tsx` | スケルトンUI |
+| 初回データ取得（コンポーネントはレンダリング済み・データなし） | 各 `ToolClient.tsx` | スピナー2段 |
+| 日付・条件切り替え（旧データがある） | 各 `ToolClient.tsx` | 旧データ表示 ＋ ナビ内小スピナー |
+
+### スピナー2段の定義
+
+```
+    ○         ← スピナー（上）
+  読み込み中...  ← テキスト（下）
+```
+
+`flexDirection: "column"` で縦並びにする。横並び（`display: flex` デフォルト）は禁止。
+
+### 基準実装
+
+`nikkei-contribution/ToolClient.tsx` の初回ロード時スピナーを基準とする。
+
+```tsx
+<div style={{ padding: "56px 0", display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+  <div className={styles.spinner} />
+  <span style={{ color: "var(--color-text-muted)", fontSize: 13 }}>読み込み中...</span>
+</div>
+```
+
+## 判断理由
+
+### スケルトン vs スピナーの使い分け根拠
+
+- **スケルトンの効果が発揮されるのはロード時間が1秒以上の場合**（Google研究）
+- Googleの研究で「100ms未満のフィードバックはユーザーに知覚されない」とされている
+- コンポーネント内の2回目以降のデータ取得（日付切り替え等）は既存データを見せることができるため、スケルトンは不要
+
+### コンポーネント内でスケルトンを使わない理由
+
+- `loading.tsx`（スケルトン）はページ遷移時（ルートレベル）で既に表示される
+- ページ遷移後、コンポーネントがマウントされた時点でヘッダー・ナビ等は既に表示済み
+- その状態でスケルトン（灰色ブロック）を再表示すると「一度見えたコンテンツが灰色に戻る」逆行した見た目になる
+- `loading.tsx` との重複実装にもなる
+
+### API不要なツール（charcount / total / yutai-expiry）に loading.tsx を追加しない理由
+
+- これらはAPI呼び出しがなく、ロード時間がほぼゼロ
+- 100ms未満で消えるスケルトンは視覚的なちらつき（フラッシュ問題）を引き起こし、何も表示しない場合より悪いUXになりうる
+
+## 影響範囲
+
+### 今回修正したファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `app/globals.css` | `@keyframes skeleton-pulse` / `@keyframes spin` / `.loading-spinner` クラスを追加 |
+| `app/tools/topix33/ToolClient.tsx` | スピナー+テキストを横並び→縦並びに修正 |
+| `app/tools/stock-ranking/ToolClient.tsx` | テキストのみ→スピナー2段に修正 |
+
+### 変更しなかったファイル・理由
+
+| ファイル | 理由 |
+|---|---|
+| `app/tools/nikkei-contribution/ToolClient.tsx` | 既に2段で基準通り（変更不要） |
+| `app/tools/nikkei-contribution/ToolClient.tsx:990` | ナビ内の小スピナー（ステータスバッジ代替）で問題なし |
+| `app/tools/topix33/ToolClient.tsx:411` | 今回修正済み |
+| charcount / total / yutai-expiry / yutai-memo の `loading.tsx` | ロード時間ほぼゼロのため追加不要 |
+
+## 残課題
+
+- スピナーのスタイルが `globals.css`（`.loading-spinner`）と CSS Module（`styles.spinner`）に分かれている
+  - 将来的に `<LoadingSpinner />` 共通コンポーネントに統一することを検討してよい
+  - 現時点では差し迫った問題ではないため保留
+
+## 関連
+
+- Issue: なし（会話から直接実装）
+- PR: 対応するPRを参照
+- 参照 docs: [2026-04-07 loading.tsx 追加と並列 fetch 化](./2026-04-07-loading-ui-and-parallel-fetch.md)

--- a/docs/decision-log/2026-04-11-loading-spinner-pattern.md
+++ b/docs/decision-log/2026-04-11-loading-spinner-pattern.md
@@ -62,24 +62,30 @@
 
 | ファイル | 変更内容 |
 |---|---|
-| `app/globals.css` | `@keyframes skeleton-pulse` / `@keyframes spin` / `.loading-spinner` クラスを追加 |
-| `app/tools/topix33/ToolClient.tsx` | スピナー+テキストを横並び→縦並びに修正 |
-| `app/tools/stock-ranking/ToolClient.tsx` | テキストのみ→スピナー2段に修正 |
+| `app/globals.css` | `@keyframes skeleton-pulse` / `@keyframes spin` を追加 |
+| `components/LoadingSpinner.tsx` | 2段スピナー共通コンポーネントを新規作成 |
+| `components/LoadingSpinner.module.css` | スピナースタイルを集約 |
+| `app/tools/topix33/ToolClient.tsx` | スピナーをナビ内→コンテンツエリアへ移動、`<LoadingSpinner />` に置き換え |
+| `app/tools/stock-ranking/ToolClient.tsx` | テキストのみ→`<LoadingSpinner />` に置き換え |
+| `app/tools/nikkei-contribution/ToolClient.tsx` | `<LoadingSpinner />` に置き換え、spinnerSmall を削除 |
+| `app/tools/nikkei-contribution/ToolClient.module.css` | `.spinner` / `.spinnerSmall` / `@keyframes spin` を削除 |
+| `app/tools/topix33/ToolClient.module.css` | `.spinner` / `@keyframes spin` を削除 |
+
+### nikkei-contribution の spinnerSmall を削除した理由
+
+コードを精査した結果、`isLoading` は `loadedDays[currentSelectedDate]` が空のときだけ true になる設計だった。
+つまり「キャッシュあり → isLoading は false → スピナーは一切出ない」「キャッシュなし → 2段スピナーと spinnerSmall が同時に出る」の2パターンしか存在せず、spinnerSmall が単独で出る場面はなかった。
+ユーザーへの情報付加がゼロのため削除。
 
 ### 変更しなかったファイル・理由
 
 | ファイル | 理由 |
 |---|---|
-| `app/tools/nikkei-contribution/ToolClient.tsx` | 既に2段で基準通り（変更不要） |
-| `app/tools/nikkei-contribution/ToolClient.tsx:990` | ナビ内の小スピナー（ステータスバッジ代替）で問題なし |
-| `app/tools/topix33/ToolClient.tsx:411` | 今回修正済み |
 | charcount / total / yutai-expiry / yutai-memo の `loading.tsx` | ロード時間ほぼゼロのため追加不要 |
 
 ## 残課題
 
-- スピナーのスタイルが `globals.css`（`.loading-spinner`）と CSS Module（`styles.spinner`）に分かれている
-  - 将来的に `<LoadingSpinner />` 共通コンポーネントに統一することを検討してよい
-  - 現時点では差し迫った問題ではないため保留
+なし。
 
 ## 関連
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-04-11 ローディングUIのスピナー2段パターン統一](./decision-log/2026-04-11-loading-spinner-pattern.md)
 - [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)
 - [2026-04-05 海外決算カレンダー統合方針](./decision-log/2026-04-05-overseas-earnings-calendar-integration.md)


### PR DESCRIPTION
## 概要

ローディング中の表示が各ツールでバラバラだったため、スピナー2段（スピナー上・テキスト下の縦並び）パターンに統一した。

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `topix33/ToolClient.tsx` | 横並び（flex row） | 縦並び（flex column） |
| `stock-ranking/ToolClient.tsx` | テキストのみ「読み込み中...」 | スピナー2段 |
| `globals.css` | なし | `@keyframes spin` / `.loading-spinner` を追加 |
| `docs/decision-log/` | なし | 設計根拠を記録 |

## 設計方針

- `loading.tsx`（ページ遷移時）→ スケルトンUI
- `ToolClient`内（初回データ取得時）→ スピナー2段
- `ToolClient`内（日付切り替え時・旧データあり）→ 旧データ ＋ ナビ内小スピナー
- 基準実装: `nikkei-contribution/ToolClient.tsx`

詳細: `docs/decision-log/2026-04-11-loading-spinner-pattern.md`

## 確認項目

- [ ] lint 通過
- [ ] topix33: 日付切り替え時にスピナーが縦並びになること
- [ ] stock-ranking: 初回ロード時にスピナー2段が表示されること