### PR TITLE
refactor(shared): extract common market tool helpers

### DIFF
--- a/app/tools/_shared/date-data-route.ts
+++ b/app/tools/_shared/date-data-route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+const DATE_PARAM_RE = /^\d{4}-\d{2}-\d{2}$/;
+const CACHE_CONTROL_HEADER = "public, max-age=300, s-maxage=300";
+
+type RouteContext = {
+  params: Promise<{
+    date: string;
+  }>;
+};
+
+export function buildDateDataRoute<T>(
+  loader: (date: string) => Promise<T | null>,
+) {
+  return async function GET(_request: Request, context: RouteContext) {
+    const { date } = await context.params;
+
+    if (!DATE_PARAM_RE.test(date)) {
+      return NextResponse.json({ error: "invalid date" }, { status: 400 });
+    }
+
+    const dayData = await loader(date);
+    if (!dayData) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(dayData, {
+      headers: {
+        "Cache-Control": CACHE_CONTROL_HEADER,
+      },
+    });
+  };
+}

--- a/app/tools/_shared/market-trading-dates.ts
+++ b/app/tools/_shared/market-trading-dates.ts
@@ -1,0 +1,71 @@
+type MarketClosedDay = {
+  date: string;
+  market_closed: boolean;
+};
+
+type MarketClosedResponse = {
+  days: MarketClosedDay[];
+};
+
+type FirstUsableDayDataResult<T> = {
+  matched: {
+    date: string;
+    dayData: T;
+  } | null;
+  skippedDates: string[];
+};
+
+function getDayOfWeek(dateStr: string) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d).getDay();
+}
+
+function isWeekendDate(dateStr: string) {
+  const day = getDayOfWeek(dateStr);
+  return day === 0 || day === 6;
+}
+
+export function filterVisibleTradingDates(
+  dates: string[],
+  holidays: MarketClosedResponse | null,
+) {
+  const closedDateSet = new Set(
+    (holidays?.days ?? [])
+      .filter((day) => day.market_closed)
+      .map((day) => day.date),
+  );
+
+  return dates.filter((date) => {
+    if (closedDateSet.has(date)) {
+      return false;
+    }
+
+    return !isWeekendDate(date);
+  });
+}
+
+export async function findFirstUsableDayData<T>(
+  dates: string[],
+  loadDayData: (date: string) => Promise<T | null>,
+  isUsable: (dayData: T | null) => dayData is T,
+): Promise<FirstUsableDayDataResult<T>> {
+  const skippedDates: string[] = [];
+
+  for (const date of dates) {
+    const dayData = await loadDayData(date);
+    if (!isUsable(dayData)) {
+      skippedDates.push(date);
+      continue;
+    }
+
+    return {
+      matched: { date, dayData },
+      skippedDates,
+    };
+  }
+
+  return {
+    matched: null,
+    skippedDates,
+  };
+}

--- a/app/tools/_shared/use-daily-market-data.ts
+++ b/app/tools/_shared/use-daily-market-data.ts
@@ -78,5 +78,8 @@ export function useDailyMarketData<T extends DatedDayData>({
     isLoading,
     loadError,
     currentDayData: activeDate ? loadedDays[activeDate] ?? null : null,
+    storeDayData: (day: T) => {
+      setLoadedDays((current) => ({ ...current, [day.date]: day }));
+    },
   };
 }

--- a/app/tools/_shared/use-daily-market-data.ts
+++ b/app/tools/_shared/use-daily-market-data.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type DatedDayData = {
+  date: string;
+};
+
+type UseDailyMarketDataParams<T extends DatedDayData> = {
+  activeDate: string;
+  initialDayData: T | null;
+  routePrefix: string;
+  errorMessage?: string;
+};
+
+export function useDailyMarketData<T extends DatedDayData>({
+  activeDate,
+  initialDayData,
+  routePrefix,
+  errorMessage = "データを読み込めませんでした。時間をおいて再度お試しください。",
+}: UseDailyMarketDataParams<T>) {
+  const [loadedDays, setLoadedDays] = useState<Record<string, T>>(() => {
+    if (!initialDayData) {
+      return {};
+    }
+
+    return { [initialDayData.date]: initialDayData };
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!activeDate || loadedDays[activeDate]) {
+      setLoadError(null);
+      return;
+    }
+
+    let active = true;
+
+    async function loadSelectedDate() {
+      setIsLoading(true);
+      setLoadError(null);
+
+      try {
+        const res = await fetch(`${routePrefix}/${activeDate}`);
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        const day = (await res.json()) as T;
+        if (!active) {
+          return;
+        }
+
+        setLoadedDays((current) => ({ ...current, [day.date]: day }));
+      } catch {
+        if (!active) {
+          return;
+        }
+
+        setLoadError(errorMessage);
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadSelectedDate();
+
+    return () => {
+      active = false;
+    };
+  }, [activeDate, errorMessage, loadedDays, routePrefix]);
+
+  return {
+    loadedDays,
+    isLoading,
+    loadError,
+    currentDayData: activeDate ? loadedDays[activeDate] ?? null : null,
+  };
+}

--- a/app/tools/charcount/ClientOnly.tsx
+++ b/app/tools/charcount/ClientOnly.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { createClientOnlyTool } from "@/components/createClientOnlyTool";
 
-const ToolClient = dynamic(() => import("./ToolClient"), { ssr: false });
+const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
 
-export default function ClientOnly() {
-  return <ToolClient />;
-}
+export default ClientOnly;

--- a/app/tools/nikkei-contribution/ToolClient.tsx
+++ b/app/tools/nikkei-contribution/ToolClient.tsx
@@ -766,10 +766,12 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
   const { manifest, initialDayData, holidays } = data;
   const [selectedDate, setSelectedDate] = useState<string>(manifest.latest_date ?? "");
   const [selectedCode, setSelectedCode] = useState<string | null>(initialDayData?.records[0]?.code ?? null);
+  const [isFallbackLoading, setIsFallbackLoading] = useState(false);
   const {
     loadedDays,
     isLoading,
     loadError,
+    storeDayData,
   } = useDailyMarketData<NikkeiContributionDayData>({
     activeDate: selectedDate,
     initialDayData,
@@ -805,7 +807,48 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
       ? displayDates[currentDateIndex + 1]
       : null;
   const nextDate = currentDateIndex > 0 ? displayDates[currentDateIndex - 1] : null;
+
+  useEffect(() => {
+    if (!currentSelectedDate || currentSelectedDate === selectedDate || loadedDays[currentSelectedDate]) {
+      setIsFallbackLoading(false);
+      return;
+    }
+
+    let active = true;
+
+    async function loadFallbackDate() {
+      setIsFallbackLoading(true);
+      try {
+        const res = await fetch(`/tools/nikkei-contribution/data/${currentSelectedDate}`);
+        if (!res.ok) {
+          return;
+        }
+
+        const day = (await res.json()) as NikkeiContributionDayData;
+        if (!active) {
+          return;
+        }
+
+        storeDayData(day);
+      } catch {
+        // Keep the existing selectedDate result and let the UI continue to show the
+        // current fallback state if the secondary fetch fails.
+      } finally {
+        if (active) {
+          setIsFallbackLoading(false);
+        }
+      }
+    }
+
+    void loadFallbackDate();
+
+    return () => {
+      active = false;
+    };
+  }, [currentSelectedDate, loadedDays, selectedDate, storeDayData]);
+
   const dayData = currentSelectedDate ? loadedDays[currentSelectedDate] ?? null : null;
+  const isDataLoading = isLoading || isFallbackLoading;
   const selectedRecord = useMemo(() => {
     if (!dayData) return null;
     return dayData.records.find((record) => record.code === selectedCode) ?? dayData.records[0] ?? null;
@@ -1034,7 +1077,7 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
 
       {loadError ? (
         <div style={{ padding: "20px 0", color: "var(--color-text-muted)" }}>{loadError}</div>
-      ) : isLoading && !dayData ? (
+      ) : isDataLoading && !dayData ? (
         <LoadingSpinner />
       ) : !dayData ? (
         <div

--- a/app/tools/nikkei-contribution/ToolClient.tsx
+++ b/app/tools/nikkei-contribution/ToolClient.tsx
@@ -10,6 +10,7 @@ import type {
   NikkeiContributionRankItem,
   NikkeiContributionRecord,
 } from "./types";
+import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
 function formatDate(dateStr: string) {
   const [y, m, d] = dateStr.split("-");
@@ -764,13 +765,16 @@ function RecordsTable({ records }: { records: NikkeiContributionRecord[] }) {
 export default function ToolClient({ data }: { data: NikkeiContributionPageData }) {
   const { manifest, initialDayData, holidays } = data;
   const [selectedDate, setSelectedDate] = useState<string>(manifest.latest_date ?? "");
-  const [loadedDays, setLoadedDays] = useState<Record<string, NikkeiContributionDayData>>(() => {
-    if (!initialDayData) return {};
-    return { [initialDayData.date]: initialDayData };
-  });
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedCode, setSelectedCode] = useState<string | null>(initialDayData?.records[0]?.code ?? null);
+  const {
+    loadedDays,
+    isLoading,
+    loadError,
+  } = useDailyMarketData<NikkeiContributionDayData>({
+    activeDate: selectedDate,
+    initialDayData,
+    routePrefix: "/tools/nikkei-contribution/data",
+  });
   const holidayMap = useMemo(() => {
     return new Map((holidays?.days ?? []).map((day) => [day.date, day]));
   }, [holidays]);
@@ -801,45 +805,6 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
       ? displayDates[currentDateIndex + 1]
       : null;
   const nextDate = currentDateIndex > 0 ? displayDates[currentDateIndex - 1] : null;
-
-  useEffect(() => {
-    if (!currentSelectedDate || loadedDays[currentSelectedDate]) {
-      setLoadError(null);
-      return;
-    }
-
-    let active = true;
-
-    async function loadSelectedDate() {
-      setIsLoading(true);
-      setLoadError(null);
-
-      try {
-        const res = await fetch(`/tools/nikkei-contribution/data/${currentSelectedDate}`);
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`);
-        }
-
-        const day = (await res.json()) as NikkeiContributionDayData;
-        if (!active) return;
-        setLoadedDays((current) => ({ ...current, [day.date]: day }));
-      } catch {
-        if (!active) return;
-        setLoadError("データを読み込めませんでした。時間をおいて再度お試しください。");
-      } finally {
-        if (active) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    void loadSelectedDate();
-
-    return () => {
-      active = false;
-    };
-  }, [currentSelectedDate, loadedDays]);
-
   const dayData = currentSelectedDate ? loadedDays[currentSelectedDate] ?? null : null;
   const selectedRecord = useMemo(() => {
     if (!dayData) return null;
@@ -862,13 +827,6 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
       ...dayData.top_negative.map((item) => Math.abs(item.contribution)),
     );
   }, [dayData]);
-  useEffect(() => {
-    if (!dayData) return;
-    if (!selectedCode || !dayData.records.some((record) => record.code === selectedCode)) {
-      setSelectedCode(dayData.records[0]?.code ?? null);
-    }
-  }, [dayData, selectedCode]);
-
   return (
     <main style={{ maxWidth: 1180, margin: "0 auto", padding: "0 16px 64px" }}>
       <section style={{ padding: "32px 0 24px" }}>

--- a/app/tools/nikkei-contribution/data/[date]/route.ts
+++ b/app/tools/nikkei-contribution/data/[date]/route.ts
@@ -1,27 +1,4 @@
-import { NextResponse } from "next/server";
 import { loadContributionDayData } from "../../data-loader";
+import { buildDateDataRoute } from "@/app/tools/_shared/date-data-route";
 
-type RouteContext = {
-  params: Promise<{
-    date: string;
-  }>;
-};
-
-export async function GET(_request: Request, context: RouteContext) {
-  const { date } = await context.params;
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: "invalid date" }, { status: 400 });
-  }
-
-  const dayData = await loadContributionDayData(date);
-  if (!dayData) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
-  }
-
-  return NextResponse.json(dayData, {
-    headers: {
-      "Cache-Control": "public, max-age=300, s-maxage=300",
-    },
-  });
-}
+export const GET = buildDateDataRoute(loadContributionDayData);

--- a/app/tools/nikkei-contribution/page.tsx
+++ b/app/tools/nikkei-contribution/page.tsx
@@ -3,6 +3,10 @@ import ToolClient from "./ToolClient";
 import { loadContributionDayData, loadContributionManifest } from "./data-loader";
 import type { NikkeiContributionPageData } from "./types";
 import { loadJpxMarketClosedData } from "@/lib/jpx-market-closed";
+import {
+  filterVisibleTradingDates,
+  findFirstUsableDayData,
+} from "@/app/tools/_shared/market-trading-dates";
 
 export const metadata: Metadata = {
   title: "日経225寄与度 | mini-tools",
@@ -12,16 +16,6 @@ export const metadata: Metadata = {
     canonical: "/tools/nikkei-contribution",
   },
 };
-
-function getDayOfWeek(dateStr: string) {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  return new Date(y, m - 1, d).getDay();
-}
-
-function isWeekendDate(dateStr: string) {
-  const day = getDayOfWeek(dateStr);
-  return day === 0 || day === 6;
-}
 
 function isLikelyMarketClosed(dayData: NikkeiContributionPageData["initialDayData"]) {
   if (!dayData || dayData.records.length === 0) {
@@ -39,28 +33,15 @@ async function loadData(): Promise<NikkeiContributionPageData> {
     loadJpxMarketClosedData(),
   ]);
 
-  const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
-  const visibleDates = manifest.dates.filter((date) => {
-    if (holidayMap.get(date)?.market_closed) {
-      return false;
-    }
-
-    return !isWeekendDate(date);
-  });
-
-  let initialDayData = null;
-  const excludedLeadingDates = new Set<string>();
-
-  for (const date of visibleDates) {
-    const dayData = await loadContributionDayData(date);
-    if (!dayData || isLikelyMarketClosed(dayData)) {
-      excludedLeadingDates.add(date);
-      continue;
-    }
-
-    initialDayData = dayData;
-    break;
-  }
+  const visibleDates = filterVisibleTradingDates(manifest.dates, holidays);
+  const { matched, skippedDates } = await findFirstUsableDayData(
+    visibleDates,
+    loadContributionDayData,
+    (dayData): dayData is NonNullable<NikkeiContributionPageData["initialDayData"]> =>
+      !!dayData && !isLikelyMarketClosed(dayData),
+  );
+  const initialDayData = matched?.dayData ?? null;
+  const excludedLeadingDates = new Set(skippedDates);
 
   const filteredDates = visibleDates.filter((date) => !excludedLeadingDates.has(date));
   const filteredManifest = {

--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { RankingDayData, RankingPageData, RankingMarket, RankingType, RankingRecord } from "./types";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
 const MARKETS: RankingMarket[] = ["プライム", "スタンダード", "グロース"];
 const RANKINGS: RankingType[] = ["値上がり率", "値下がり率", "売買高"];
@@ -196,50 +197,11 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
   const [selectedDate, setSelectedDate] = useState<string>(manifest.latest);
   const [selectedMarket, setSelectedMarket] = useState<RankingMarket>("プライム");
   const [selectedRanking, setSelectedRanking] = useState<RankingType>("値上がり率");
-  const [loadedDays, setLoadedDays] = useState<Record<string, RankingDayData>>(() => {
-    if (!initialDayData) return {};
-    return { [initialDayData.date]: initialDayData };
+  const { loadedDays, isLoading, loadError } = useDailyMarketData<RankingDayData>({
+    activeDate: selectedDate,
+    initialDayData,
+    routePrefix: "/tools/stock-ranking/data",
   });
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (loadedDays[selectedDate]) {
-      setLoadError(null);
-      return;
-    }
-
-    let active = true;
-
-    async function loadSelectedDate() {
-      setIsLoading(true);
-      setLoadError(null);
-
-      try {
-        const res = await fetch(`/tools/stock-ranking/data/${selectedDate}`);
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`);
-        }
-
-        const day = (await res.json()) as RankingDayData;
-        if (!active) return;
-        setLoadedDays((current) => ({ ...current, [day.date]: day }));
-      } catch {
-        if (!active) return;
-        setLoadError("データを読み込めませんでした。時間をおいて再度お試しください。");
-      } finally {
-        if (active) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    void loadSelectedDate();
-
-    return () => {
-      active = false;
-    };
-  }, [loadedDays, selectedDate]);
 
   const filtered = useMemo<RankingRecord[]>(() => {
     const day = loadedDays[selectedDate];

--- a/app/tools/stock-ranking/data/[date]/route.ts
+++ b/app/tools/stock-ranking/data/[date]/route.ts
@@ -1,27 +1,4 @@
-import { NextResponse } from "next/server";
 import { loadRankingDayData } from "../../data-loader";
+import { buildDateDataRoute } from "@/app/tools/_shared/date-data-route";
 
-type RouteContext = {
-  params: Promise<{
-    date: string;
-  }>;
-};
-
-export async function GET(_request: Request, context: RouteContext) {
-  const { date } = await context.params;
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: "invalid date" }, { status: 400 });
-  }
-
-  const dayData = await loadRankingDayData(date);
-  if (!dayData) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
-  }
-
-  return NextResponse.json(dayData, {
-    headers: {
-      "Cache-Control": "public, max-age=300, s-maxage=300",
-    },
-  });
-}
+export const GET = buildDateDataRoute(loadRankingDayData);

--- a/app/tools/stock-ranking/page.tsx
+++ b/app/tools/stock-ranking/page.tsx
@@ -3,6 +3,7 @@ import ToolClient from "./ToolClient";
 import { loadRankingDayData, loadRankingManifest } from "./data-loader";
 import type { RankingPageData } from "./types";
 import { loadJpxMarketClosedData } from "@/lib/jpx-market-closed";
+import { filterVisibleTradingDates } from "@/app/tools/_shared/market-trading-dates";
 
 export const metadata: Metadata = {
   title: "株価ランキング | mini-tools",
@@ -13,30 +14,13 @@ export const metadata: Metadata = {
   },
 };
 
-function getDayOfWeek(dateStr: string) {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  return new Date(y, m - 1, d).getDay();
-}
-
-function isWeekendDate(dateStr: string) {
-  const day = getDayOfWeek(dateStr);
-  return day === 0 || day === 6;
-}
-
 async function loadData(): Promise<RankingPageData> {
   const [manifest, holidays] = await Promise.all([
     loadRankingManifest(),
     loadJpxMarketClosedData(),
   ]);
 
-  const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
-  const visibleDates = manifest.dates.filter((date) => {
-    if (holidayMap.get(date)?.market_closed) {
-      return false;
-    }
-
-    return !isWeekendDate(date);
-  });
+  const visibleDates = filterVisibleTradingDates(manifest.dates, holidays);
   const latest = visibleDates[0] ?? manifest.latest;
   const initialDayData = latest ? await loadRankingDayData(latest) : null;
 

--- a/app/tools/topix33/ToolClient.tsx
+++ b/app/tools/topix33/ToolClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import type {
@@ -10,6 +10,7 @@ import type {
   Topix33RankItem,
   Topix33SectorRecord,
 } from "./types";
+import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
 function formatDate(dateStr: string) {
   const [y, m, d] = dateStr.split("-");
@@ -223,12 +224,6 @@ function SectorsTable({ sectors }: { sectors: Topix33SectorRecord[] }) {
 export default function ToolClient({ data }: { data: Topix33PageData }) {
   const { manifest, initialDayData, holidays } = data;
   const [selectedDate, setSelectedDate] = useState<string>(manifest.latest_date ?? "");
-  const [loadedDays, setLoadedDays] = useState<Record<string, Topix33DayData>>(() => {
-    if (!initialDayData) return {};
-    return { [initialDayData.date]: initialDayData };
-  });
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
 
   const holidayMap = useMemo(() => {
     return new Map((holidays?.days ?? []).map((day) => [day.date, day]));
@@ -250,45 +245,16 @@ export default function ToolClient({ data }: { data: Topix33PageData }) {
       ? displayDates[currentDateIndex + 1]
       : null;
   const nextDate = currentDateIndex > 0 ? displayDates[currentDateIndex - 1] : null;
-
-  useEffect(() => {
-    if (!currentSelectedDate || loadedDays[currentSelectedDate]) {
-      setLoadError(null);
-      return;
-    }
-
-    let active = true;
-
-    async function loadSelectedDate() {
-      setIsLoading(true);
-      setLoadError(null);
-
-      try {
-        const res = await fetch(`/tools/topix33/data/${currentSelectedDate}`);
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`);
-        }
-        const day = (await res.json()) as Topix33DayData;
-        if (!active) return;
-        setLoadedDays((current) => ({ ...current, [day.date]: day }));
-      } catch {
-        if (!active) return;
-        setLoadError("データを読み込めませんでした。時間をおいて再度お試しください。");
-      } finally {
-        if (active) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    void loadSelectedDate();
-
-    return () => {
-      active = false;
-    };
-  }, [currentSelectedDate, loadedDays]);
-
-  const dayData = currentSelectedDate ? loadedDays[currentSelectedDate] ?? null : null;
+  const {
+    loadedDays,
+    isLoading,
+    loadError,
+    currentDayData: dayData,
+  } = useDailyMarketData<Topix33DayData>({
+    activeDate: currentSelectedDate,
+    initialDayData,
+    routePrefix: "/tools/topix33/data",
+  });
 
   const rankingMaxAbs = useMemo(() => {
     if (!dayData) return 1;

--- a/app/tools/topix33/data/[date]/route.ts
+++ b/app/tools/topix33/data/[date]/route.ts
@@ -1,27 +1,4 @@
-import { NextResponse } from "next/server";
 import { loadTopix33DayData } from "../../data-loader";
+import { buildDateDataRoute } from "@/app/tools/_shared/date-data-route";
 
-type RouteContext = {
-  params: Promise<{
-    date: string;
-  }>;
-};
-
-export async function GET(_request: Request, context: RouteContext) {
-  const { date } = await context.params;
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: "invalid date" }, { status: 400 });
-  }
-
-  const dayData = await loadTopix33DayData(date);
-  if (!dayData) {
-    return NextResponse.json({ error: "not found" }, { status: 404 });
-  }
-
-  return NextResponse.json(dayData, {
-    headers: {
-      "Cache-Control": "public, max-age=300, s-maxage=300",
-    },
-  });
-}
+export const GET = buildDateDataRoute(loadTopix33DayData);

--- a/app/tools/topix33/page.tsx
+++ b/app/tools/topix33/page.tsx
@@ -3,6 +3,10 @@ import ToolClient from "./ToolClient";
 import { loadTopix33DayData, loadTopix33Manifest } from "./data-loader";
 import type { Topix33PageData } from "./types";
 import { loadJpxMarketClosedData } from "@/lib/jpx-market-closed";
+import {
+  filterVisibleTradingDates,
+  findFirstUsableDayData,
+} from "@/app/tools/_shared/market-trading-dates";
 
 export const metadata: Metadata = {
   title: "TOPIX33業種 | mini-tools",
@@ -13,39 +17,20 @@ export const metadata: Metadata = {
   },
 };
 
-function getDayOfWeek(dateStr: string) {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  return new Date(y, m - 1, d).getDay();
-}
-
-function isWeekendDate(dateStr: string) {
-  const day = getDayOfWeek(dateStr);
-  return day === 0 || day === 6;
-}
-
 async function loadData(): Promise<Topix33PageData> {
   const [manifest, holidays] = await Promise.all([
     loadTopix33Manifest(),
     loadJpxMarketClosedData(),
   ]);
 
-  const holidayMap = new Map((holidays?.days ?? []).map((day) => [day.date, day]));
-  const visibleDates = manifest.dates.filter((date) => {
-    if (holidayMap.get(date)?.market_closed) {
-      return false;
-    }
-    return !isWeekendDate(date);
-  });
-
-  let initialDayData = null;
-
-  for (const date of visibleDates) {
-    const dayData = await loadTopix33DayData(date);
-    if (dayData && dayData.sectors.length > 0) {
-      initialDayData = dayData;
-      break;
-    }
-  }
+  const visibleDates = filterVisibleTradingDates(manifest.dates, holidays);
+  const { matched } = await findFirstUsableDayData(
+    visibleDates,
+    loadTopix33DayData,
+    (dayData): dayData is NonNullable<Topix33PageData["initialDayData"]> =>
+      !!dayData && dayData.sectors.length > 0,
+  );
+  const initialDayData = matched?.dayData ?? null;
 
   const filteredManifest = {
     ...manifest,

--- a/app/tools/total/ClientOnly.tsx
+++ b/app/tools/total/ClientOnly.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { createClientOnlyTool } from "@/components/createClientOnlyTool";
 
-const ToolClient = dynamic(() => import("./ToolClient"), { ssr: false });
+const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
 
-export default function ClientOnly() {
-  return <ToolClient />;
-}
+export default ClientOnly;

--- a/app/tools/yutai-expiry/ClientOnly.tsx
+++ b/app/tools/yutai-expiry/ClientOnly.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { createClientOnlyTool } from "@/components/createClientOnlyTool";
 
-const ToolClient = dynamic(() => import("./ToolClient"), { ssr: false });
+const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
 
-export default function ClientOnly() {
-  return <ToolClient />;
-}
+export default ClientOnly;

--- a/app/tools/yutai-memo/ClientOnly.tsx
+++ b/app/tools/yutai-memo/ClientOnly.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { createClientOnlyTool } from "@/components/createClientOnlyTool";
 
-const ToolClient = dynamic(() => import("./ToolClient"), { ssr: false });
+const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
 
-export default function ClientOnly() {
-  return <ToolClient />;
-}
+export default ClientOnly;

--- a/components/createClientOnlyTool.tsx
+++ b/components/createClientOnlyTool.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import type { ComponentType } from "react";
+import dynamic from "next/dynamic";
+
+type ToolClientModule = {
+  default: ComponentType;
+};
+
+export function createClientOnlyTool(
+  loader: () => Promise<ToolClientModule>,
+) {
+  const ToolClient = dynamic(loader, { ssr: false });
+
+  return function ClientOnlyTool() {
+    return <ToolClient />;
+  };
+}

--- a/docs/decision-log/2026-04-11-commonization-priority.md
+++ b/docs/decision-log/2026-04-11-commonization-priority.md
@@ -1,0 +1,83 @@
+# 2026-04-11 共通化 Issue の着手順メモ
+
+## 背景
+
+- repo 規模感の調査の中で、完全重複と構造重複が複数見つかった。
+- その結果をもとに、共通化候補を次の Issue に分割した。
+  - `#215` `ops(ui): localStorage系 ClientOnly ラッパーを共通化する`
+  - `#216` `ops(market-tools): 日付別 data route の共通化と検証ポイントを整理する`
+  - `#217` `ops(market-tools): visibleDates と初期日データ選定ロジックを整理する`
+  - `#218` `ops(market-tools): ToolClient の日次データ取得 state を hook 化する`
+  - `#219` `UI(small-tools): charcount と total の共通ページ shell を整理する`
+- 進め方は後で見直す可能性があるため、現時点の推奨順だけでも docs に残しておく。
+
+## 今回決めたこと
+
+- 共通化は、次の順で進めるのを基本方針とする。
+
+1. `#215` `ClientOnly` 共通化
+2. `#216` market tools の date route 共通化
+3. `#217` visibleDates / 初期日選定ロジック整理
+4. `#218` ToolClient の日次取得 state hook 化
+5. `#219` `charcount` / `total` の page shell 共通化
+
+- この順番は固定ではなく、途中で前提や優先度が変わったら見直してよい。
+- ただし、見直した場合も「なぜ順番を変えたか」が追えるように docs か Issue に残す。
+
+## 判断理由
+
+- `#215` は完全重複で、変更範囲が狭く、効果に対してリスクが小さい。
+- `#216` と `#217` は market tools の基盤整理で、後続の `#218` より先にそろえた方が安全。
+- `#218` は loading / error / cache の見え方に直結するため、route と SSR 側の共通化後に着手する。
+- `#219` は整理価値はあるが影響範囲が限定的で、前半 4 件より優先度は低い。
+
+## UI確認の基本タイミング
+
+- `#215`
+  - 共通ラッパー導入直後
+  - `charcount` / `total` の入力と再読み込み確認後
+  - `yutai-memo` / `yutai-expiry` の hydration warning 確認時
+- `#216`
+  - route helper 導入直後
+  - `stock-ranking` / `topix33` / `nikkei-contribution` の日付切替確認時
+- `#217`
+  - helper 導入直後
+  - 各ページの初回表示日と表示対象日一覧確認時
+- `#218`
+  - hook 抽出直後
+  - 初回ロード、日付切替、エラー時の UI 確認時
+- `#219`
+  - shell 化直後
+  - モバイル / デスクトップ両方のレイアウト確認時
+
+## 影響範囲
+
+- `docs/decision-log/`
+- `docs/index.md`
+- 共通化候補の優先順位づけ
+- 今後の PR 分割方針
+
+## 残課題
+
+- 実際の着手時に、Issue の分け方をさらに細かくするかは未確定。
+- `#214` の JSON / fallback 方針整理との兼ね合いで、market tools 側の優先順位が変わる可能性はある。
+- 各 Issue の実装前に、必要なら UAT 観点を追加で整理する。
+
+## 関連
+
+- Issue:
+  - `#214`
+  - `#215`
+  - `#216`
+  - `#217`
+  - `#218`
+  - `#219`
+- PR:
+  - なし
+- 参照 docs:
+  - `docs/docs-writing-workflow.md`
+  - `docs/system-architecture-overview.md`
+  - `docs/market-tools-data-fetch-paths.md`
+  - `docs/decision-log/2026-03-12-ssr-localstorage-hydration-guidelines.md`
+  - `docs/decision-log/2026-04-07-loading-ui-and-parallel-fetch.md`
+  - `docs/decision-log/2026-04-11-loading-spinner-pattern.md`

--- a/docs/devlog/2026-04-11-commonization-handoff.md
+++ b/docs/devlog/2026-04-11-commonization-handoff.md
@@ -1,0 +1,55 @@
+# 2026-04-11 commonization PR handoff
+
+## 現在地
+
+- PR: `#221`
+- branch: `feature-commonization-shared-foundation`
+- preview: Vercel `Ready`
+- Codex CLI review: 指摘解消後、最終結果は問題なし
+
+## 今回完了したもの
+
+- `#215` `ClientOnly` 共通化
+- `#216` market tools の date route 共通化
+- `#217` visibleDates / 初期日選定ロジック整理
+- `#218` 日次取得 state の hook 化
+
+## PR #221 の要点
+
+- `components/createClientOnlyTool.tsx` を追加
+- `app/tools/_shared/date-data-route.ts` を追加
+- `app/tools/_shared/market-trading-dates.ts` を追加
+- `app/tools/_shared/use-daily-market-data.ts` を追加
+- `stock-ranking` / `topix33` / `nikkei-contribution` の route / page / client state を整理
+- `nikkei-contribution` は review 指摘を受けて fallback 日読込中の loading 表示も補正済み
+
+## 確認済み
+
+- `npm run lint`
+- ローカル HTTP 到達確認
+  - `/tools/charcount`
+  - `/tools/total`
+  - `/tools/yutai-memo`
+  - `/tools/yutai-expiry`
+  - `/tools/stock-ranking`
+  - `/tools/topix33`
+  - `/tools/nikkei-contribution`
+- internal route の `200 / 400`
+- `codex --profile review-low review --base main`
+
+## 次の担当がまず見るところ
+
+1. PR `#221` のレビューコメント有無
+2. Vercel preview の実 UI 確認
+3. 問題なければ merge
+
+## 後続タスク
+
+- `#219` `charcount` / `total` の page shell 共通化
+- `#214` JSON 同梱データと fallback 方針整理
+- `#220` dev 環境 UI スモークテストと artifact 収集
+
+## メモ
+
+- 今回の本線は shared helper 抽出なので、次は `#219` より先に `#221` のレビュー対応を優先するのが自然。
+- `#220` は今すぐ必須ではないが、今後の refactor 継続にはかなり効く。

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-04-11 共通化 Issue の着手順メモ](./decision-log/2026-04-11-commonization-priority.md)
 - [2026-04-11 ローディングUIのスピナー2段パターン統一](./decision-log/2026-04-11-loading-spinner-pattern.md)
 - [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@
 
 日々の開発作業や試行錯誤の記録です。
 
+- [2026-04-11 commonization PR handoff](./devlog/2026-04-11-commonization-handoff.md)
 - [2026-04-05 market tools 本番確認メモ](./devlog/2026-04-05-market-tools-production-verification.md)
 - [2026-01-11 QR 共有 UI 改善ログ](./devlog/2026-01-11-qr-share-ui-improvement.md)
 - [2026-01-10 Git 学習ログ](./devlog/2026-01-10_git-learning-log.md)


### PR DESCRIPTION
## 概要

shared helper を導入して、localStorage 系 `ClientOnly` と market tools の route / page / client state の重複を整理しました。

## 変更内容

- `components/createClientOnlyTool.tsx` を追加し、`charcount` / `total` / `yutai-expiry` / `yutai-memo` の `ClientOnly` を共通化
- `app/tools/_shared/date-data-route.ts` を追加し、market tools の date route を共通化
- `app/tools/_shared/market-trading-dates.ts` を追加し、visible dates と初期表示日探索の共通ロジックを整理
- `app/tools/_shared/use-daily-market-data.ts` を追加し、`stock-ranking` / `topix33` / `nikkei-contribution` の日次取得 state を hook 化
- `nikkei-contribution` では review 指摘に対応し、fallback 日の読込中も空状態に落ちないよう補正
- 共通化の着手順メモを `docs/decision-log/2026-04-11-commonization-priority.md` に追加し、`docs/index.md` から辿れるように更新

## 確認項目

- `npm run lint`
- ローカル HTTP 確認
  - `/tools/charcount`
  - `/tools/total`
  - `/tools/yutai-memo`
  - `/tools/yutai-expiry`
  - `/tools/stock-ranking`
  - `/tools/topix33`
  - `/tools/nikkei-contribution`
- internal route 確認
  - `stock-ranking` / `topix33` / `nikkei-contribution` の date route が `200`
  - invalid date が `400 {"error":"invalid date"}`
- `codex --profile review-low review --base main`
  - 最終結果: 問題なし

## 関連 Issue

- Closes #215
- Closes #216
- Closes #217
- Closes #218
- Related #214
- Related #220