### PR TITLE
refactor(ui): commonize small tool page shell

### DIFF
--- a/app/tools/charcount/ToolClient.tsx
+++ b/app/tools/charcount/ToolClient.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
-import ShareButtons from "@/components/ShareButtonsSuspended";
-import MonetizeBar from "@/components/MonetizeBar";
+import SimpleInputToolLayout from "@/components/SimpleInputToolLayout";
 import { track } from "@/lib/analytics";
 
 const STORAGE_KEY = "mini_tools_charcount_text_v1";
@@ -161,58 +159,16 @@ export default function ToolClient() {
   const progressPct = isEmpty ? 0 : Math.min((stats.xEstimated / 140) * 100, 100);
 
   return (
-    <main style={{ maxWidth: 820, margin: "0 auto", padding: "16px 16px 48px" }}>
-
-      {/* ナビ */}
-      <div style={{ marginBottom: 20 }}>
-        <Link
-          href="/"
-          onClick={() => track("nav_clicked", { to: "home_from_tool" })}
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            padding: "6px 12px",
-            borderRadius: 999,
-            border: "1px solid var(--color-border-strong)",
-            textDecoration: "none",
-            color: "var(--color-text-sub)",
-            fontSize: 13,
-            fontWeight: 600,
-          }}
-        >
-          ← ツール一覧
-        </Link>
-      </div>
-
-      {/* ヒーロー */}
-      <div style={{ marginBottom: 24 }}>
-        <div style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 6,
-          padding: "4px 10px",
-          borderRadius: 999,
-          background: "var(--color-accent-sub)",
-          color: "var(--color-accent)",
-          fontSize: 11,
-          fontWeight: 800,
-          marginBottom: 10,
-        }}>
-          𝕏 X投稿向け
-        </div>
-        <h1 style={{ fontSize: 26, fontWeight: 800, margin: "0 0 6px", letterSpacing: -0.4 }}>
-          X投稿文字数カウント
-        </h1>
-        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--color-text-sub)" }}>
-          140字に収めたい投稿文を貼るだけで確認できます。URL・絵文字も正確に推定。
-        </p>
-      </div>
-
-      {/* 2カラムレイアウト */}
-      <div className="charcount-layout">
-
-        {/* 左: 入力エリア */}
+    <SimpleInputToolLayout
+      badge="𝕏 X投稿向け"
+      title="X投稿文字数カウント"
+      description="140字に収めたい投稿文を貼るだけで確認できます。URL・絵文字も正確に推定。"
+      shareText="X投稿文字数カウント：140字に収まるかを確認できる"
+      footerNote="※入力はこの端末（ブラウザ）にのみ保存されます（localStorage）。"
+      maxWidth={820}
+      resultColumnWidth={260}
+      mobileBreakpoint={600}
+      inputPanel={
         <div className="charcount-input-col">
           <div style={{
             background: "var(--color-bg-card)",
@@ -264,8 +220,8 @@ export default function ToolClient() {
             </div>
           </div>
         </div>
-
-        {/* 右: 結果エリア */}
+      }
+      resultPanel={
         <div className="charcount-result-col">
           <div style={{
             background: "var(--color-bg-card)",
@@ -450,33 +406,7 @@ export default function ToolClient() {
             </div>
           </div>
         </div>
-      </div>
-
-      <div style={{ marginTop: 32 }}>
-        <ShareButtons text="X投稿文字数カウント：140字に収まるかを確認できる" />
-        <MonetizeBar />
-      </div>
-
-      <div style={{ marginTop: 16, fontSize: 12, color: "var(--color-text-muted)" }}>
-        ※入力はこの端末（ブラウザ）にのみ保存されます（localStorage）。
-      </div>
-
-      <style>{`
-        .charcount-layout {
-          display: grid;
-          grid-template-columns: 1fr 260px;
-          gap: 16px;
-          align-items: start;
-        }
-        @media (max-width: 600px) {
-          .charcount-layout {
-            grid-template-columns: 1fr;
-          }
-          .charcount-result-col {
-            order: -1;
-          }
-        }
-      `}</style>
-    </main>
+      }
+    />
   );
 }

--- a/app/tools/total/ToolClient.tsx
+++ b/app/tools/total/ToolClient.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import ShareButtons from "@/components/ShareButtonsSuspended";
-import MonetizeBar from "@/components/MonetizeBar";
+import SimpleInputToolLayout from "@/components/SimpleInputToolLayout";
 import { track } from "@/lib/analytics";
-import Link from "next/link";
 
 const STORAGE_KEY = "mini_tools_total_lines_v1";
 
@@ -67,58 +65,15 @@ export default function ToolClient() {
   const isEmpty = lines.trim().length === 0;
 
   return (
-    <main style={{ maxWidth: 760, margin: "0 auto", padding: "16px 16px 48px" }}>
-
-      {/* ナビ */}
-      <div style={{ marginBottom: 20 }}>
-        <Link
-          href="/"
-          onClick={() => track("nav_clicked", { to: "home_from_tool" })}
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            padding: "6px 12px",
-            borderRadius: 999,
-            border: "1px solid var(--color-border-strong)",
-            textDecoration: "none",
-            color: "var(--color-text-sub)",
-            fontSize: 13,
-            fontWeight: 600,
-          }}
-        >
-          ← ツール一覧
-        </Link>
-      </div>
-
-      {/* ヒーロー */}
-      <div style={{ marginBottom: 24 }}>
-        <div style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 6,
-          padding: "4px 10px",
-          borderRadius: 999,
-          background: "var(--color-accent-sub)",
-          color: "var(--color-accent)",
-          fontSize: 11,
-          fontWeight: 800,
-          marginBottom: 10,
-        }}>
-          🧮 合計計算
-        </div>
-        <h1 style={{ fontSize: 26, fontWeight: 800, margin: "0 0 6px", letterSpacing: -0.4 }}>
-          数字を貼るだけで合計
-        </h1>
-        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--color-text-sub)" }}>
-          1行1つの数字を入れるだけ。カンマ・円・マイナスも自動で読み取ります。
-        </p>
-      </div>
-
-      {/* 2カラムレイアウト */}
-      <div className="total-layout">
-
-        {/* 左: 入力エリア */}
+    <SimpleInputToolLayout
+      badge="🧮 合計計算"
+      title="数字を貼るだけで合計"
+      description="1行1つの数字を入れるだけ。カンマ・円・マイナスも自動で読み取ります。"
+      shareText="合計計算ツール：数字を貼るだけで合計できる"
+      maxWidth={760}
+      resultColumnWidth={220}
+      mobileBreakpoint={560}
+      inputPanel={
         <div className="total-input-col">
           <div style={{
             background: "var(--color-bg-card)",
@@ -167,8 +122,8 @@ export default function ToolClient() {
             </div>
           </div>
         </div>
-
-        {/* 右: 結果エリア */}
+      }
+      resultPanel={
         <div className="total-result-col">
           <div style={{
             background: "var(--color-bg-card)",
@@ -264,29 +219,7 @@ export default function ToolClient() {
             </div>
           </div>
         </div>
-      </div>
-
-      <div style={{ marginTop: 32 }}>
-        <ShareButtons text="合計計算ツール：数字を貼るだけで合計できる" />
-        <MonetizeBar />
-      </div>
-
-      <style>{`
-        .total-layout {
-          display: grid;
-          grid-template-columns: 1fr 220px;
-          gap: 16px;
-          align-items: start;
-        }
-        @media (max-width: 560px) {
-          .total-layout {
-            grid-template-columns: 1fr;
-          }
-          .total-result-col {
-            order: -1;
-          }
-        }
-      `}</style>
-    </main>
+      }
+    />
   );
 }

--- a/components/SimpleInputToolLayout.tsx
+++ b/components/SimpleInputToolLayout.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useId, type ReactNode } from "react";
+import Link from "next/link";
+import ShareButtons from "@/components/ShareButtonsSuspended";
+import MonetizeBar from "@/components/MonetizeBar";
+import { track } from "@/lib/analytics";
+
+type SimpleInputToolLayoutProps = {
+  badge: ReactNode;
+  title: string;
+  description: string;
+  inputPanel: ReactNode;
+  resultPanel: ReactNode;
+  shareText: string;
+  footerNote?: ReactNode;
+  maxWidth?: number;
+  resultColumnWidth?: number;
+  mobileBreakpoint?: number;
+};
+
+export default function SimpleInputToolLayout({
+  badge,
+  title,
+  description,
+  inputPanel,
+  resultPanel,
+  shareText,
+  footerNote,
+  maxWidth = 820,
+  resultColumnWidth = 260,
+  mobileBreakpoint = 600,
+}: SimpleInputToolLayoutProps) {
+  const layoutId = useId().replace(/:/g, "");
+  const layoutClassName = `simple-input-layout-${layoutId}`;
+  const resultClassName = `simple-input-result-${layoutId}`;
+
+  return (
+    <main style={{ maxWidth, margin: "0 auto", padding: "16px 16px 48px" }}>
+      <div style={{ marginBottom: 20 }}>
+        <Link
+          href="/"
+          onClick={() => track("nav_clicked", { to: "home_from_tool" })}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "6px 12px",
+            borderRadius: 999,
+            border: "1px solid var(--color-border-strong)",
+            textDecoration: "none",
+            color: "var(--color-text-sub)",
+            fontSize: 13,
+            fontWeight: 600,
+          }}
+        >
+          ← ツール一覧
+        </Link>
+      </div>
+
+      <div style={{ marginBottom: 24 }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "4px 10px",
+            borderRadius: 999,
+            background: "var(--color-accent-sub)",
+            color: "var(--color-accent)",
+            fontSize: 11,
+            fontWeight: 800,
+            marginBottom: 10,
+          }}
+        >
+          {badge}
+        </div>
+        <h1 style={{ fontSize: 26, fontWeight: 800, margin: "0 0 6px", letterSpacing: -0.4 }}>
+          {title}
+        </h1>
+        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--color-text-sub)" }}>
+          {description}
+        </p>
+      </div>
+
+      <div className={layoutClassName}>
+        <div>{inputPanel}</div>
+        <div className={resultClassName}>{resultPanel}</div>
+      </div>
+
+      <div style={{ marginTop: 32 }}>
+        <ShareButtons text={shareText} />
+        <MonetizeBar />
+      </div>
+
+      {footerNote ? (
+        <div style={{ marginTop: 16, fontSize: 12, color: "var(--color-text-muted)" }}>
+          {footerNote}
+        </div>
+      ) : null}
+
+      <style>{`
+        .${layoutClassName} {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) ${resultColumnWidth}px;
+          gap: 16px;
+          align-items: start;
+        }
+        @media (max-width: ${mobileBreakpoint}px) {
+          .${layoutClassName} {
+            grid-template-columns: 1fr;
+          }
+          .${resultClassName} {
+            order: -1;
+          }
+        }
+      `}</style>
+    </main>
+  );
+}

--- a/docs/decision-log/2026-04-11-small-tools-page-shell-commonization.md
+++ b/docs/decision-log/2026-04-11-small-tools-page-shell-commonization.md
@@ -1,0 +1,35 @@
+# 2026-04-11 小さな入力系 tool の page shell 共通化
+
+## 結論
+
+`charcount` と `total` は、固有ロジックは各 `ToolClient.tsx` に残しつつ、ページ骨格だけ `components/SimpleInputToolLayout.tsx` に共通化する。
+
+## 背景
+
+- `charcount` と `total` は UI 骨格がかなり近い
+- 共通点は、戻るナビ、ヒーロー見出し、2カラムレイアウト、下部の共有導線
+- 一方で、入力欄や結果カードの中身はそれぞれ独自で、過度な抽象化は保守性を下げやすい
+
+## 決めたこと
+
+- 共通化対象は page shell に限定する
+- shell は `badge` / `title` / `description` / `inputPanel` / `resultPanel` / `shareText` を props で受ける
+- レイアウト差分は `maxWidth` / `resultColumnWidth` / `mobileBreakpoint` で吸収する
+- 各 tool の入力状態、計算、ボタン挙動、注記文言は引き続き各 `ToolClient.tsx` 側で持つ
+
+## 理由
+
+- 新規の小さな入力系 tool を追加するとき、まず shell を再利用できる
+- 見た目の統一感を出しつつ、tool 固有の UI 変更をしやすい
+- `charcount` のように入力欄の高さ固定や補足注記が少し特殊でも、slot 方式なら無理なく対応できる
+
+## 影響範囲
+
+- `app/tools/charcount/ToolClient.tsx`
+- `app/tools/total/ToolClient.tsx`
+- `components/SimpleInputToolLayout.tsx`
+
+## 補足
+
+- 現時点では `charcount` と `total` を対象にする
+- 他の小さな入力系 tool へ広げる場合も、まずは page shell の一致度を見てから適用する

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 設計・方針・トレードオフの判断理由を記録します。
 
 - [2026-04-11 共通化 Issue の着手順メモ](./decision-log/2026-04-11-commonization-priority.md)
+- [2026-04-11 小さな入力系 tool の page shell 共通化](./decision-log/2026-04-11-small-tools-page-shell-commonization.md)
 - [2026-04-11 ローディングUIのスピナー2段パターン統一](./decision-log/2026-04-11-loading-spinner-pattern.md)
 - [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)


### PR DESCRIPTION
## 概要

`charcount` と `total` の page shell を共通化し、小さな入力系 tool のレイアウト重複を整理しました。

## 変更内容

- `components/SimpleInputToolLayout.tsx` を追加
- `charcount` / `total` の戻るナビ、ヒーロー、2 カラムレイアウト、共有導線を共通 shell に移動
- 各 tool の入力ロジック、計算ロジック、結果カード固有 UI は各 `ToolClient.tsx` に維持
- page shell 共通化の判断を decision log に記録し、`docs/index.md` から辿れるよう更新

## 確認項目

- `npm run lint`
- `npm run build`
  - TypeScript / compile は通過
  - 静的ページ生成中に Next.js build worker が `3221226505` で終了し、環境寄りの失敗が継続

## 関連 Issue

Closes #219
