### PR TITLE
docs(data): define json fallback policy

### DIFF
--- a/app/tools/stock-ranking/__tests__/data-loader.test.ts
+++ b/app/tools/stock-ranking/__tests__/data-loader.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { RankingManifest, RankingDayData } from "../types";
 
 vi.mock("node:fs/promises", () => ({
   readFile: vi.fn(),
@@ -7,18 +6,9 @@ vi.mock("node:fs/promises", () => ({
 
 import { readFile } from "node:fs/promises";
 import { loadRankingManifest, loadRankingDayData } from "../data-loader";
+import { SAMPLE_DAY_DATA, SAMPLE_MANIFEST } from "./fixtures";
 
 const mockReadFile = vi.mocked(readFile);
-
-const SAMPLE_MANIFEST: RankingManifest = {
-  dates: ["2025-04-01", "2025-04-02"],
-  latest: "2025-04-02",
-};
-
-const SAMPLE_DAY_DATA: RankingDayData = {
-  date: "2025-04-02",
-  records: [],
-};
 
 function makeFetchOk(body: unknown): Response {
   return {

--- a/app/tools/stock-ranking/__tests__/fixtures.ts
+++ b/app/tools/stock-ranking/__tests__/fixtures.ts
@@ -1,0 +1,29 @@
+import type { RankingDayData, RankingManifest } from "../types";
+
+export const SAMPLE_MANIFEST: RankingManifest = {
+  dates: ["2025-04-01", "2025-04-02"],
+  latest: "2025-04-02",
+};
+
+export const SAMPLE_DAY_DATA: RankingDayData = {
+  date: "2025-04-02",
+  records: [
+    {
+      date: "2025-04-02",
+      market: "プライム",
+      ranking: "値上がり率",
+      page: 1,
+      rank: 1,
+      name: "テスト銘柄",
+      code: "1234",
+      marketLabel: "東証プライム",
+      industry: "情報・通信業",
+      price: 1234,
+      time: "15:30",
+      change: 120,
+      changeRate: 10.77,
+      volume: 123456,
+      value: 98765432,
+    },
+  ],
+};

--- a/app/tools/stock-ranking/__tests__/fixtures.ts
+++ b/app/tools/stock-ranking/__tests__/fixtures.ts
@@ -9,10 +9,8 @@ export const SAMPLE_DAY_DATA: RankingDayData = {
   date: "2025-04-02",
   records: [
     {
-      date: "2025-04-02",
       market: "プライム",
       ranking: "値上がり率",
-      page: 1,
       rank: 1,
       name: "テスト銘柄",
       code: "1234",

--- a/docs/decision-log/2026-04-11-json-fallback-policy.md
+++ b/docs/decision-log/2026-04-11-json-fallback-policy.md
@@ -1,0 +1,59 @@
+# 2026-04-11 JSON 同梱データと fallback 方針整理
+
+## 結論
+
+- market tools の本番主経路は引き続き `MARKET_INFO_API_BASE_URL` とする
+- repo 同梱 JSON fallback は当面残すが、役割は `開発` と `緊急退避` に限定する
+- `stock-ranking` の日次 JSON は履歴アーカイブ置き場として repo を使わず、fallback 用に最小限だけ残す前提で運用する
+- `public/data/jpx_listed_companies.json` は、サイズと更新頻度の観点から当面 repo 同梱維持とする
+- テストは本番フル JSON を参照せず、小さい fixture を基本にする
+
+## 背景
+
+- `stock-ranking` の日次 JSON が repo 規模と差分ノイズの大半を占めている
+- 一方で market tools の標準入口はすでに `MARKET_INFO_API_BASE_URL` に寄せる方針が決まっている
+- JSON を一律に扱うのではなく、更新頻度、サイズ、fallback の必要性で扱いを分けた方が運用しやすい
+
+## 決めたこと
+
+### 1. `stock-ranking` 日次 JSON
+
+- `mini-tools` の標準取得は `GET /ranking/manifest` と `GET /ranking/{date}` を使う
+- repo 同梱 JSON は fallback 用であり、履歴保存の主置き場ではない
+- 今後のデータ更新では、repo に置く日次 JSON は `manifest` と開発・緊急退避に必要な最小限の期間に絞る
+- 大きい JSON 更新はコード変更 PR と分離する
+
+### 2. `jpx_listed_companies.json`
+
+- 当面は `public/data/jpx_listed_companies.json` を repo 同梱で維持する
+- 理由は、`stock-ranking` 日次データほどサイズが大きくなく、更新頻度も高くないため
+- ただし、将来的にサイズ増加や更新運用が重くなったら API 化を再検討する
+
+### 3. テストデータ
+
+- loader / parser テストは本番フル JSON ではなく、小さい fixture を使う
+- フルデータ相当の fixture は、本当に必要なケースだけ限定して追加する
+- まず `stock-ranking` の loader テストから小さい fixture ベースを明示する
+
+### 4. docs / 調査運用
+
+- repo 規模や LOC を見るときは、JSON を除いた数値も併記する
+- fallback の役割は docs 上でも `開発・緊急退避` と明示する
+
+## 理由
+
+- 本番主経路を API に寄せる方針と、repo 容量の抑制を両立できる
+- fallback をゼロにはしないので、ローカル開発や API 障害時の保険を維持できる
+- `jpx_listed_companies.json` は現時点では運用コストより repo 同梱の単純さの利点が大きい
+- テストが本番データに引っ張られなくなると、レビューと保守がしやすい
+
+## 今回の影響範囲
+
+- `stock-ranking` の test fixture 運用
+- docs の fallback 説明
+- 今後のデータ更新 PR の分け方
+
+## 補足
+
+- `stock-ranking` の既存同梱 JSON をどの時点で何日分まで prune するかは、データ更新 PR と切り分けて進める
+- 今回は「削減方針の明文化」と「テストの本番 JSON 非依存化」を優先する

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 設計・方針・トレードオフの判断理由を記録します。
 
 - [2026-04-11 共通化 Issue の着手順メモ](./decision-log/2026-04-11-commonization-priority.md)
+- [2026-04-11 JSON 同梱データと fallback 方針整理](./decision-log/2026-04-11-json-fallback-policy.md)
 - [2026-04-11 小さな入力系 tool の page shell 共通化](./decision-log/2026-04-11-small-tools-page-shell-commonization.md)
 - [2026-04-11 ローディングUIのスピナー2段パターン統一](./decision-log/2026-04-11-loading-spinner-pattern.md)
 - [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)

--- a/docs/market-tools-data-fetch-paths.md
+++ b/docs/market-tools-data-fetch-paths.md
@@ -27,7 +27,7 @@
 | --- | --- | --- | --- | --- | --- |
 | `topix33` | サーバーで `loadTopix33Manifest()` / `loadTopix33DayData()` | クライアントは `/tools/topix33/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/topix33/data` のローカル JSON | 同じデータソースを、SSR と client route の 2 入口で使っている |
 | `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
-| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | 休場日 API は `GET /market-calendar/jpx-closed` を使う |
+| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | fallback は開発・緊急退避用。repo 同梱 JSON は履歴保管の主用途にしない |
 | `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | SBI は `is_short=true` の扱い有無だけを表示し、在庫状態では除外しない |
 | `earnings-calendar` | サーバーで `loadEarningsCalendarPageData()` を呼ぶ | クライアント再 fetch なし | `MARKET_INFO_API_BASE_URL` | あり。国内は同梱 JSON、海外は API 未設定/失敗時は非表示 | 国内は repo 同梱 JSON、海外は `earnings-calendar/overseas/*` API を読む |
 
@@ -77,6 +77,13 @@
 - fallback の原則
 - cache-control / `revalidate` の原則
 - 「外部 API の JSON をそのまま返す route」と「加工して返す route」の区別
+
+## fallback 方針の補足
+
+- market tools の本番主経路は `MARKET_INFO_API_BASE_URL`
+- repo 同梱 JSON fallback は当面残すが、役割は `開発` と `緊急退避`
+- 特に `stock-ranking` は、repo 同梱 JSON を履歴アーカイブとして増やし続けない
+- `public/data/jpx_listed_companies.json` は現時点では repo 同梱維持でよい
 
 ## 関連ファイル
 


### PR DESCRIPTION
## 概要

JSON 同梱データの置き方と fallback 方針を docs に整理し、`stock-ranking` の loader テストを本番フル JSON 非依存の fixture ベースへ寄せました。

## 変更内容

- `docs/decision-log/2026-04-11-json-fallback-policy.md` を追加
- `docs/market-tools-data-fetch-paths.md` に fallback の役割を追記
- `docs/index.md` に decision log への導線を追加
- `app/tools/stock-ranking/__tests__/fixtures.ts` を追加
- `stock-ranking` loader テストのサンプルデータを fixture に切り出し

## 確認項目

- `npm run lint`
- `npm test -- app/tools/stock-ranking/__tests__/data-loader.test.ts`

## 関連 Issue

Closes #214
