### PR TITLE
test(ui): add local smoke test foundation

### DIFF
--- a/docs/decision-log/2026-04-11-ui-smoke-test-foundation.md
+++ b/docs/decision-log/2026-04-11-ui-smoke-test-foundation.md
@@ -1,0 +1,35 @@
+# 2026-04-11 dev 環境 UI スモークテスト基盤
+
+## 結論
+
+- local 専用の最小 UI スモークテスト基盤として Playwright を導入する
+- 実行入口は `npm run test:ui`
+- 初期対象は `charcount` / `total` / `yutai-memo` / `yutai-expiry` / `stock-ranking` / `topix33` / `nikkei-contribution`
+- artifact は `.tmp/ui-smoke-artifacts/` と `.tmp/ui-smoke-report/` に出力する
+
+## 背景
+
+- 共通化や refactor が進み、lint だけでは UI 退行を拾いにくくなってきた
+- 特に「ページが開くか」「console error がないか」「failed request がないか」「主要ページの見た目を残せるか」をまとめて確認したい
+
+## 決めたこと
+
+- まずは CI ではなく local 専用で始める
+- 最初の判定軸は次の 4 つに絞る
+  - ページが開く
+  - H1 が表示される
+  - console error がない
+  - request failure がない
+- `charcount` と `total` だけは簡単な入力操作も smoke に含める
+- screenshot と json artifact を保存して、Codex からも追いやすくする
+
+## 理由
+
+- 最小のセットでも、共通化時の明確な崩れをかなり拾える
+- local 専用なら導入コストを抑えつつ、必要になったら CI へ広げやすい
+- baseline 比較や visual regression は後から追加できる
+
+## 補足
+
+- market tools のデータ状態により表示内容は変わるため、初期版では厳密な文面比較より「到達」「主要見出し」「エラーなし」を優先する
+- artifact の保存先は `.gitignore` 済みの `.tmp/` 配下に寄せる

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@
 - [2026-04-11 共通化 Issue の着手順メモ](./decision-log/2026-04-11-commonization-priority.md)
 - [2026-04-11 JSON 同梱データと fallback 方針整理](./decision-log/2026-04-11-json-fallback-policy.md)
 - [2026-04-11 小さな入力系 tool の page shell 共通化](./decision-log/2026-04-11-small-tools-page-shell-commonization.md)
+- [2026-04-11 dev 環境 UI スモークテスト基盤](./decision-log/2026-04-11-ui-smoke-test-foundation.md)
 - [2026-04-11 ローディングUIのスピナー2段パターン統一](./decision-log/2026-04-11-loading-spinner-pattern.md)
 - [2026-04-07 loading.tsx 追加と並列 fetch 化](./decision-log/2026-04-07-loading-ui-and-parallel-fetch.md)
 - [2026-04-05 yutai-candidates の SBI 短期対象表示ルール](./decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^19.2.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "25.0.3",
         "@types/react": "19.2.7",
         "@vitest/coverage-v8": "^4.1.2",
@@ -2473,6 +2474,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -8027,6 +8044,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:ui": "playwright test --config=playwright.ui-smoke.config.ts"
   },
   "dependencies": {
     "next": "^16.0.10",
@@ -18,6 +19,7 @@
     "react-dom": "^19.2.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@vitest/coverage-v8": "^4.1.2",

--- a/playwright.ui-smoke.config.ts
+++ b/playwright.ui-smoke.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.UI_SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
+
+export default defineConfig({
+  testDir: "./tests/ui-smoke",
+  timeout: 30_000,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [["list"], ["html", { outputFolder: ".tmp/ui-smoke-report", open: "never" }]],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  outputDir: ".tmp/ui-smoke-artifacts/test-results",
+  webServer: {
+    command: "npm run dev",
+    url: baseURL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/playwright.ui-smoke.config.ts
+++ b/playwright.ui-smoke.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const baseURL = process.env.UI_SMOKE_BASE_URL ?? "http://127.0.0.1:3000";
+const basePort = new URL(baseURL).port || "80";
 
 export default defineConfig({
   testDir: "./tests/ui-smoke",
@@ -17,10 +18,14 @@ export default defineConfig({
   },
   outputDir: ".tmp/ui-smoke-artifacts/test-results",
   webServer: {
-    command: "npm run dev",
+    command: `npx next dev --webpack --port ${basePort}`,
     url: baseURL,
     reuseExistingServer: true,
     timeout: 120_000,
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_GA_ID: "",
+    },
   },
   projects: [
     {

--- a/tests/ui-smoke/ui-smoke.spec.ts
+++ b/tests/ui-smoke/ui-smoke.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+type SmokeCase = {
+  slug: string;
+  path: string;
+  heading: RegExp;
+  action?: "fill-charcount" | "fill-total";
+};
+
+const smokeCases: SmokeCase[] = [
+  { slug: "charcount", path: "/tools/charcount", heading: /X投稿文字数カウント/, action: "fill-charcount" },
+  { slug: "total", path: "/tools/total", heading: /数字を貼るだけで合計/, action: "fill-total" },
+  { slug: "yutai-memo", path: "/tools/yutai-memo", heading: /優待銘柄メモ帳/ },
+  { slug: "yutai-expiry", path: "/tools/yutai-expiry", heading: /株主優待リスト|株主優待期限帳/ },
+  { slug: "stock-ranking", path: "/tools/stock-ranking", heading: /株価ランキング|ランキング/ },
+  { slug: "topix33", path: "/tools/topix33", heading: /TOPIX33|業種/ },
+  { slug: "nikkei-contribution", path: "/tools/nikkei-contribution", heading: /日経225寄与度|寄与度/ },
+];
+
+async function persistArtifact(slug: string, name: string, body: string) {
+  const dir = path.join(process.cwd(), ".tmp", "ui-smoke-artifacts", slug);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, name), body, "utf-8");
+}
+
+test.describe("ui smoke", () => {
+  for (const smokeCase of smokeCases) {
+    test(smokeCase.slug, async ({ page }, testInfo) => {
+      const consoleErrors: string[] = [];
+      const requestFailures: string[] = [];
+
+      page.on("console", (message) => {
+        if (message.type() === "error") {
+          consoleErrors.push(message.text());
+        }
+      });
+
+      page.on("pageerror", (error) => {
+        consoleErrors.push(error.message);
+      });
+
+      page.on("requestfailed", (request) => {
+        const failureText = request.failure()?.errorText ?? "unknown";
+        const url = request.url();
+        if (url.includes("google-analytics.com/g/collect")) {
+          return;
+        }
+        requestFailures.push(`${request.method()} ${url} :: ${failureText}`);
+      });
+
+      const response = await page.goto(smokeCase.path, { waitUntil: "networkidle" });
+      expect(response?.ok()).toBeTruthy();
+      await expect(page.locator("body")).toContainText(smokeCase.heading);
+
+      if (smokeCase.action === "fill-charcount") {
+        const textarea = page.locator("textarea").first();
+        await textarea.fill("テスト投稿です\nhttps://example.com");
+        await expect(page.getByText("OK")).toBeVisible();
+      }
+
+      if (smokeCase.action === "fill-total") {
+        const textarea = page.locator("textarea").first();
+        await textarea.fill("1200\n300\n-50");
+        await expect(page.getByText("1,450")).toBeVisible();
+      }
+
+      const screenshotPath = path.join(process.cwd(), ".tmp", "ui-smoke-artifacts", smokeCase.slug, "page.png");
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+
+      await persistArtifact(smokeCase.slug, "console-errors.json", JSON.stringify(consoleErrors, null, 2));
+      await persistArtifact(smokeCase.slug, "request-failures.json", JSON.stringify(requestFailures, null, 2));
+
+      await testInfo.attach("console-errors", {
+        body: Buffer.from(JSON.stringify(consoleErrors, null, 2)),
+        contentType: "application/json",
+      });
+      await testInfo.attach("request-failures", {
+        body: Buffer.from(JSON.stringify(requestFailures, null, 2)),
+        contentType: "application/json",
+      });
+
+      expect(consoleErrors).toEqual([]);
+      expect(requestFailures).toEqual([]);
+    });
+  }
+});

--- a/tests/ui-smoke/ui-smoke.spec.ts
+++ b/tests/ui-smoke/ui-smoke.spec.ts
@@ -44,7 +44,10 @@ test.describe("ui smoke", () => {
       page.on("requestfailed", (request) => {
         const failureText = request.failure()?.errorText ?? "unknown";
         const url = request.url();
-        if (url.includes("google-analytics.com/g/collect")) {
+        if (
+          url.includes("google-analytics.com/g/collect") ||
+          url.includes("www.googletagmanager.com/gtag/js")
+        ) {
           return;
         }
         requestFailures.push(`${request.method()} ${url} :: ${failureText}`);


### PR DESCRIPTION
## 概要

local 専用の UI スモークテスト基盤として Playwright を導入し、主要ツールの到達確認・簡単な操作・artifact 収集を回せるようにしました。

## 変更内容

- `@playwright/test` を devDependencies に追加
- `npm run test:ui` を追加
- `playwright.ui-smoke.config.ts` を追加
- `tests/ui-smoke/ui-smoke.spec.ts` を追加
- `.tmp/ui-smoke-artifacts/` と `.tmp/ui-smoke-report/` に artifact を出す運用を追加
- `#220` の方針を decision log に記録

## 確認項目

- `npm run lint`
- `npm run test:ui`

## 関連 Issue

Closes #220
