### PR TITLE
fix(layout): remove duplicate back button from SimpleInputToolLayout

### DIFF
--- a/components/SimpleInputToolLayout.tsx
+++ b/components/SimpleInputToolLayout.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useId, type ReactNode } from "react";
-import Link from "next/link";
 import ShareButtons from "@/components/ShareButtonsSuspended";
 import MonetizeBar from "@/components/MonetizeBar";
-import { track } from "@/lib/analytics";
 
 type SimpleInputToolLayoutProps = {
   badge: ReactNode;
@@ -37,27 +35,6 @@ export default function SimpleInputToolLayout({
 
   return (
     <main style={{ maxWidth, margin: "0 auto", padding: "16px 16px 48px" }}>
-      <div style={{ marginBottom: 20 }}>
-        <Link
-          href="/"
-          onClick={() => track("nav_clicked", { to: "home_from_tool" })}
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            padding: "6px 12px",
-            borderRadius: 999,
-            border: "1px solid var(--color-border-strong)",
-            textDecoration: "none",
-            color: "var(--color-text-sub)",
-            fontSize: 13,
-            fontWeight: 600,
-          }}
-        >
-          ← ツール一覧
-        </Link>
-      </div>
-
       <div style={{ marginBottom: 24 }}>
         <div
           style={{


### PR DESCRIPTION
## 変更内容

`SimpleInputToolLayout` にあった `← ツール一覧` ボタンを削除。

## 背景

- Header のロゴ（`mini-tools`）が全ページで `/` へのリンクとして機能している
- `← ツール一覧` を持つツールは `charcount` / `total` のみで、他の8ツールにはなかった
- 「偶然ついているだけ」の状態で統一感を欠いていたため、ロゴ一本化で揃える

## 影響範囲

- `components/SimpleInputToolLayout.tsx` — ボタンと関連 import（`Link`, `track`）を削除