### PR TITLE
feat(us-stock-ranking): US株ランキングツール追加（phase 1）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,6 +80,13 @@ const TOOLS: ToolItem[] = [
     icon: "📊",
   },
   {
+    title: "米国株ランキング",
+    short: "値上がり・値下がり・売買代金",
+    detail: "米国株の値上がり率・値下がり率・売買代金ランキングをデイリーで確認。",
+    href: "/tools/us-stock-ranking",
+    icon: "🇺🇸",
+  },
+  {
     title: "日経225寄与度",
     short: "誰が指数を動かしたか",
     detail: "日経225の上昇・下落寄与、影響度マップ、全銘柄一覧を日付ごとに確認。",

--- a/app/tools/us-stock-ranking/ToolClient.tsx
+++ b/app/tools/us-stock-ranking/ToolClient.tsx
@@ -29,7 +29,7 @@ function fmtRate(n: number) {
   return `${sign(n)}${n.toFixed(2)}%`;
 }
 
-// tradedValue は千USD単位（CSV カラム: 売買代金(千)）
+// tradedValue は千USD単位。fallback で ×1000 して実ドル値に換算
 function fmtTradedValue(n: number) {
   if (n >= 1_000_000) {
     return `$${(n / 1_000_000).toFixed(2)}B`;

--- a/app/tools/us-stock-ranking/ToolClient.tsx
+++ b/app/tools/us-stock-ranking/ToolClient.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type {
+  UsRankingDayData,
+  UsRankingPageData,
+  UsRankingRecord,
+  UsRankingType,
+} from "./types";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
+
+const RANKINGS: UsRankingType[] = ["値上がり率", "値下がり率", "売買代金"];
+
+function formatDate(dateStr: string) {
+  const [y, m, d] = dateStr.split("-");
+  return `${y}年${Number(m)}月${Number(d)}日`;
+}
+
+function sign(n: number) {
+  return n > 0 ? "+" : "";
+}
+
+function fmtPrice(n: number) {
+  return n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtRate(n: number) {
+  return `${sign(n)}${n.toFixed(2)}%`;
+}
+
+function fmtTradedValue(n: number) {
+  if (n >= 1_000_000_000) {
+    return `$${(n / 1_000_000_000).toFixed(2)}B`;
+  }
+  if (n >= 1_000_000) {
+    return `$${(n / 1_000_000).toFixed(1)}M`;
+  }
+  return `$${n.toLocaleString("en-US")}`;
+}
+
+type TabBarProps = {
+  options: string[];
+  value: string;
+  onChange: (v: string) => void;
+};
+
+function TabBar({ options, value, onChange }: TabBarProps) {
+  return (
+    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {options.map((opt) => {
+        const active = opt === value;
+        return (
+          <button
+            key={opt}
+            onClick={() => onChange(opt)}
+            style={{
+              padding: "6px 14px",
+              borderRadius: 8,
+              border: active
+                ? "1.5px solid var(--color-accent)"
+                : "1.5px solid var(--color-border-strong)",
+              background: active ? "var(--color-accent-sub)" : "var(--color-bg-card)",
+              color: active ? "var(--color-accent)" : "var(--color-text-sub)",
+              fontWeight: active ? 700 : 500,
+              fontSize: 13,
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+          >
+            {opt}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+type RankingTableProps = {
+  records: UsRankingRecord[];
+};
+
+function RankingTable({ records }: RankingTableProps) {
+  if (records.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          textAlign: "center",
+          color: "var(--color-text-muted)",
+          fontSize: 14,
+        }}
+      >
+        データがありません
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: 13,
+          minWidth: 560,
+        }}
+      >
+        <thead>
+          <tr style={{ borderBottom: "2px solid var(--color-border-strong)" }}>
+            {[
+              { label: "順位", align: "right" as const },
+              { label: "銘柄", align: "left" as const },
+              { label: "現在値(USD)", align: "right" as const },
+              { label: "前日比", align: "right" as const },
+              { label: "騰落率", align: "right" as const },
+              { label: "売買代金", align: "right" as const },
+            ].map((col) => (
+              <th
+                key={col.label}
+                style={{
+                  padding: "8px 10px",
+                  textAlign: col.align,
+                  fontWeight: 700,
+                  color: "var(--color-text-muted)",
+                  whiteSpace: "nowrap",
+                  fontSize: 11,
+                  letterSpacing: 0.3,
+                }}
+              >
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((r) => {
+            const up = r.changeRate > 0;
+            const down = r.changeRate < 0;
+            const rateColor = up
+              ? "var(--color-error)"
+              : down
+              ? "#2563eb"
+              : "var(--color-text-muted)";
+
+            return (
+              <tr
+                key={`${r.ticker}-${r.rank}`}
+                style={{ borderBottom: "1px solid var(--color-border)" }}
+              >
+                {/* 順位 */}
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    textAlign: "right",
+                    color: "var(--color-text-muted)",
+                    fontWeight: 600,
+                    width: 44,
+                  }}
+                >
+                  {r.rank}
+                </td>
+                {/* 銘柄 */}
+                <td style={{ padding: "8px 10px" }}>
+                  <div style={{ fontWeight: 700, color: "var(--color-text)", fontSize: 13 }}>
+                    {r.ticker}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: "var(--color-text-muted)",
+                      marginTop: 1,
+                      maxWidth: 180,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {r.nameEn || r.name}
+                  </div>
+                </td>
+                {/* 現在値 */}
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    textAlign: "right",
+                    fontWeight: 600,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {fmtPrice(r.price)}
+                </td>
+                {/* 前日比 */}
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    textAlign: "right",
+                    color: rateColor,
+                    fontWeight: 600,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {sign(r.change)}{fmtPrice(r.change)}
+                </td>
+                {/* 騰落率 */}
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    textAlign: "right",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  <span
+                    style={{
+                      display: "inline-block",
+                      padding: "2px 7px",
+                      borderRadius: 6,
+                      background: up
+                        ? "#fee2e2"
+                        : down
+                        ? "#dbeafe"
+                        : "var(--color-bg-input)",
+                      color: rateColor,
+                      fontWeight: 700,
+                      fontSize: 12,
+                    }}
+                  >
+                    {fmtRate(r.changeRate)}
+                  </span>
+                </td>
+                {/* 売買代金 */}
+                <td
+                  style={{
+                    padding: "8px 10px",
+                    textAlign: "right",
+                    color: "var(--color-text-sub)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {fmtTradedValue(r.tradedValue)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function ToolClient({ data }: { data: UsRankingPageData }) {
+  const { manifest, initialDayData } = data;
+
+  const [selectedDate, setSelectedDate] = useState<string>(manifest?.latest ?? "");
+  const [selectedRanking, setSelectedRanking] = useState<UsRankingType>("値上がり率");
+
+  const { loadedDays, isLoading, loadError } = useDailyMarketData<UsRankingDayData>({
+    activeDate: selectedDate,
+    initialDayData,
+    routePrefix: "/tools/us-stock-ranking/data",
+  });
+
+  const filtered = useMemo<UsRankingRecord[]>(() => {
+    if (!selectedDate) return [];
+    const day = loadedDays[selectedDate];
+    if (!day) return [];
+    return day.records.filter((r) => r.ranking === selectedRanking);
+  }, [loadedDays, selectedDate, selectedRanking]);
+
+  const dates = manifest?.dates ?? [];
+  const currentDateIndex = dates.indexOf(selectedDate);
+  const prevDate =
+    currentDateIndex >= 0 && currentDateIndex < dates.length - 1
+      ? dates[currentDateIndex + 1]
+      : null;
+  const nextDate = currentDateIndex > 0 ? dates[currentDateIndex - 1] : null;
+
+  if (!manifest) {
+    return (
+      <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
+        <section style={{ padding: "32px 0 24px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+            <span style={{ fontSize: 26 }}>🇺🇸</span>
+            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
+              米国株ランキング
+            </h1>
+          </div>
+        </section>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            color: "var(--color-text-muted)",
+            fontSize: 14,
+          }}
+        >
+          データを取得できませんでした。時間をおいて再度お試しください。
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
+      {/* ヘッダー */}
+      <section style={{ padding: "32px 0 24px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+          <span style={{ fontSize: 26 }}>🇺🇸</span>
+          <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
+            米国株ランキング
+          </h1>
+        </div>
+        <p style={{ margin: 0, fontSize: 13, color: "var(--color-text-muted)" }}>
+          米国株の値上がり率・値下がり率・売買代金ランキング。
+        </p>
+      </section>
+
+      {/* コントロール */}
+      <div
+        style={{
+          background: "#fff",
+          borderRadius: 22,
+          border: "1px solid rgba(15, 23, 42, 0.04)",
+          boxShadow: "0 10px 30px rgba(15, 23, 42, 0.06)",
+          padding: 16,
+          marginBottom: 20,
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+      >
+        {/* 日付 */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            flexWrap: "wrap",
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => prevDate && setSelectedDate(prevDate)}
+            disabled={!prevDate}
+            aria-label="前日へ移動"
+            style={{
+              width: 34,
+              height: 34,
+              padding: 0,
+              borderRadius: 999,
+              border: "1px solid rgba(37, 84, 255, 0.12)",
+              background: "#f5f8ff",
+              color: prevDate ? "#2554ff" : "#b9c2d0",
+              display: "grid",
+              placeItems: "center",
+              cursor: prevDate ? "pointer" : "default",
+              opacity: prevDate ? 1 : 0.45,
+            }}
+          >
+            ‹
+          </button>
+          <select
+            value={selectedDate}
+            onChange={(e) => setSelectedDate(e.target.value)}
+            style={{
+              minHeight: 38,
+              minWidth: 210,
+              padding: "8px 12px",
+              borderRadius: 10,
+              border: "1.5px solid rgba(148, 163, 184, 0.35)",
+              background: "#fff",
+              fontSize: 13,
+              fontWeight: 700,
+              color: "#0f172a",
+              textAlignLast: "center",
+              cursor: "pointer",
+            }}
+          >
+            {dates.map((d) => (
+              <option key={d} value={d}>
+                {formatDate(d)}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => nextDate && setSelectedDate(nextDate)}
+            disabled={!nextDate}
+            aria-label="翌日へ移動"
+            style={{
+              width: 34,
+              height: 34,
+              padding: 0,
+              borderRadius: 999,
+              border: "1px solid rgba(37, 84, 255, 0.12)",
+              background: "#f5f8ff",
+              color: nextDate ? "#2554ff" : "#b9c2d0",
+              display: "grid",
+              placeItems: "center",
+              cursor: nextDate ? "pointer" : "default",
+              opacity: nextDate ? 1 : 0.45,
+            }}
+          >
+            ›
+          </button>
+        </div>
+
+        {/* ランキング種別 */}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <span
+            style={{
+              fontSize: 12,
+              fontWeight: 700,
+              color: "var(--color-text-muted)",
+              minWidth: 40,
+            }}
+          >
+            種別
+          </span>
+          <TabBar
+            options={RANKINGS}
+            value={selectedRanking}
+            onChange={(v) => setSelectedRanking(v as UsRankingType)}
+          />
+        </div>
+      </div>
+
+      {/* 件数バッジ */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+        <span style={{ fontSize: 13, fontWeight: 700, color: "var(--color-text-sub)" }}>
+          {selectedRanking}
+        </span>
+        <span
+          style={{
+            padding: "2px 8px",
+            borderRadius: 999,
+            background: "var(--color-accent-sub)",
+            color: "var(--color-accent)",
+            fontSize: 11,
+            fontWeight: 800,
+          }}
+        >
+          {filtered.length}件
+        </span>
+      </div>
+
+      {/* テーブル */}
+      <div
+        style={{
+          background: "var(--color-bg-card)",
+          borderRadius: 14,
+          border: "1px solid var(--color-border)",
+          overflow: "hidden",
+        }}
+      >
+        {loadError ? (
+          <div
+            style={{
+              padding: "32px 20px",
+              textAlign: "center",
+              color: "var(--color-text-muted)",
+              fontSize: 14,
+            }}
+          >
+            {loadError}
+          </div>
+        ) : isLoading && !loadedDays[selectedDate] ? (
+          <LoadingSpinner />
+        ) : (
+          <RankingTable records={filtered} />
+        )}
+      </div>
+
+      {/* データ注記 */}
+      <p
+        style={{
+          marginTop: 16,
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          lineHeight: 1.6,
+        }}
+      >
+        ※ 投資判断の参考情報としてご利用ください。
+      </p>
+    </main>
+  );
+}

--- a/app/tools/us-stock-ranking/ToolClient.tsx
+++ b/app/tools/us-stock-ranking/ToolClient.tsx
@@ -10,7 +10,7 @@ import type {
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
-const RANKINGS: UsRankingType[] = ["値上がり率", "値下がり率", "売買代金"];
+const RANKINGS: UsRankingType[] = ["値上り率", "値下り率", "売買代金"];
 
 function formatDate(dateStr: string) {
   const [y, m, d] = dateStr.split("-");
@@ -253,7 +253,7 @@ export default function ToolClient({ data }: { data: UsRankingPageData }) {
   const { manifest, initialDayData } = data;
 
   const [selectedDate, setSelectedDate] = useState<string>(manifest?.latest ?? "");
-  const [selectedRanking, setSelectedRanking] = useState<UsRankingType>("値上がり率");
+  const [selectedRanking, setSelectedRanking] = useState<UsRankingType>("値上り率");
 
   const { loadedDays, isLoading, loadError } = useDailyMarketData<UsRankingDayData>({
     activeDate: selectedDate,

--- a/app/tools/us-stock-ranking/ToolClient.tsx
+++ b/app/tools/us-stock-ranking/ToolClient.tsx
@@ -29,14 +29,15 @@ function fmtRate(n: number) {
   return `${sign(n)}${n.toFixed(2)}%`;
 }
 
+// tradedValue は千USD単位（CSV カラム: 売買代金(千)）
 function fmtTradedValue(n: number) {
-  if (n >= 1_000_000_000) {
-    return `$${(n / 1_000_000_000).toFixed(2)}B`;
-  }
   if (n >= 1_000_000) {
-    return `$${(n / 1_000_000).toFixed(1)}M`;
+    return `$${(n / 1_000_000).toFixed(2)}B`;
   }
-  return `$${n.toLocaleString("en-US")}`;
+  if (n >= 1_000) {
+    return `$${(n / 1_000).toFixed(1)}M`;
+  }
+  return `$${(n * 1_000).toLocaleString("en-US")}`;
 }
 
 type TabBarProps = {

--- a/app/tools/us-stock-ranking/data-loader.ts
+++ b/app/tools/us-stock-ranking/data-loader.ts
@@ -1,0 +1,26 @@
+import { fetchJson, getApiBaseUrl } from "@/lib/market-api";
+import type { UsRankingDayData, UsRankingManifest } from "./types";
+
+export async function loadUsRankingManifest(): Promise<UsRankingManifest | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<UsRankingManifest>(`${apiBase}/us-ranking/manifest`);
+  } catch {
+    return null;
+  }
+}
+
+export async function loadUsRankingDayData(
+  dateStr: string,
+): Promise<UsRankingDayData | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<UsRankingDayData>(`${apiBase}/us-ranking/${dateStr}`);
+  } catch {
+    return null;
+  }
+}

--- a/app/tools/us-stock-ranking/data/[date]/route.ts
+++ b/app/tools/us-stock-ranking/data/[date]/route.ts
@@ -1,0 +1,4 @@
+import { loadUsRankingDayData } from "../../data-loader";
+import { buildDateDataRoute } from "@/app/tools/_shared/date-data-route";
+
+export const GET = buildDateDataRoute(loadUsRankingDayData);

--- a/app/tools/us-stock-ranking/loading.tsx
+++ b/app/tools/us-stock-ranking/loading.tsx
@@ -1,0 +1,73 @@
+export default function Loading() {
+  const sk = {
+    background: "var(--color-border)",
+    animation: "skeleton-pulse 1.4s ease-in-out infinite",
+  } as const;
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
+      {/* Header */}
+      <div style={{ padding: "32px 0 24px" }}>
+        <div style={{ ...sk, width: 160, height: 28, borderRadius: 6, marginBottom: 8 }} />
+        <div style={{ ...sk, width: 240, height: 14, borderRadius: 4 }} />
+      </div>
+
+      {/* Date nav: ← date select → */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+        <div style={{ ...sk, width: 160, height: 34, borderRadius: 8 }} />
+        <div style={{ ...sk, width: 34, height: 34, borderRadius: 999 }} />
+      </div>
+
+      {/* Ranking tabs */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        {[92, 96, 84].map((w, i) => (
+          <div key={i} style={{ ...sk, width: w, height: 32, borderRadius: 8 }} />
+        ))}
+      </div>
+
+      {/* Ranking table */}
+      <div
+        style={{
+          borderRadius: 12,
+          border: "1px solid var(--color-border)",
+          background: "var(--color-bg-card)",
+          overflow: "hidden",
+        }}
+      >
+        {Array.from({ length: 10 }).map((_, i) => (
+          <div
+            key={i}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              padding: "12px 16px",
+              borderBottom: i < 9 ? "1px solid var(--color-border)" : "none",
+            }}
+          >
+            <div style={{ ...sk, width: 24, height: 16, borderRadius: 4, flexShrink: 0 }} />
+            <div style={{ ...sk, flex: 1, height: 16, borderRadius: 4 }} />
+            <div style={{ ...sk, width: 70, height: 16, borderRadius: 4, flexShrink: 0 }} />
+            <div style={{ ...sk, width: 60, height: 16, borderRadius: 4, flexShrink: 0 }} />
+          </div>
+        ))}
+      </div>
+
+      <style>{`
+        @keyframes skeleton-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/app/tools/us-stock-ranking/page.tsx
+++ b/app/tools/us-stock-ranking/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import ToolClient from "./ToolClient";
+import { loadUsRankingManifest, loadUsRankingDayData } from "./data-loader";
+import type { UsRankingPageData } from "./types";
+
+export const metadata: Metadata = {
+  title: "米国株ランキング | mini-tools",
+  description:
+    "米国株の値上がり率・値下がり率・売買代金ランキングを日付別に確認できるツール。",
+  alternates: {
+    canonical: "/tools/us-stock-ranking",
+  },
+};
+
+async function loadData(): Promise<UsRankingPageData> {
+  const manifest = await loadUsRankingManifest();
+  if (!manifest) {
+    return { manifest: null, initialDayData: null };
+  }
+
+  const latest = manifest.latest;
+  const initialDayData = latest ? await loadUsRankingDayData(latest) : null;
+
+  return { manifest, initialDayData };
+}
+
+export default async function Page() {
+  const data = await loadData();
+  return <ToolClient data={data} />;
+}

--- a/app/tools/us-stock-ranking/page.tsx
+++ b/app/tools/us-stock-ranking/page.tsx
@@ -18,10 +18,19 @@ async function loadData(): Promise<UsRankingPageData> {
     return { manifest: null, initialDayData: null };
   }
 
-  const latest = manifest.latest;
-  const initialDayData = latest ? await loadUsRankingDayData(latest) : null;
+  // manifest.latest が未発行の場合に備え、dates を順に試して最初に取得できた日付を使う
+  let initialDayData = null;
+  let resolvedLatest = manifest.latest;
+  for (const date of manifest.dates.slice(0, 5)) {
+    const data = await loadUsRankingDayData(date);
+    if (data) {
+      initialDayData = data;
+      resolvedLatest = date;
+      break;
+    }
+  }
 
-  return { manifest, initialDayData };
+  return { manifest: { ...manifest, latest: resolvedLatest }, initialDayData };
 }
 
 export default async function Page() {

--- a/app/tools/us-stock-ranking/types.ts
+++ b/app/tools/us-stock-ranking/types.ts
@@ -1,4 +1,4 @@
-export type UsRankingType = "値上がり率" | "値下がり率" | "売買代金";
+export type UsRankingType = "値上り率" | "値下り率" | "売買代金";
 
 export type UsRankingRecord = {
   exchange: string;

--- a/app/tools/us-stock-ranking/types.ts
+++ b/app/tools/us-stock-ranking/types.ts
@@ -1,0 +1,35 @@
+export type UsRankingType = "値上がり率" | "値下がり率" | "売買代金";
+
+export type UsRankingRecord = {
+  exchange: string;
+  ranking: UsRankingType;
+  rank: number;
+  ticker: string;
+  listingExchange: string;
+  handlingFlag: string;
+  name: string;
+  nameEn: string;
+  price: number;
+  time: string;
+  change: number;
+  changeRate: number;
+  volume: number;
+  tradedValue: number;
+  per: number | null;
+  pbr: number | null;
+};
+
+export type UsRankingDayData = {
+  date: string;
+  records: UsRankingRecord[];
+};
+
+export type UsRankingManifest = {
+  dates: string[];
+  latest: string;
+};
+
+export type UsRankingPageData = {
+  manifest: UsRankingManifest | null;
+  initialDayData: UsRankingDayData | null;
+};


### PR DESCRIPTION
## 概要

米国株ランキングツール（phase 1）を新規追加。

## 変更内容

- `app/tools/us-stock-ranking/types.ts` — 型定義（`UsRankingType`, `UsRankingRecord`, `UsRankingDayData`, `UsRankingManifest`, `UsRankingPageData`）
- `app/tools/us-stock-ranking/data-loader.ts` — `MARKET_INFO_API_BASE_URL` 経由で `/us-ranking/manifest` と `/us-ranking/{date}` を取得。API 未設定 / fetch 失敗時は null を返す
- `app/tools/us-stock-ranking/page.tsx` — SSR で manifest + latest day data をロード
- `app/tools/us-stock-ranking/ToolClient.tsx` — 日付ナビ＋ランキング種別タブ（値上がり率/値下がり率/売買代金）のクライアント UI。exchange は all 固定なので市場タブなし
- `app/tools/us-stock-ranking/loading.tsx` — スケルトン
- `app/tools/us-stock-ranking/data/[date]/route.ts` — クライアント側の日付別データフェッチ用 API route
- `app/page.tsx` — TOOLS 一覧に「米国株ランキング」を追加

## 確認項目

- [x] `npm run lint` パス
- [ ] `MARKET_INFO_API_BASE_URL` 設定済み環境での動作確認（API 接続後）
- [ ] manifest null 時のエラー表示確認

## 仕様メモ

- phase 1 対象ランキング: 値上がり率 / 値下がり率 / 売買代金のみ
- 売買高 / 低PER / 低PBR は raw/cleaned には残るが US UI JSON には含めない
- records の `ranking` フィールドで種別をフィルタリング
- `tradedValue` は raw USD を想定し B/M 単位でフォーマット（実データ確認後に調整可）
