### PR TITLE
fix(stock-ranking): handle missing local manifest fallback

### DIFF
--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { RankingDayData, RankingPageData, RankingMarket, RankingType, RankingRecord } from "./types";
+import type { RankingDayData, RankingManifest, RankingMarket, RankingType, RankingRecord } from "./types";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
@@ -191,10 +191,14 @@ function RankingTable({ records, rankingType }: RankingTableProps) {
   );
 }
 
-export default function ToolClient({ data }: { data: RankingPageData }) {
-  const { manifest, initialDayData } = data;
-
-  const [selectedDate, setSelectedDate] = useState<string>(manifest?.latest ?? "");
+export default function ToolClient({
+  manifest,
+  initialDayData,
+}: {
+  manifest: RankingManifest;
+  initialDayData: RankingDayData | null;
+}) {
+  const [selectedDate, setSelectedDate] = useState<string>(manifest.latest);
   const [selectedMarket, setSelectedMarket] = useState<RankingMarket>("プライム");
   const [selectedRanking, setSelectedRanking] = useState<RankingType>("値上がり率");
   const { loadedDays, isLoading, loadError } = useDailyMarketData<RankingDayData>({
@@ -210,38 +214,12 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
       (r) => r.market === selectedMarket && r.ranking === selectedRanking,
     );
   }, [loadedDays, selectedDate, selectedMarket, selectedRanking]);
-  const dates = manifest?.dates ?? [];
-  const currentDateIndex = dates.indexOf(selectedDate);
+  const currentDateIndex = manifest.dates.indexOf(selectedDate);
   const prevDate =
-    currentDateIndex >= 0 && currentDateIndex < dates.length - 1
-      ? dates[currentDateIndex + 1]
+    currentDateIndex >= 0 && currentDateIndex < manifest.dates.length - 1
+      ? manifest.dates[currentDateIndex + 1]
       : null;
-  const nextDate = currentDateIndex > 0 ? dates[currentDateIndex - 1] : null;
-
-  if (!manifest) {
-    return (
-      <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
-        <section style={{ padding: "32px 0 24px" }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
-            <span style={{ fontSize: 26 }}>📊</span>
-            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
-              株価ランキング
-            </h1>
-          </div>
-        </section>
-        <div
-          style={{
-            padding: "32px 20px",
-            textAlign: "center",
-            color: "var(--color-text-muted)",
-            fontSize: 14,
-          }}
-        >
-          データを取得できませんでした。時間をおいて再度お試しください。
-        </div>
-      </main>
-    );
-  }
+  const nextDate = currentDateIndex > 0 ? manifest.dates[currentDateIndex - 1] : null;
 
   return (
     <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
@@ -310,7 +288,7 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
               cursor: "pointer",
             }}
           >
-            {dates.map((d) => (
+            {manifest.dates.map((d) => (
               <option key={d} value={d}>
                 {formatDate(d)}
               </option>

--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -194,7 +194,7 @@ function RankingTable({ records, rankingType }: RankingTableProps) {
 export default function ToolClient({ data }: { data: RankingPageData }) {
   const { manifest, initialDayData } = data;
 
-  const [selectedDate, setSelectedDate] = useState<string>(manifest.latest);
+  const [selectedDate, setSelectedDate] = useState<string>(manifest?.latest ?? "");
   const [selectedMarket, setSelectedMarket] = useState<RankingMarket>("プライム");
   const [selectedRanking, setSelectedRanking] = useState<RankingType>("値上がり率");
   const { loadedDays, isLoading, loadError } = useDailyMarketData<RankingDayData>({
@@ -210,12 +210,38 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
       (r) => r.market === selectedMarket && r.ranking === selectedRanking,
     );
   }, [loadedDays, selectedDate, selectedMarket, selectedRanking]);
-  const currentDateIndex = manifest.dates.indexOf(selectedDate);
+  const dates = manifest?.dates ?? [];
+  const currentDateIndex = dates.indexOf(selectedDate);
   const prevDate =
-    currentDateIndex >= 0 && currentDateIndex < manifest.dates.length - 1
-      ? manifest.dates[currentDateIndex + 1]
+    currentDateIndex >= 0 && currentDateIndex < dates.length - 1
+      ? dates[currentDateIndex + 1]
       : null;
-  const nextDate = currentDateIndex > 0 ? manifest.dates[currentDateIndex - 1] : null;
+  const nextDate = currentDateIndex > 0 ? dates[currentDateIndex - 1] : null;
+
+  if (!manifest) {
+    return (
+      <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
+        <section style={{ padding: "32px 0 24px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+            <span style={{ fontSize: 26 }}>📊</span>
+            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
+              株価ランキング
+            </h1>
+          </div>
+        </section>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            color: "var(--color-text-muted)",
+            fontSize: 14,
+          }}
+        >
+          データを取得できませんでした。時間をおいて再度お試しください。
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
@@ -284,7 +310,7 @@ export default function ToolClient({ data }: { data: RankingPageData }) {
               cursor: "pointer",
             }}
           >
-            {manifest.dates.map((d) => (
+            {dates.map((d) => (
               <option key={d} value={d}>
                 {formatDate(d)}
               </option>

--- a/app/tools/stock-ranking/__tests__/data-loader.test.ts
+++ b/app/tools/stock-ranking/__tests__/data-loader.test.ts
@@ -74,15 +74,23 @@ describe("loadRankingManifest", () => {
     expect(result).toEqual(SAMPLE_MANIFEST);
   });
 
-  // NOTE: loadLocalRankingManifest に try/catch がないため、
-  // ローカルファイル欠損時は throw する（他ローダーと挙動が異なる）。
-  // これは既知の設計差異であり、別 Issue で揃えるか検討する。
-  it("API 設定あり・fetch 失敗かつローカルファイル欠損のとき throw する（既知の挙動）", async () => {
+  it("API 設定あり・fetch 失敗かつローカルファイル欠損のとき null を返す", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
 
-    await expect(loadRankingManifest()).rejects.toThrow("ENOENT");
+    const result = await loadRankingManifest();
+
+    expect(result).toBeNull();
+  });
+
+  it("API 未設定かつローカルファイル欠損のとき null を返す", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await loadRankingManifest();
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/app/tools/stock-ranking/__tests__/data-loader.test.ts
+++ b/app/tools/stock-ranking/__tests__/data-loader.test.ts
@@ -77,7 +77,9 @@ describe("loadRankingManifest", () => {
   it("API 設定あり・fetch 失敗かつローカルファイル欠損のとき null を返す", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
-    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    const error = new Error("ENOENT") as Error & { code?: string };
+    error.code = "ENOENT";
+    mockReadFile.mockRejectedValue(error);
 
     const result = await loadRankingManifest();
 
@@ -85,12 +87,30 @@ describe("loadRankingManifest", () => {
   });
 
   it("API 未設定かつローカルファイル欠損のとき null を返す", async () => {
-    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    const error = new Error("ENOENT") as Error & { code?: string };
+    error.code = "ENOENT";
+    mockReadFile.mockRejectedValue(error);
 
     const result = await loadRankingManifest();
 
     expect(result).toBeNull();
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("ローカル manifest が壊れているときは throw する", async () => {
+    mockReadFile.mockResolvedValue("{invalid json");
+
+    await expect(loadRankingManifest()).rejects.toThrow();
+  });
+
+  it("API 設定あり・fetch 失敗かつローカル権限エラーのとき throw する", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    const error = new Error("EACCES") as Error & { code?: string };
+    error.code = "EACCES";
+    mockReadFile.mockRejectedValue(error);
+
+    await expect(loadRankingManifest()).rejects.toThrow("EACCES");
   });
 });
 

--- a/app/tools/stock-ranking/data-loader.ts
+++ b/app/tools/stock-ranking/data-loader.ts
@@ -7,9 +7,13 @@ function getDataDir() {
   return path.join(process.cwd(), "app/tools/stock-ranking/data");
 }
 
-async function loadLocalRankingManifest(): Promise<RankingManifest> {
-  const raw = await readFile(path.join(getDataDir(), "manifest.json"), "utf-8");
-  return JSON.parse(raw) as RankingManifest;
+async function loadLocalRankingManifest(): Promise<RankingManifest | null> {
+  try {
+    const raw = await readFile(path.join(getDataDir(), "manifest.json"), "utf-8");
+    return JSON.parse(raw) as RankingManifest;
+  } catch {
+    return null;
+  }
 }
 
 async function loadLocalRankingDayData(dateStr: string): Promise<RankingDayData | null> {
@@ -23,7 +27,7 @@ async function loadLocalRankingDayData(dateStr: string): Promise<RankingDayData 
   }
 }
 
-export async function loadRankingManifest(): Promise<RankingManifest> {
+export async function loadRankingManifest(): Promise<RankingManifest | null> {
   const apiBase = getApiBaseUrl();
 
   if (!apiBase) {

--- a/app/tools/stock-ranking/data-loader.ts
+++ b/app/tools/stock-ranking/data-loader.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { RankingDayData, RankingManifest } from "./types";
 
+type NodeErrorLike = Error & { code?: string };
+
 function getDataDir() {
   return path.join(process.cwd(), "app/tools/stock-ranking/data");
 }
@@ -11,7 +13,10 @@ async function loadLocalRankingManifest(): Promise<RankingManifest | null> {
   try {
     const raw = await readFile(path.join(getDataDir(), "manifest.json"), "utf-8");
     return JSON.parse(raw) as RankingManifest;
-  } catch {
+  } catch (error) {
+    if ((error as NodeErrorLike).code !== "ENOENT") {
+      throw error;
+    }
     return null;
   }
 }

--- a/app/tools/stock-ranking/page.tsx
+++ b/app/tools/stock-ranking/page.tsx
@@ -40,5 +40,31 @@ async function loadData(): Promise<RankingPageData> {
 
 export default async function Page() {
   const data = await loadData();
-  return <ToolClient data={data} />;
+
+  if (!data.manifest) {
+    return (
+      <main style={{ maxWidth: 900, margin: "0 auto", padding: "0 16px 64px" }}>
+        <section style={{ padding: "32px 0 24px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+            <span style={{ fontSize: 26 }}>📊</span>
+            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
+              株価ランキング
+            </h1>
+          </div>
+        </section>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            color: "var(--color-text-muted)",
+            fontSize: 14,
+          }}
+        >
+          データを取得できませんでした。時間をおいて再度お試しください。
+        </div>
+      </main>
+    );
+  }
+
+  return <ToolClient manifest={data.manifest} initialDayData={data.initialDayData} />;
 }

--- a/app/tools/stock-ranking/page.tsx
+++ b/app/tools/stock-ranking/page.tsx
@@ -20,6 +20,10 @@ async function loadData(): Promise<RankingPageData> {
     loadJpxMarketClosedData(),
   ]);
 
+  if (!manifest) {
+    return { manifest: null, initialDayData: null };
+  }
+
   const visibleDates = filterVisibleTradingDates(manifest.dates, holidays);
   const latest = visibleDates[0] ?? manifest.latest;
   const initialDayData = latest ? await loadRankingDayData(latest) : null;

--- a/app/tools/stock-ranking/types.ts
+++ b/app/tools/stock-ranking/types.ts
@@ -41,6 +41,6 @@ export type JpxMarketClosedResponse = {
 };
 
 export type RankingPageData = {
-  manifest: RankingManifest;
+  manifest: RankingManifest | null;
   initialDayData: RankingDayData | null;
 };


### PR DESCRIPTION
## 概要

stock-ranking の manifest loader が API / ローカル両方で取得できない場合に throw していた挙動を、他ローダーと同様に安全な fallback へ揃えました。

## 変更内容

- `loadRankingManifest()` のローカル manifest 読み込みに try/catch を追加
- manifest 取得失敗時は `null` を返すように型とページ処理を更新
- stock-ranking 画面で manifest 不在時のエラー表示を追加
- data-loader のテスト期待値を `null` 返却に更新

## 確認項目

- `npm run lint`
- `npm test -- app/tools/stock-ranking/__tests__/data-loader.test.ts`

## 関連 Issue

Closes #236
