### PR TITLE
docs(devlog): mark #219 SimpleInputToolLayout as complete (#249)

### DIFF
--- a/docs/decision-log/2026-04-11-small-tools-page-shell-commonization.md
+++ b/docs/decision-log/2026-04-11-small-tools-page-shell-commonization.md
@@ -33,3 +33,8 @@
 
 - 現時点では `charcount` と `total` を対象にする
 - 他の小さな入力系 tool へ広げる場合も、まずは page shell の一致度を見てから適用する
+
+## 実装完了（#219）
+
+- `components/SimpleInputToolLayout.tsx` として実装済み
+- `app/tools/charcount/ToolClient.tsx` / `app/tools/total/ToolClient.tsx` に適用済み

--- a/docs/devlog/2026-04-11-commonization-handoff.md
+++ b/docs/devlog/2026-04-11-commonization-handoff.md
@@ -45,7 +45,7 @@
 
 ## 後続タスク
 
-- `#219` `charcount` / `total` の page shell 共通化
+- ~~`#219` `charcount` / `total` の page shell 共通化~~ → **完了**（`components/SimpleInputToolLayout.tsx` として実装済み）
 - `#214` JSON 同梱データと fallback 方針整理
 - `#220` dev 環境 UI スモークテストと artifact 収集
 


### PR DESCRIPTION
## 概要

Issue #219（SimpleInputToolLayout 実装）の完了記録を docs に追記します。

## 変更内容

- `docs/devlog/2026-04-11-commonization-handoff.md` の「後続タスク」から #219 を削除（打ち消し線 + 完了注記）
- `docs/decision-log/2026-04-11-small-tools-page-shell-commonization.md` に「実装完了」セクションを追加

## 確認項目

- [x] `npm run lint` パス
- [x] コード変更なし（docs のみ）

Closes #249
