### PR TITLE
refactor(tools): share tool client helpers

### DIFF
--- a/app/tools/_shared/TabBar.tsx
+++ b/app/tools/_shared/TabBar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+type TabBarProps<T extends string> = {
+  options: readonly T[];
+  value: T;
+  onChange: (value: T) => void;
+};
+
+export default function TabBar<T extends string>({
+  options,
+  value,
+  onChange,
+}: TabBarProps<T>) {
+  return (
+    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {options.map((option) => {
+        const active = option === value;
+        return (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            style={{
+              padding: "6px 14px",
+              borderRadius: 8,
+              border: active
+                ? "1.5px solid var(--color-accent)"
+                : "1.5px solid var(--color-border-strong)",
+              background: active ? "var(--color-accent-sub)" : "var(--color-bg-card)",
+              color: active ? "var(--color-accent)" : "var(--color-text-sub)",
+              fontWeight: active ? 700 : 500,
+              fontSize: 13,
+              cursor: "pointer",
+              transition: "all 0.15s",
+            }}
+          >
+            {option}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/tools/_shared/market-calendar-types.ts
+++ b/app/tools/_shared/market-calendar-types.ts
@@ -1,0 +1,4 @@
+export type {
+  JpxMarketClosedDay,
+  JpxMarketClosedResponse,
+} from "@/lib/market-calendar-types";

--- a/app/tools/_shared/tool-client-format.ts
+++ b/app/tools/_shared/tool-client-format.ts
@@ -1,0 +1,8 @@
+export function formatToolDate(dateStr: string) {
+  const [y, m, d] = dateStr.split("-");
+  return `${y}年${Number(m)}月${Number(d)}日`;
+}
+
+export function signPrefix(value: number) {
+  return value > 0 ? "+" : "";
+}

--- a/app/tools/earnings-calendar/ToolClient.tsx
+++ b/app/tools/earnings-calendar/ToolClient.tsx
@@ -10,8 +10,8 @@ import type {
   EarningsCalendarManifest,
   EarningsCalendarManifestMonth,
   EarningsCalendarPageData,
-  JpxMarketClosedDay,
 } from "./types";
+import type { JpxMarketClosedDay } from "@/app/tools/_shared/market-calendar-types";
 
 type CalendarCell = {
   key: string;

--- a/app/tools/earnings-calendar/__tests__/data-loader.test.ts
+++ b/app/tools/earnings-calendar/__tests__/data-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
+import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 import type {
   EarningsCalendarManifest,
   EarningsCalendarResponse,

--- a/app/tools/earnings-calendar/data-loader.ts
+++ b/app/tools/earnings-calendar/data-loader.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadUsMarketClosedData } from "@/lib/us-market-closed";
 import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
-import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
+import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 import type {
   EarningsCalendarManifest,
   EarningsCalendarItem,

--- a/app/tools/earnings-calendar/types.ts
+++ b/app/tools/earnings-calendar/types.ts
@@ -1,4 +1,4 @@
-import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
+import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 
 export type EarningsCalendarItem = {
   event_id?: string;
@@ -80,5 +80,3 @@ export type EarningsCalendarPageData = {
   domestic: EarningsCalendarMarketData;
   overseas: EarningsCalendarMarketData;
 };
-
-export type { JpxMarketClosedDay, JpxMarketClosedResponse } from "@/lib/market-calendar-types";

--- a/app/tools/nikkei-contribution/ToolClient.tsx
+++ b/app/tools/nikkei-contribution/ToolClient.tsx
@@ -4,18 +4,14 @@ import { useEffect, useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import type {
-  JpxMarketClosedDay,
   NikkeiContributionDayData,
   NikkeiContributionPageData,
   NikkeiContributionRankItem,
   NikkeiContributionRecord,
 } from "./types";
+import type { JpxMarketClosedDay } from "@/app/tools/_shared/market-calendar-types";
+import { formatToolDate, signPrefix } from "@/app/tools/_shared/tool-client-format";
 import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
-
-function formatDate(dateStr: string) {
-  const [y, m, d] = dateStr.split("-");
-  return `${y}年${Number(m)}月${Number(d)}日`;
-}
 
 function getDayOfWeek(dateStr: string) {
   const [y, m, d] = dateStr.split("-").map(Number);
@@ -43,16 +39,12 @@ function isLikelyMarketClosed(dayData: NikkeiContributionDayData | null | undefi
   return !hasMovement;
 }
 
-function sign(n: number) {
-  return n > 0 ? "+" : "";
-}
-
 function fmtPct(n: number) {
-  return `${sign(n)}${n.toFixed(2)}%`;
+  return `${signPrefix(n)}${n.toFixed(2)}%`;
 }
 
 function fmtPt(n: number) {
-  return `${sign(n)}${n.toFixed(1)}pt`;
+  return `${signPrefix(n)}${n.toFixed(1)}pt`;
 }
 
 function fmtNumber(n: number) {
@@ -577,7 +569,7 @@ function ImpactMap({ records, selectedCode, onSelect }: ImpactMapProps) {
                   <span style={{ color: "rgba(148,163,184,0.95)" }}>ウェイト</span>
                   <span style={{ fontWeight: 800 }}>{hoveredPlacement.record.weight_pct.toFixed(2)}%</span>
                   <span style={{ color: "rgba(148,163,184,0.95)" }}>前日比</span>
-                  <span style={{ fontWeight: 800 }}>{sign(hoveredPlacement.record.chg)}{fmtNumber(hoveredPlacement.record.chg)}</span>
+                  <span style={{ fontWeight: 800 }}>{signPrefix(hoveredPlacement.record.chg)}{fmtNumber(hoveredPlacement.record.chg)}</span>
                 </div>
                   </div>
                 );
@@ -726,7 +718,7 @@ function RecordsTable({ records }: { records: NikkeiContributionRecord[] }) {
                     return (
                       <td key={`${record.code}-${column.key}`} style={{ textAlign: "right", whiteSpace: "nowrap", color: getBarTone(record.chg_pct).text }}>
                         <span className={styles.desktopOnly}>{fmtPct(record.chg_pct)}</span>
-                        <span className={styles.mobileOnly}>{`${sign(record.chg_pct)}${record.chg_pct.toFixed(1)}%`}</span>
+                        <span className={styles.mobileOnly}>{`${signPrefix(record.chg_pct)}${record.chg_pct.toFixed(1)}%`}</span>
                       </td>
                     );
                   }
@@ -734,7 +726,7 @@ function RecordsTable({ records }: { records: NikkeiContributionRecord[] }) {
                   if (column.key === "chg") {
                     return (
                       <td key={`${record.code}-${column.key}`} className={styles.recordsMobileHidden} style={{ textAlign: "right", whiteSpace: "nowrap", color: getBarTone(record.chg).text }}>
-                        {sign(record.chg)}{fmtNumber(record.chg)}
+                        {signPrefix(record.chg)}{fmtNumber(record.chg)}
                       </td>
                     );
                   }
@@ -954,7 +946,7 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
             ) : (
               displayDates.map((date) => (
                 <option key={date} value={date}>
-                  {formatDate(date)}
+                  {formatToolDate(date)}
                 </option>
               ))
             )}
@@ -1132,7 +1124,7 @@ export default function ToolClient({ data }: { data: NikkeiContributionPageData 
                 </div>
                 <div style={{ background: "var(--color-bg-input)", border: "1px solid var(--color-border)", borderRadius: 6, padding: 10 }}>
                   <div style={{ fontSize: 11, color: "var(--color-text-muted)", marginBottom: 4 }}>前日比</div>
-                  <div style={{ fontWeight: 800 }}>{sign(selectedRecord.chg)}{fmtNumber(selectedRecord.chg)}</div>
+                  <div style={{ fontWeight: 800 }}>{signPrefix(selectedRecord.chg)}{fmtNumber(selectedRecord.chg)}</div>
                 </div>
               </div>
             </section>

--- a/app/tools/nikkei-contribution/types.ts
+++ b/app/tools/nikkei-contribution/types.ts
@@ -1,4 +1,4 @@
-import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
+import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 
 export type NikkeiContributionRecord = {
   code: string;
@@ -52,5 +52,3 @@ export type NikkeiContributionPageData = {
   initialDayData: NikkeiContributionDayData | null;
   holidays: JpxMarketClosedResponse | null;
 };
-
-export type { JpxMarketClosedDay, JpxMarketClosedResponse } from "@/lib/market-calendar-types";

--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -3,22 +3,15 @@
 import { useMemo, useState } from "react";
 import type { RankingDayData, RankingManifest, RankingMarket, RankingType, RankingRecord } from "./types";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import TabBar from "@/app/tools/_shared/TabBar";
+import { formatToolDate, signPrefix } from "@/app/tools/_shared/tool-client-format";
 import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
 const MARKETS: RankingMarket[] = ["プライム", "スタンダード", "グロース"];
 const RANKINGS: RankingType[] = ["値上がり率", "値下がり率", "売買高"];
 
-function formatDate(dateStr: string) {
-  const [y, m, d] = dateStr.split("-");
-  return `${y}年${Number(m)}月${Number(d)}日`;
-}
-
-function sign(n: number) {
-  return n > 0 ? "+" : "";
-}
-
 function fmtRate(n: number) {
-  return `${sign(n)}${n.toFixed(2)}%`;
+  return `${signPrefix(n)}${n.toFixed(2)}%`;
 }
 
 function fmtPrice(n: number) {
@@ -31,43 +24,6 @@ function fmtVolume(n: number) {
 
 function fmtValue(n: number) {
   return `${(n / 100).toFixed(1)}億円`;
-}
-
-type TabBarProps = {
-  options: string[];
-  value: string;
-  onChange: (v: string) => void;
-};
-
-function TabBar({ options, value, onChange }: TabBarProps) {
-  return (
-    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
-      {options.map((opt) => {
-        const active = opt === value;
-        return (
-          <button
-            key={opt}
-            onClick={() => onChange(opt)}
-            style={{
-              padding: "6px 14px",
-              borderRadius: 8,
-              border: active
-                ? "1.5px solid var(--color-accent)"
-                : "1.5px solid var(--color-border-strong)",
-              background: active ? "var(--color-accent-sub)" : "var(--color-bg-card)",
-              color: active ? "var(--color-accent)" : "var(--color-text-sub)",
-              fontWeight: active ? 700 : 500,
-              fontSize: 13,
-              cursor: "pointer",
-              transition: "all 0.15s",
-            }}
-          >
-            {opt}
-          </button>
-        );
-      })}
-    </div>
-  );
 }
 
 type RankingTableProps = {
@@ -156,7 +112,7 @@ function RankingTable({ records, rankingType }: RankingTableProps) {
                 </td>
                 {/* 前日比 */}
                 <td style={{ padding: "8px 10px", textAlign: "right", color: rateColor, fontWeight: 600, whiteSpace: "nowrap" }}>
-                  {sign(r.change)}{fmtPrice(r.change)}
+                  {signPrefix(r.change)}{fmtPrice(r.change)}
                 </td>
                 {/* 騰落率 */}
                 <td style={{ padding: "8px 10px", textAlign: "right", whiteSpace: "nowrap" }}>
@@ -290,7 +246,7 @@ export default function ToolClient({
           >
             {manifest.dates.map((d) => (
               <option key={d} value={d}>
-                {formatDate(d)}
+                {formatToolDate(d)}
               </option>
             ))}
           </select>
@@ -325,7 +281,7 @@ export default function ToolClient({
           <TabBar
             options={MARKETS}
             value={selectedMarket}
-            onChange={(v) => setSelectedMarket(v as RankingMarket)}
+            onChange={setSelectedMarket}
           />
         </div>
 
@@ -337,7 +293,7 @@ export default function ToolClient({
           <TabBar
             options={RANKINGS}
             value={selectedRanking}
-            onChange={(v) => setSelectedRanking(v as RankingType)}
+            onChange={setSelectedRanking}
           />
         </div>
       </div>

--- a/app/tools/stock-ranking/ToolClient.tsx
+++ b/app/tools/stock-ranking/ToolClient.tsx
@@ -278,7 +278,7 @@ export default function ToolClient({
           <span style={{ fontSize: 12, fontWeight: 700, color: "var(--color-text-muted)", minWidth: 40 }}>
             市場
           </span>
-          <TabBar
+          <TabBar<RankingMarket>
             options={MARKETS}
             value={selectedMarket}
             onChange={setSelectedMarket}
@@ -290,7 +290,7 @@ export default function ToolClient({
           <span style={{ fontSize: 12, fontWeight: 700, color: "var(--color-text-muted)", minWidth: 40 }}>
             種別
           </span>
-          <TabBar
+          <TabBar<RankingType>
             options={RANKINGS}
             value={selectedRanking}
             onChange={setSelectedRanking}

--- a/app/tools/stock-ranking/types.ts
+++ b/app/tools/stock-ranking/types.ts
@@ -1,4 +1,4 @@
-import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
+import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 
 export type RankingMarket = "プライム" | "スタンダード" | "グロース";
 export type RankingType = "値上がり率" | "値下がり率" | "売買高";
@@ -33,5 +33,3 @@ export type RankingPageData = {
   manifest: RankingManifest | null;
   initialDayData: RankingDayData | null;
 };
-
-export type { JpxMarketClosedDay, JpxMarketClosedResponse } from "@/lib/market-calendar-types";

--- a/app/tools/topix33/ToolClient.tsx
+++ b/app/tools/topix33/ToolClient.tsx
@@ -4,18 +4,14 @@ import { useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import type {
-  JpxMarketClosedDay,
   Topix33DayData,
   Topix33PageData,
   Topix33RankItem,
   Topix33SectorRecord,
 } from "./types";
+import type { JpxMarketClosedDay } from "@/app/tools/_shared/market-calendar-types";
+import { formatToolDate, signPrefix } from "@/app/tools/_shared/tool-client-format";
 import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
-
-function formatDate(dateStr: string) {
-  const [y, m, d] = dateStr.split("-");
-  return `${y}年${Number(m)}月${Number(d)}日`;
-}
 
 function getDayOfWeek(dateStr: string) {
   const [y, m, d] = dateStr.split("-").map(Number);
@@ -31,12 +27,8 @@ function isMarketClosedDate(dateStr: string, holidayMap: Map<string, JpxMarketCl
   return holidayMap.get(dateStr)?.market_closed ?? false;
 }
 
-function sign(n: number) {
-  return n > 0 ? "+" : "";
-}
-
 function fmtPct(n: number) {
-  return `${sign(n)}${n.toFixed(2)}%`;
+  return `${signPrefix(n)}${n.toFixed(2)}%`;
 }
 
 function getBarTone(n: number) {
@@ -210,7 +202,7 @@ function SectorsTable({ sectors }: { sectors: Topix33SectorRecord[] }) {
                   {fmtPct(sector.chg_pct)}
                 </td>
                 <td className={styles.sectorsMobileHidden} style={{ textAlign: "right", whiteSpace: "nowrap", color: getBarTone(sector.chg).text }}>
-                  {sign(sector.chg)}{sector.chg.toFixed(2)}
+                  {signPrefix(sector.chg)}{sector.chg.toFixed(2)}
                 </td>
               </tr>
             );
@@ -345,7 +337,7 @@ export default function ToolClient({ data }: { data: Topix33PageData }) {
             ) : (
               displayDates.map((date) => (
                 <option key={date} value={date}>
-                  {formatDate(date)}
+                  {formatToolDate(date)}
                 </option>
               ))
             )}

--- a/app/tools/topix33/types.ts
+++ b/app/tools/topix33/types.ts
@@ -1,4 +1,4 @@
-import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
+import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 
 export type Topix33SectorRecord = {
   sector_code: string;
@@ -44,5 +44,3 @@ export type Topix33PageData = {
   initialDayData: Topix33DayData | null;
   holidays: JpxMarketClosedResponse | null;
 };
-
-export type { JpxMarketClosedDay, JpxMarketClosedResponse } from "@/lib/market-calendar-types";

--- a/app/tools/us-stock-ranking/ToolClient.tsx
+++ b/app/tools/us-stock-ranking/ToolClient.tsx
@@ -375,7 +375,7 @@ export default function ToolClient({ data }: { data: UsRankingPageData }) {
           >
             種別
           </span>
-          <TabBar
+          <TabBar<UsRankingType>
             options={RANKINGS}
             value={selectedRanking}
             onChange={setSelectedRanking}

--- a/app/tools/us-stock-ranking/ToolClient.tsx
+++ b/app/tools/us-stock-ranking/ToolClient.tsx
@@ -8,25 +8,18 @@ import type {
   UsRankingType,
 } from "./types";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import TabBar from "@/app/tools/_shared/TabBar";
+import { formatToolDate, signPrefix } from "@/app/tools/_shared/tool-client-format";
 import { useDailyMarketData } from "@/app/tools/_shared/use-daily-market-data";
 
 const RANKINGS: UsRankingType[] = ["値上り率", "値下り率", "売買代金"];
-
-function formatDate(dateStr: string) {
-  const [y, m, d] = dateStr.split("-");
-  return `${y}年${Number(m)}月${Number(d)}日`;
-}
-
-function sign(n: number) {
-  return n > 0 ? "+" : "";
-}
 
 function fmtPrice(n: number) {
   return n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 function fmtRate(n: number) {
-  return `${sign(n)}${n.toFixed(2)}%`;
+  return `${signPrefix(n)}${n.toFixed(2)}%`;
 }
 
 // tradedValue は千USD単位。fallback で ×1000 して実ドル値に換算
@@ -38,43 +31,6 @@ function fmtTradedValue(n: number) {
     return `$${(n / 1_000).toFixed(1)}M`;
   }
   return `$${(n * 1_000).toLocaleString("en-US")}`;
-}
-
-type TabBarProps = {
-  options: string[];
-  value: string;
-  onChange: (v: string) => void;
-};
-
-function TabBar({ options, value, onChange }: TabBarProps) {
-  return (
-    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
-      {options.map((opt) => {
-        const active = opt === value;
-        return (
-          <button
-            key={opt}
-            onClick={() => onChange(opt)}
-            style={{
-              padding: "6px 14px",
-              borderRadius: 8,
-              border: active
-                ? "1.5px solid var(--color-accent)"
-                : "1.5px solid var(--color-border-strong)",
-              background: active ? "var(--color-accent-sub)" : "var(--color-bg-card)",
-              color: active ? "var(--color-accent)" : "var(--color-text-sub)",
-              fontWeight: active ? 700 : 500,
-              fontSize: 13,
-              cursor: "pointer",
-              transition: "all 0.15s",
-            }}
-          >
-            {opt}
-          </button>
-        );
-      })}
-    </div>
-  );
 }
 
 type RankingTableProps = {
@@ -201,7 +157,7 @@ function RankingTable({ records }: RankingTableProps) {
                     whiteSpace: "nowrap",
                   }}
                 >
-                  {sign(r.change)}{fmtPrice(r.change)}
+                  {signPrefix(r.change)}{fmtPrice(r.change)}
                 </td>
                 {/* 騰落率 */}
                 <td
@@ -380,7 +336,7 @@ export default function ToolClient({ data }: { data: UsRankingPageData }) {
           >
             {dates.map((d) => (
               <option key={d} value={d}>
-                {formatDate(d)}
+                {formatToolDate(d)}
               </option>
             ))}
           </select>
@@ -422,7 +378,7 @@ export default function ToolClient({ data }: { data: UsRankingPageData }) {
           <TabBar
             options={RANKINGS}
             value={selectedRanking}
-            onChange={(v) => setSelectedRanking(v as UsRankingType)}
+            onChange={setSelectedRanking}
           />
         </div>
       </div>

--- a/app/tools/us-stock-ranking/__tests__/data-loader.test.ts
+++ b/app/tools/us-stock-ranking/__tests__/data-loader.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsRankingDayData, UsRankingManifest } from "../types";
+import { loadUsRankingDayData, loadUsRankingManifest } from "../data-loader";
+
+const SAMPLE_MANIFEST: UsRankingManifest = {
+  dates: ["2025-04-11", "2025-04-10"],
+  latest: "2025-04-11",
+};
+
+const SAMPLE_DAY_DATA: UsRankingDayData = {
+  date: "2025-04-11",
+  records: [
+    {
+      exchange: "US",
+      ranking: "値上り率",
+      rank: 1,
+      ticker: "AAPL",
+      listingExchange: "NASDAQ",
+      handlingFlag: "1",
+      name: "アップル",
+      nameEn: "Apple Inc.",
+      price: 198.76,
+      time: "2025-04-11T16:00:00-04:00",
+      change: 4.12,
+      changeRate: 2.12,
+      volume: 123456,
+      tradedValue: 789012,
+      per: 31.4,
+      pbr: 45.2,
+    },
+  ],
+};
+
+function makeFetchOk(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function makeFetch404(): Response {
+  return { ok: false, status: 404 } as unknown as Response;
+}
+
+describe("loadUsRankingManifest", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    delete process.env.MARKET_INFO_API_BASE_URL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("API 未設定のとき null を返す", async () => {
+    const result = await loadUsRankingManifest();
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("API 設定あり・正常レスポンスのとき、API のマニフェストを返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockResolvedValue(makeFetchOk(SAMPLE_MANIFEST));
+
+    const result = await loadUsRankingManifest();
+
+    expect(result).toEqual(SAMPLE_MANIFEST);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.com/us-ranking/manifest",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("API 設定あり・404 のとき null を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockResolvedValue(makeFetch404());
+
+    const result = await loadUsRankingManifest();
+
+    expect(result).toBeNull();
+  });
+
+  it("API 設定あり・timeout のとき null を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new DOMException("AbortError", "AbortError"));
+
+    const result = await loadUsRankingManifest();
+
+    expect(result).toBeNull();
+  });
+
+  it("API 設定あり・network error のとき null を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+
+    const result = await loadUsRankingManifest();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("loadUsRankingDayData", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    delete process.env.MARKET_INFO_API_BASE_URL;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("API 未設定のとき null を返す", async () => {
+    const result = await loadUsRankingDayData("2025-04-11");
+
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("API 設定あり・正常レスポンスのとき、API のデータを返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockResolvedValue(makeFetchOk(SAMPLE_DAY_DATA));
+
+    const result = await loadUsRankingDayData("2025-04-11");
+
+    expect(result).toEqual(SAMPLE_DAY_DATA);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.com/us-ranking/2025-04-11",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("API 設定あり・404 のとき null を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockResolvedValue(makeFetch404());
+
+    const result = await loadUsRankingDayData("2025-04-11");
+
+    expect(result).toBeNull();
+  });
+
+  it("API 設定あり・timeout のとき null を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new DOMException("AbortError", "AbortError"));
+
+    const result = await loadUsRankingDayData("2025-04-11");
+
+    expect(result).toBeNull();
+  });
+
+  it("API 設定あり・network error のとき null を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+
+    const result = await loadUsRankingDayData("2025-04-11");
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

tool client 間の軽量な重複を `_shared` へ寄せつつ、`us-stock-ranking` data-loader のユニットテストを追加しました。

## 変更内容

- `TabBar` / 日付フォーマット / sign 表示を `app/tools/_shared/` に共通化
- `JpxMarketClosedResponse` / `JpxMarketClosedDay` の tool 側参照入口を `app/tools/_shared/market-calendar-types.ts` に整理
- `app/tools/us-stock-ranking/__tests__/data-loader.test.ts` を追加し、API 専用 loader の fallback 挙動をテスト

## 確認項目

- `npm run lint`
- `npm test -- app/tools/topix33/__tests__/data-loader.test.ts app/tools/nikkei-contribution/__tests__/data-loader.test.ts app/tools/stock-ranking/__tests__/data-loader.test.ts app/tools/earnings-calendar/__tests__/data-loader.test.ts app/tools/us-stock-ranking/__tests__/data-loader.test.ts`

## 関連 Issue

- Refs #234
- Refs #237
- Refs #240
