### PR TITLE
fix(penguin-rabbit-shooter): widen compact layout threshold and drop portrait condition

### DIFF
--- a/app/tools/penguin-rabbit-shooter/ToolClient.tsx
+++ b/app/tools/penguin-rabbit-shooter/ToolClient.tsx
@@ -11,7 +11,7 @@ const BULLET_HEIGHT = 18;
 const ENEMY_WIDTH = 42;
 const ENEMY_HEIGHT = 38;
 const STAR_COUNT = 40;
-const COMPACT_PORTRAIT_MAX_WIDTH = 500;
+const COMPACT_MAX_WIDTH = 640;
 const TOUCH_PANEL_MIN_VIEWPORT = 768;
 
 type GameState = "idle" | "playing" | "gameover";
@@ -551,7 +551,7 @@ export default function ToolClient() {
       const viewportWidth = window.innerWidth;
       const viewportHeight = window.innerHeight;
       const isCompactPortrait =
-        viewportWidth <= COMPACT_PORTRAIT_MAX_WIDTH && viewportHeight > viewportWidth;
+        viewportWidth <= COMPACT_MAX_WIDTH && viewportHeight > viewportWidth;
       const heightCap = isCompactPortrait
         ? Math.min(Math.max(viewportHeight * 0.52, 380), 560)
         : HEIGHT;
@@ -586,14 +586,10 @@ export default function ToolClient() {
       : gameState === "gameover"
         ? "ゲームオーバー"
         : "待機中";
-  const isCompactPortrait =
-    viewportSize.width > 0 &&
-    viewportSize.width <= COMPACT_PORTRAIT_MAX_WIDTH &&
-    viewportSize.height > viewportSize.width;
+  const isCompact =
+    viewportSize.width > 0 && viewportSize.width <= COMPACT_MAX_WIDTH;
   const showTouchPanel =
-    isCompactPortrait ||
-    viewportSize.width === 0 ||
-    viewportSize.width >= TOUCH_PANEL_MIN_VIEWPORT;
+    isCompact || viewportSize.width === 0 || viewportSize.width >= TOUCH_PANEL_MIN_VIEWPORT;
 
   return (
     <main style={styles.page}>
@@ -601,14 +597,14 @@ export default function ToolClient() {
         <section
           style={{
             ...styles.hero,
-            ...(isCompactPortrait ? styles.heroCompact : {}),
+            ...(isCompact ? styles.heroCompact : {}),
           }}
         >
           <div style={styles.eyebrow}>extras / mini game</div>
           <h1
             style={{
               ...styles.title,
-              ...(isCompactPortrait ? styles.titleCompact : {}),
+              ...(isCompact ? styles.titleCompact : {}),
             }}
           >
             ペンギン・バニーシューター
@@ -616,7 +612,7 @@ export default function ToolClient() {
           <p
             style={{
               ...styles.note,
-              ...(isCompactPortrait ? styles.noteCompact : {}),
+              ...(isCompact ? styles.noteCompact : {}),
             }}
           >
             矢印キーでペンギンを動かし、Space でショット。絵文字だけで遊べる最短版のミニゲームです。
@@ -626,13 +622,13 @@ export default function ToolClient() {
         <div
           style={{
             ...styles.layout,
-            ...(isCompactPortrait ? styles.layoutCompact : {}),
+            ...(isCompact ? styles.layoutCompact : {}),
           }}
         >
           <section
             style={{
               ...styles.sideColumn,
-              ...(isCompactPortrait ? styles.sideColumnCompact : {}),
+              ...(isCompact ? styles.sideColumnCompact : {}),
             }}
           >
             <article style={styles.card}>
@@ -665,7 +661,7 @@ export default function ToolClient() {
                 onClick={startGame}
                 style={{
                   ...styles.primaryButton,
-                  ...(isCompactPortrait ? styles.primaryButtonCompact : {}),
+                  ...(isCompact ? styles.primaryButtonCompact : {}),
                 }}
               >
                 {gameState === "idle" ? "スタート" : "リスタート"}
@@ -675,7 +671,7 @@ export default function ToolClient() {
             <div
               style={{
                 ...styles.statGrid,
-                ...(isCompactPortrait ? styles.statGridCompact : {}),
+                ...(isCompact ? styles.statGridCompact : {}),
               }}
             >
               <article style={styles.statCard}>
@@ -705,7 +701,7 @@ export default function ToolClient() {
           <section
             style={{
               ...styles.gameCard,
-              ...(isCompactPortrait ? styles.gameCardCompact : {}),
+              ...(isCompact ? styles.gameCardCompact : {}),
             }}
           >
             <div ref={gameViewportRef} style={styles.gameViewport}>
@@ -783,37 +779,37 @@ export default function ToolClient() {
             <div
               style={{
                 ...styles.touchPanel,
-                ...(isCompactPortrait ? styles.touchPanelCompact : {}),
+                ...(isCompact ? styles.touchPanelCompact : {}),
               }}
             >
               <div style={styles.touchPanelTitle}>スマホ操作</div>
               <div
                 style={{
                   ...styles.touchGrid,
-                  ...(isCompactPortrait ? styles.touchGridCompact : {}),
+                  ...(isCompact ? styles.touchGridCompact : {}),
                 }}
               >
                 <div style={styles.touchPad}>
                   <div />
                   <TouchButton
                     label="↑"
-                    compact={isCompactPortrait}
+                    compact={isCompact}
                     onPressChange={(pressed) => setControlPressed("ArrowUp", pressed)}
                   />
                   <div />
                   <TouchButton
                     label="←"
-                    compact={isCompactPortrait}
+                    compact={isCompact}
                     onPressChange={(pressed) => setControlPressed("ArrowLeft", pressed)}
                   />
                   <TouchButton
                     label="↓"
-                    compact={isCompactPortrait}
+                    compact={isCompact}
                     onPressChange={(pressed) => setControlPressed("ArrowDown", pressed)}
                   />
                   <TouchButton
                     label="→"
-                    compact={isCompactPortrait}
+                    compact={isCompact}
                     onPressChange={(pressed) => setControlPressed("ArrowRight", pressed)}
                   />
                 </div>
@@ -823,7 +819,7 @@ export default function ToolClient() {
                     label="発射"
                     wide
                     accent
-                    compact={isCompactPortrait}
+                    compact={isCompact}
                     onPressChange={(pressed) => {
                       if (pressed && gameState === "idle") {
                         startGame();


### PR DESCRIPTION
## Summary

- `COMPACT_MAX_WIDTH` を 500px → 640px に拡大（Pixel 10 Pro など高解像度フラッグシップの CSS 幅が 500px 超の可能性に対応）
- レンダー側の `isCompact` からポートレート条件（`height > width`）を削除し、**幅だけ**でレイアウトを切り替えるよう変更
- ポートレート条件はゲームキャンバス高さキャップ計算（`updateScale` 内）にのみ残す

## 設計上の変更理由

従来：`width ≤ 500 && height > width` → レイアウト＆高さキャップ両方を判定
今回：
- レイアウト切替 → `width ≤ 640`（幅だけ、ポートレート不問）
- 高さキャップ → `width ≤ 640 && height > width`（変更なし）

ポートレート条件は Chrome の URL バー表示タイミングや端末 DPR の違いで誤作動しうるため、レイアウト判定から除外。

## Test plan

- [ ] Pixel 10 Pro でレイアウトが縦積み（1カラム）になる
- [ ] デスクトップ幅（>768px）では2カラムレイアウトのまま
- [ ] 幅 640px 以下で縦積みに切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)