### PR TITLE
fix(penguin-rabbit-shooter): resolve hydration mismatch in star positions

### DIFF
--- a/app/tools/penguin-rabbit-shooter/ToolClient.tsx
+++ b/app/tools/penguin-rabbit-shooter/ToolClient.tsx
@@ -67,9 +67,9 @@ function pseudoRandom(seed: number) {
 function createStars(): Star[] {
   return Array.from({ length: STAR_COUNT }, (_, index) => ({
     id: index,
-    x: pseudoRandom(index + 1) * WIDTH,
-    y: pseudoRandom(index + 101) * HEIGHT,
-    r: pseudoRandom(index + 201) * 2 + 1,
+    x: Math.round(pseudoRandom(index + 1) * WIDTH),
+    y: Math.round(pseudoRandom(index + 101) * HEIGHT),
+    r: Math.round(pseudoRandom(index + 201) * 2 + 1),
     speed: pseudoRandom(index + 301) * 1.5 + 0.5,
   }));
 }


### PR DESCRIPTION
## Summary

- `createStars()` で生成する星の座標 (`x`, `y`, `r`) に `Math.round` を適用し、整数値に統一
- SSR（Node.js）とブラウザでの CSS シリアライズ精度の違いによるハイドレーションミスマッチを解消

## 原因

`pseudoRandom`（`Math.sin` ベース）が返す浮動小数点値をそのままスタイルに使用していたため、サーバー側の CSS 変換（例: `"41.1971px"`）とクライアント側の数値（`41.19708193698898`）が一致しなかった。

## Test plan

- [ ] ブラウザのコンソールにハイドレーションエラーが出ないことを確認
- [ ] 星の表示が正常にレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)