### PR TITLE
feat(edinet-documents): EDINET書類一覧ページを追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,6 +101,13 @@ const TOOLS: ToolItem[] = [
     icon: "📈",
   },
   {
+    title: "EDINET書類一覧",
+    short: "有報・大量保有報告書をまとめて確認",
+    detail: "金融庁EDINETに提出された有価証券報告書・大量保有報告書などを日次で一覧表示。上場企業フィルター・書類種別絞込み対応。",
+    href: "/tools/edinet-documents",
+    icon: "📄",
+  },
+  {
     title: "ペンギン・バニーシューター",
     short: "絵文字で遊ぶミニゲーム",
     detail: "ペンギンを動かして、うさぎをショット。絵文字ベースで気軽に遊べるおまけゲーム。",

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -56,7 +56,7 @@ function formatDate(dateStr: string): string {
 type DocTypeFilter = "all" | string;
 
 function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
-  const edinetUrl = `https://disclosure2.edinet-fsa.go.jp/WZEK0040.aspx?S1${item.doc_id.replace(/^S/, "")},,`;
+  const edinetUrl = `https://disclosure2.edinet-fsa.go.jp/WZEK0040.aspx?${item.doc_id},,`;
 
   return (
     <tr
@@ -85,16 +85,25 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
           {item.filer_name}
         </div>
         {item.sec_code && (
-          <div
+          <a
+            href={`https://finance.yahoo.co.jp/quote/${item.sec_code}0.T`}
+            target="_blank"
+            rel="noopener noreferrer"
             style={{
+              display: "inline-block",
               fontSize: 11,
-              color: "var(--color-text-muted)",
-              fontWeight: 500,
-              marginTop: 2,
+              color: "var(--color-accent)",
+              fontWeight: 600,
+              marginTop: 3,
+              textDecoration: "none",
+              padding: "1px 6px",
+              borderRadius: 4,
+              border: "1px solid var(--color-accent)",
+              background: "var(--color-accent-sub)",
             }}
           >
-            {item.sec_code}
-          </div>
+            {item.sec_code} ↗
+          </a>
         )}
       </td>
       <td

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -53,7 +53,6 @@ function formatDate(dateStr: string): string {
   return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
-type DocTypeFilter = "all" | string;
 
 function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
   const edinetUrl = `https://disclosure2.edinet-fsa.go.jp/WZEK0040.aspx?${item.doc_id},,`;
@@ -86,7 +85,7 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
         </div>
         {item.sec_code && (
           <a
-            href={`https://finance.yahoo.co.jp/quote/${item.sec_code.slice(0, 4)}.T`}
+            href={`https://finance.yahoo.co.jp/quote/${item.sec_code.replace(/0+$/, "")}.T`}
             target="_blank"
             rel="noopener noreferrer"
             style={{
@@ -169,7 +168,7 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
 export default function ToolClient({ data }: { data: EdinetDocumentListResponse }) {
   const [secCodeOnly, setSecCodeOnly] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [docTypeFilter, setDocTypeFilter] = useState<DocTypeFilter>("all");
+  const [docTypeFilter, setDocTypeFilter] = useState("all");
 
   const docTypeCounts = useMemo(() => {
     const counts = new Map<string, number>();

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -86,7 +86,7 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
         </div>
         {item.sec_code && (
           <a
-            href={`https://finance.yahoo.co.jp/quote/${item.sec_code}0.T`}
+            href={`https://finance.yahoo.co.jp/quote/${item.sec_code.slice(0, 4)}.T`}
             target="_blank"
             rel="noopener noreferrer"
             style={{
@@ -102,7 +102,7 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
               background: "var(--color-accent-sub)",
             }}
           >
-            {item.sec_code} ↗
+            {item.sec_code.slice(0, 4)} ↗
           </a>
         )}
       </td>

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { EdinetDocumentListResponse, EdinetDocItem } from "./types";
+
+const DOC_TYPE_LABELS: Record<string, string> = {
+  "020": "有価証券届出書",
+  "030": "訂正有価証券届出書",
+  "040": "有価証券届出書（組込方式）",
+  "050": "訂正有価証券届出書（組込方式）",
+  "060": "有価証券届出書（参照方式）",
+  "070": "訂正有価証券届出書（参照方式）",
+  "120": "有価証券報告書",
+  "130": "訂正有価証券報告書",
+  "140": "半期報告書",
+  "150": "訂正半期報告書",
+  "160": "四半期報告書",
+  "170": "訂正四半期報告書",
+  "180": "臨時報告書",
+  "190": "訂正臨時報告書",
+  "200": "親会社等状況報告書",
+  "210": "訂正親会社等状況報告書",
+  "220": "自己株券買付状況報告書",
+  "230": "訂正自己株券買付状況報告書",
+  "240": "内部統制報告書",
+  "250": "訂正内部統制報告書",
+  "251": "確認書",
+  "252": "訂正確認書",
+  "270": "大量保有報告書",
+  "280": "訂正大量保有報告書",
+  "290": "基準日の届出書",
+  "300": "株券等の取引に関する報告書",
+  "310": "公開買付届出書",
+  "320": "訂正公開買付届出書",
+  "330": "公開買付撤回届出書",
+  "340": "公開買付報告書",
+  "350": "訂正公開買付報告書",
+  "360": "意見表明報告書",
+  "370": "訂正意見表明報告書",
+  "380": "対質問回答報告書",
+  "390": "訂正対質問回答報告書",
+  "400": "計画書",
+  "410": "訂正計画書",
+};
+
+function getDocTypeLabel(code: string): string {
+  return DOC_TYPE_LABELS[code] ?? `書類(${code})`;
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr.replace(" ", "T"));
+  if (isNaN(d.getTime())) return dateStr;
+  return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+type DocTypeFilter = "all" | string;
+
+function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
+  const edinetUrl = `https://disclosure2.edinet-fsa.go.jp/WZEK0040.aspx?S1${item.doc_id.replace(/^S/, "")},,`;
+
+  return (
+    <tr
+      style={{
+        borderBottom: "1px solid var(--color-border)",
+        opacity: muted ? 0.45 : 1,
+      }}
+    >
+      <td
+        style={{
+          padding: "10px 8px",
+          fontSize: 13,
+          fontWeight: 700,
+          color: "var(--color-text)",
+          maxWidth: 180,
+        }}
+      >
+        <div
+          style={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+          title={item.filer_name}
+        >
+          {item.filer_name}
+        </div>
+        {item.sec_code && (
+          <div
+            style={{
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+              fontWeight: 500,
+              marginTop: 2,
+            }}
+          >
+            {item.sec_code}
+          </div>
+        )}
+      </td>
+      <td
+        style={{
+          padding: "10px 8px",
+          fontSize: 12,
+          color: "var(--color-text-sub)",
+          maxWidth: 240,
+        }}
+      >
+        <a
+          href={edinetUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            color: "inherit",
+            textDecoration: "none",
+            display: "block",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+          title={item.doc_description}
+        >
+          {item.doc_description || getDocTypeLabel(item.doc_type_code)}
+        </a>
+      </td>
+      <td
+        style={{
+          padding: "10px 8px",
+          fontSize: 12,
+          color: "var(--color-text-muted)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {formatDate(item.submit_datetime)}
+      </td>
+      <td
+        style={{
+          padding: "10px 8px",
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <span
+          style={{
+            display: "inline-block",
+            padding: "2px 6px",
+            borderRadius: 999,
+            background: "var(--color-bg-input)",
+            border: "1px solid var(--color-border)",
+            fontWeight: 600,
+          }}
+        >
+          {getDocTypeLabel(item.doc_type_code)}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+export default function ToolClient({ data }: { data: EdinetDocumentListResponse }) {
+  const [secCodeOnly, setSecCodeOnly] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [docTypeFilter, setDocTypeFilter] = useState<DocTypeFilter>("all");
+
+  const docTypeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of data.items) {
+      counts.set(item.doc_type_code, (counts.get(item.doc_type_code) ?? 0) + 1);
+    }
+    return counts;
+  }, [data.items]);
+
+  const topDocTypes = useMemo(() => {
+    return [...docTypeCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([code]) => code);
+  }, [docTypeCounts]);
+
+  const filteredItems = useMemo(() => {
+    return data.items.filter((item) => {
+      if (secCodeOnly && !item.sec_code) return false;
+      if (docTypeFilter !== "all" && item.doc_type_code !== docTypeFilter) return false;
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        if (
+          !item.filer_name.toLowerCase().includes(q) &&
+          !item.doc_description.toLowerCase().includes(q) &&
+          !(item.sec_code ?? "").includes(q)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [data.items, secCodeOnly, docTypeFilter, searchQuery]);
+
+  const displayItems = useMemo(
+    () => filteredItems.map((item) => ({ item, muted: !secCodeOnly && !item.sec_code })),
+    [filteredItems, secCodeOnly],
+  );
+
+  return (
+    <main style={{ maxWidth: 960, margin: "0 auto", padding: "0 16px 64px" }}>
+      {/* ヘッダー */}
+      <section style={{ padding: "32px 0 24px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+          <span style={{ fontSize: 26 }}>📄</span>
+          <h1 style={{ margin: 0, fontSize: 28, fontWeight: 900, letterSpacing: -0.7 }}>
+            EDINET書類一覧
+          </h1>
+        </div>
+        <p style={{ margin: 0, fontSize: 14, color: "var(--color-text-muted)", lineHeight: 1.7 }}>
+          金融庁EDINETに提出された書類を日次で確認できます。有価証券報告書・大量保有報告書などをまとめて表示。
+        </p>
+      </section>
+
+      {/* 日付・件数サマリー */}
+      <section
+        style={{
+          background: "var(--color-bg-card)",
+          borderRadius: 12,
+          border: "1px solid var(--color-border)",
+          padding: "12px 16px",
+          marginBottom: 14,
+          display: "flex",
+          alignItems: "center",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>対象日</span>
+          <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)" }}>
+            {data.as_of_date}
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>総件数</span>
+          <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)" }}>
+            {data.total_count.toLocaleString()}件
+          </span>
+        </div>
+        {filteredItems.length !== data.total_count && (
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>表示中</span>
+            <span
+              style={{
+                fontSize: 14,
+                fontWeight: 800,
+                color: "var(--color-accent)",
+              }}
+            >
+              {filteredItems.length.toLocaleString()}件
+            </span>
+          </div>
+        )}
+      </section>
+
+      {/* フィルターバー */}
+      <section
+        style={{
+          background: "var(--color-bg-card)",
+          borderRadius: 12,
+          border: "1px solid var(--color-border)",
+          padding: "12px 16px",
+          marginBottom: 14,
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        {/* 検索 */}
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="提出者名・書類名・証券コードで検索..."
+          style={{
+            padding: "8px 12px",
+            borderRadius: 8,
+            border: "1.5px solid var(--color-border)",
+            background: "var(--color-bg-input)",
+            color: "var(--color-text)",
+            fontSize: 13,
+            width: "100%",
+            boxSizing: "border-box",
+            outline: "none",
+          }}
+        />
+
+        {/* 書類種別タブ */}
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            onClick={() => setDocTypeFilter("all")}
+            style={{
+              padding: "4px 12px",
+              borderRadius: 999,
+              border: "1.5px solid",
+              borderColor: docTypeFilter === "all" ? "var(--color-accent)" : "var(--color-border)",
+              background: docTypeFilter === "all" ? "var(--color-accent-sub)" : "transparent",
+              color: docTypeFilter === "all" ? "var(--color-accent)" : "var(--color-text-muted)",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            すべて
+          </button>
+          {topDocTypes.map((code) => (
+            <button
+              key={code}
+              type="button"
+              onClick={() => setDocTypeFilter(code)}
+              style={{
+                padding: "4px 12px",
+                borderRadius: 999,
+                border: "1.5px solid",
+                borderColor: docTypeFilter === code ? "var(--color-accent)" : "var(--color-border)",
+                background: docTypeFilter === code ? "var(--color-accent-sub)" : "transparent",
+                color: docTypeFilter === code ? "var(--color-accent)" : "var(--color-text-muted)",
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {getDocTypeLabel(code)}
+              <span
+                style={{
+                  marginLeft: 4,
+                  fontSize: 10,
+                  opacity: 0.7,
+                }}
+              >
+                {docTypeCounts.get(code)}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* 証券コードフィルター */}
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            cursor: "pointer",
+            userSelect: "none",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={secCodeOnly}
+            onChange={(e) => setSecCodeOnly(e.target.checked)}
+            style={{ width: 14, height: 14, cursor: "pointer" }}
+          />
+          <span style={{ fontSize: 12, color: "var(--color-text-sub)", fontWeight: 600 }}>
+            上場企業のみ表示（証券コードあり）
+          </span>
+        </label>
+      </section>
+
+      {/* テーブル */}
+      <section
+        style={{
+          background: "var(--color-bg-card)",
+          borderRadius: 12,
+          border: "1px solid var(--color-border)",
+          overflow: "hidden",
+        }}
+      >
+        {filteredItems.length === 0 ? (
+          <div
+            style={{
+              padding: "32px 20px",
+              textAlign: "center",
+              color: "var(--color-text-muted)",
+              fontSize: 14,
+            }}
+          >
+            該当する書類がありません。
+          </div>
+        ) : (
+          <div style={{ overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                tableLayout: "fixed",
+              }}
+            >
+              <colgroup>
+                <col style={{ width: "24%" }} />
+                <col style={{ width: "36%" }} />
+                <col style={{ width: "14%" }} />
+                <col style={{ width: "26%" }} />
+              </colgroup>
+              <thead>
+                <tr style={{ borderBottom: "2px solid var(--color-border-strong)" }}>
+                  {[
+                    { label: "提出者" },
+                    { label: "書類名" },
+                    { label: "提出日時" },
+                    { label: "種別" },
+                  ].map(({ label }) => (
+                    <th
+                      key={label}
+                      style={{
+                        padding: "10px 8px",
+                        textAlign: "left",
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: "var(--color-text-muted)",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {displayItems.map(({ item, muted }) => (
+                  <DocRow key={item.doc_id} item={item} muted={muted} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* データ注記 */}
+      <p
+        style={{
+          marginTop: 12,
+          fontSize: 11,
+          color: "var(--color-text-muted)",
+          lineHeight: 1.6,
+        }}
+      >
+        ※ データは金融庁EDINET APIから取得しています。書類名のリンクからEDINETの詳細ページへ移動できます。
+      </p>
+    </main>
+  );
+}

--- a/app/tools/edinet-documents/data-loader.ts
+++ b/app/tools/edinet-documents/data-loader.ts
@@ -1,0 +1,13 @@
+import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import type { EdinetDocumentListResponse } from "./types";
+
+export async function loadEdinetDocumentList(): Promise<EdinetDocumentListResponse | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<EdinetDocumentListResponse>(`${apiBase}/edinet/document-list/latest`);
+  } catch {
+    return null;
+  }
+}

--- a/app/tools/edinet-documents/page.tsx
+++ b/app/tools/edinet-documents/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import ToolClient from "./ToolClient";
+import { loadEdinetDocumentList } from "./data-loader";
+
+export const metadata: Metadata = {
+  title: "EDINET書類一覧 | mini-tools",
+  description:
+    "金融庁EDINETに提出された有価証券報告書などの書類を日次で確認できるツール。",
+  alternates: {
+    canonical: "/tools/edinet-documents",
+  },
+};
+
+export default async function Page() {
+  const data = await loadEdinetDocumentList();
+
+  if (!data) {
+    return (
+      <main style={{ maxWidth: 960, margin: "0 auto", padding: "0 16px 64px" }}>
+        <section style={{ padding: "32px 0 24px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+            <span style={{ fontSize: 26 }}>📄</span>
+            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
+              EDINET書類一覧
+            </h1>
+          </div>
+        </section>
+        <div
+          style={{
+            padding: "32px 20px",
+            textAlign: "center",
+            color: "var(--color-text-muted)",
+            fontSize: 14,
+          }}
+        >
+          データを取得できませんでした。時間をおいて再度お試しください。
+        </div>
+      </main>
+    );
+  }
+
+  return <ToolClient data={data} />;
+}

--- a/app/tools/edinet-documents/types.ts
+++ b/app/tools/edinet-documents/types.ts
@@ -1,0 +1,18 @@
+export type EdinetDocItem = {
+  doc_id: string;
+  submit_datetime: string;
+  edinet_code: string;
+  sec_code: string | null;
+  filer_name: string;
+  doc_type_code: string;
+  doc_description: string;
+  has_xbrl: boolean;
+  has_pdf: boolean;
+  has_csv: boolean;
+};
+
+export type EdinetDocumentListResponse = {
+  as_of_date: string;
+  total_count: number;
+  items: EdinetDocItem[];
+};


### PR DESCRIPTION
## 概要

金融庁EDINET APIから書類一覧を取得して表示する新ページ `/tools/edinet-documents` を追加。

## 変更内容

- `app/tools/edinet-documents/types.ts` — `EdinetDocItem` / `EdinetDocumentListResponse` 型定義
- `app/tools/edinet-documents/data-loader.ts` — `GET /edinet/document-list/latest` 呼び出し（APIなし時は `null` を返す）
- `app/tools/edinet-documents/page.tsx` — Server Component。データ取得失敗時のフォールバック表示あり
- `app/tools/edinet-documents/ToolClient.tsx` — Client Component。以下の機能を実装：
  - 提出者名・書類名・証券コードのフリーテキスト検索
  - 書類種別フィルター（件数上位5種をタブ表示）
  - 上場企業のみ表示チェックボックス（sec_code が null のものをミュート or 非表示）
  - 書類名からEDINETの詳細ページへリンク
- `app/page.tsx` — トップページのツール一覧にEDINET書類一覧を追加

## 確認項目

- [x] `npm run lint` パス
- [ ] APIありの環境で `/tools/edinet-documents` 表示確認
- [ ] フィルター操作の動作確認
- [ ] APIなし時のフォールバック表示確認
