### PR TITLE
fix(edinet): show document title in type cell

### DIFF
--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -56,6 +56,8 @@ function formatDate(dateStr: string): string {
 
 function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
   const edinetUrl = `https://disclosure2.edinet-fsa.go.jp/WZEK0040.aspx?${item.doc_id},,`;
+  const docTypeLabel = getDocTypeLabel(item.doc_type_code);
+  const docTitle = item.doc_description || docTypeLabel;
 
   return (
     <tr
@@ -121,7 +123,6 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
           padding: "10px 8px",
           fontSize: 11,
           color: "var(--color-text-muted)",
-          whiteSpace: "nowrap",
           textAlign: "right",
         }}
       >
@@ -129,7 +130,7 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
           href={edinetUrl}
           target="_blank"
           rel="noopener noreferrer"
-          title={item.doc_description || getDocTypeLabel(item.doc_type_code)}
+          title={docTitle}
           style={{
             display: "inline-block",
             padding: "2px 6px",
@@ -141,8 +142,27 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
             textDecoration: "none",
           }}
         >
-          {getDocTypeLabel(item.doc_type_code)}
+          {docTypeLabel}
         </a>
+        {docTitle !== docTypeLabel ? (
+          <div
+            title={docTitle}
+            style={{
+              marginTop: 4,
+              marginLeft: "auto",
+              maxWidth: "100%",
+              color: "var(--color-text-muted)",
+              fontSize: 10,
+              fontWeight: 600,
+              lineHeight: 1.35,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {docTitle}
+          </div>
+        ) : null}
       </td>
     </tr>
   );


### PR DESCRIPTION
## 概要

- EDINET 書類一覧で、書類名列を非表示にした後も各行の書類内容を判別できるように修正します。

## 変更内容

- 種別セル内に `doc_description` を1行の補足として表示
- 補足は右寄せセル内で省略表示し、列構成は `提出者 / 提出日時 / 種別` のまま維持

## 確認項目

- `npm run lint`
- `npm run build`
- `codex --profile review-low review --base main`

## 関連 Issue

- なし
