### PR TITLE
fix(earnings-calendar): 国内決算カレンダーを API-first に切り替え（同梱 JSON は fallback へ）

### DIFF
--- a/app/tools/earnings-calendar/ToolClient.tsx
+++ b/app/tools/earnings-calendar/ToolClient.tsx
@@ -458,7 +458,7 @@ export default function ToolClient({ data }: { data: EarningsCalendarPageData })
           <article style={styles.emptyCard}>
             <div style={styles.emptyTitle}>決算データがまだありません</div>
             <div style={styles.emptyNote}>
-              国内版は同梱 JSON、海外版は market-info API を参照します。データ取得先が整うとここに月間カレンダーが表示されます。
+              market-info API を参照します。データ取得先が整うとここに月間カレンダーが表示されます。
             </div>
           </article>
         </div>

--- a/app/tools/earnings-calendar/__tests__/data-loader.test.ts
+++ b/app/tools/earnings-calendar/__tests__/data-loader.test.ts
@@ -183,6 +183,24 @@ describe("loadEarningsCalendarPageData", () => {
     expect(result.domestic.monthData["2025-04"]).toEqual(SAMPLE_DOMESTIC_MONTH_DATA);
   });
 
+  it("domestic manifest 成功・monthly 失敗のとき同梱 JSON の同一月で補完する", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    makeLocalFiles();
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes("/earnings-calendar/domestic/manifest")) return makeFetchOk(SAMPLE_DOMESTIC_MANIFEST);
+      if (u.includes("/earnings-calendar/domestic/latest")) return makeFetchOk(SAMPLE_DOMESTIC_LATEST);
+      if (u.includes("/earnings-calendar/domestic/monthly/")) return makeFetch404();
+      if (u.includes("/earnings-calendar/overseas/")) return makeFetch404();
+      return makeFetch404();
+    });
+
+    const result = await loadEarningsCalendarPageData();
+
+    expect(result.domestic.manifest).toEqual(SAMPLE_DOMESTIC_MANIFEST);
+    expect(result.domestic.monthData["2025-04"]).toEqual(SAMPLE_DOMESTIC_MONTH_DATA);
+  });
+
   it("API 未設定のとき overseas は空構造を返す（fetch しない）", async () => {
     makeLocalFiles();
 

--- a/app/tools/earnings-calendar/__tests__/data-loader.test.ts
+++ b/app/tools/earnings-calendar/__tests__/data-loader.test.ts
@@ -136,7 +136,7 @@ describe("loadEarningsCalendarPageData", () => {
     vi.unstubAllGlobals();
   });
 
-  it("domestic は常にローカルファイルから取得する", async () => {
+  it("API 未設定のとき domestic はローカルファイルから取得する（fetch しない）", async () => {
     makeLocalFiles();
 
     const result = await loadEarningsCalendarPageData();
@@ -146,6 +146,41 @@ describe("loadEarningsCalendarPageData", () => {
     expect(result.domestic.latest).toEqual(SAMPLE_DOMESTIC_LATEST);
     expect(result.domestic.holidays).toEqual(SAMPLE_HOLIDAYS);
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("API 設定あり・domestic manifest 正常のとき API からデータを返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    makeLocalFiles();
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes("/earnings-calendar/domestic/manifest")) return makeFetchOk(SAMPLE_DOMESTIC_MANIFEST);
+      if (u.includes("/earnings-calendar/domestic/latest")) return makeFetchOk(SAMPLE_DOMESTIC_LATEST);
+      if (u.includes("/earnings-calendar/domestic/monthly/")) return makeFetchOk(SAMPLE_DOMESTIC_MONTH_DATA);
+      if (u.includes("/earnings-calendar/overseas/")) return makeFetch404();
+      return makeFetch404();
+    });
+
+    const result = await loadEarningsCalendarPageData();
+
+    expect(result.domestic.manifest).toEqual(SAMPLE_DOMESTIC_MANIFEST);
+    expect(result.domestic.monthData["2025-04"]).toEqual(SAMPLE_DOMESTIC_MONTH_DATA);
+    expect(result.domestic.latest).toEqual(SAMPLE_DOMESTIC_LATEST);
+  });
+
+  it("API 設定あり・domestic manifest 失敗のときローカル JSON にフォールバックする", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    makeLocalFiles();
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes("/earnings-calendar/domestic/")) return makeFetch404();
+      if (u.includes("/earnings-calendar/overseas/")) return makeFetch404();
+      return makeFetch404();
+    });
+
+    const result = await loadEarningsCalendarPageData();
+
+    expect(result.domestic.manifest).toEqual(SAMPLE_DOMESTIC_MANIFEST);
+    expect(result.domestic.monthData["2025-04"]).toEqual(SAMPLE_DOMESTIC_MONTH_DATA);
   });
 
   it("API 未設定のとき overseas は空構造を返す（fetch しない）", async () => {

--- a/app/tools/earnings-calendar/data-loader.ts
+++ b/app/tools/earnings-calendar/data-loader.ts
@@ -50,7 +50,65 @@ async function loadLocalDomesticHolidays(): Promise<JpxMarketClosedResponse | nu
   }
 }
 
+async function loadApiDomesticManifest(): Promise<EarningsCalendarManifest | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<EarningsCalendarManifest>(`${apiBase}/earnings-calendar/domestic/manifest`);
+  } catch {
+    return null;
+  }
+}
+
+async function loadApiDomesticMonthData(yearMonth: string): Promise<EarningsCalendarResponse | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<EarningsCalendarResponse>(
+      `${apiBase}/earnings-calendar/domestic/monthly/${yearMonth}`,
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function loadApiDomesticLatest(): Promise<EarningsCalendarResponse | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    return await fetchJson<EarningsCalendarResponse>(`${apiBase}/earnings-calendar/domestic/latest`);
+  } catch {
+    return null;
+  }
+}
+
 async function loadDomesticData(): Promise<EarningsCalendarMarketData> {
+  const apiManifest = await loadApiDomesticManifest();
+
+  if (apiManifest) {
+    const [monthEntries, latest, holidays] = await Promise.all([
+      Promise.all(
+        apiManifest.months.map(async (entry) => {
+          const monthData = await loadApiDomesticMonthData(entry.id);
+          return monthData ? ([entry.id, monthData] as const) : null;
+        }),
+      ),
+      loadApiDomesticLatest(),
+      loadLocalDomesticHolidays(),
+    ]);
+
+    return {
+      manifest: apiManifest,
+      monthData: Object.fromEntries(monthEntries.filter((entry) => entry !== null)),
+      latest,
+      holidays,
+    };
+  }
+
+  // API 未設定 or 失敗時は同梱 JSON にフォールバック
   const manifest = await loadLocalDomesticManifest();
   const monthEntries = await Promise.all(
     manifest.months.map(async (entry) => {

--- a/app/tools/earnings-calendar/data-loader.ts
+++ b/app/tools/earnings-calendar/data-loader.ts
@@ -89,11 +89,32 @@ async function loadDomesticData(): Promise<EarningsCalendarMarketData> {
   const apiManifest = await loadApiDomesticManifest();
 
   if (apiManifest) {
+    // 月別データが API から取れない場合は同梱 JSON で補完するため、先にローカル manifest を読む
+    let localManifest: EarningsCalendarManifest | null = null;
+    try {
+      localManifest = await loadLocalDomesticManifest();
+    } catch {
+      // 同梱 JSON がなくても続行
+    }
+
     const [monthEntries, latest, holidays] = await Promise.all([
       Promise.all(
         apiManifest.months.map(async (entry) => {
-          const monthData = await loadApiDomesticMonthData(entry.id);
-          return monthData ? ([entry.id, monthData] as const) : null;
+          const apiData = await loadApiDomesticMonthData(entry.id);
+          if (apiData) return [entry.id, apiData] as const;
+          // API の月別取得が失敗した場合、同梱 JSON の同一月にフォールバック
+          if (localManifest) {
+            const localEntry = localManifest.months.find((m) => m.id === entry.id);
+            if (localEntry) {
+              try {
+                const localData = await loadLocalDomesticMonthDataByPath(localEntry.path);
+                return [entry.id, localData] as const;
+              } catch {
+                // 同梱 JSON も取得できなければスキップ
+              }
+            }
+          }
+          return null;
         }),
       ),
       loadApiDomesticLatest(),

--- a/docs/decision-log/2026-04-25-domestic-earnings-calendar-api-first.md
+++ b/docs/decision-log/2026-04-25-domestic-earnings-calendar-api-first.md
@@ -1,0 +1,40 @@
+# 2026-04-25 国内決算カレンダーを API-first に切り替え
+
+## 背景
+
+`market_info` 側で国内決算カレンダーの最新データが R2 に publish 済みだが、
+`mini-tools` では国内のみ同梱 JSON を読んでいたため、2026-05 分が表示されていなかった。
+海外決算カレンダーは `market-info-api` 経由で取得済みで、国内だけが取り残されていた。
+
+## 決めたこと
+
+### 1. 国内決算カレンダーも API-first に切り替える
+
+- `MARKET_INFO_API_BASE_URL` が設定されていれば、まず以下の endpoint を読む:
+  - `GET /earnings-calendar/domestic/manifest`
+  - `GET /earnings-calendar/domestic/monthly/{YYYY-MM}`
+  - `GET /earnings-calendar/domestic/latest`
+- API 取得に失敗した場合（未設定 / ネットワークエラー / 4xx）のみ、repo 同梱 JSON にフォールバックする
+
+### 2. 同梱 JSON の役割
+
+- 同梱 JSON（`app/tools/earnings-calendar/data/`）は「開発・緊急退避」用として継続して保持する
+- 本番主経路は API とし、同梱 JSON は履歴アーカイブとして増やし続けない
+- `jpx_market_closed_*.json` は同梱を維持する（更新頻度が低く、API 化の優先度が低い）
+
+### 3. 海外との対称性を保つ
+
+国内と海外で loader の構造を揃えることで、将来の統合や変更が局所化しやすくなる。
+
+## 影響範囲
+
+- `app/tools/earnings-calendar/data-loader.ts` — `loadDomesticData()` を API-first に変更
+- `app/tools/earnings-calendar/__tests__/data-loader.test.ts` — テストケースを更新
+- `app/tools/earnings-calendar/ToolClient.tsx` — 空状態テキストを修正
+- `docs/market-tools-data-fetch-paths.md` — earnings-calendar 行を更新
+
+## 結果
+
+- 2026-05 分の国内決算カレンダーが表示されるようになった
+- 過去の 2026-03 分も manifest に含まれる月として引き続き表示可能
+- API 失敗時は従来通り同梱 JSON から表示される

--- a/docs/market-tools-data-fetch-paths.md
+++ b/docs/market-tools-data-fetch-paths.md
@@ -31,7 +31,7 @@
 | `us-stock-ranking` | サーバーで `loadUsRankingManifest()` を読み、`manifest.dates` を最大 5 件試して最初に取得できた日次データを初期表示に使う | クライアントは `/tools/us-stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | なし。未設定時 / fetch 失敗時は「データ取得不可」表示 | API パスは `/us-stock-ranking/*` ではなく `/us-ranking/*` |
 | `market-rankings` | サーバーで `loadMarketRankingManifest()` / `loadMarketRankingMonthData()` を呼び、`type` / `month` を正規化して初期表示を決める | クライアント再 fetch は基本なし。`type` / `month` の変更は query string を更新して server を再評価する | `MARKET_INFO_API_BASE_URL` | なし。未設定時は「API 未接続」表示、対象月 fetch 失敗時は error card 表示 | 月次 API 前提。repo 同梱 JSON は持たない |
 | `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | SBI は `is_short=true` の扱い有無だけを表示し、在庫状態では除外しない |
-| `earnings-calendar` | サーバーで `loadEarningsCalendarPageData()` を呼ぶ | クライアント再 fetch なし | `MARKET_INFO_API_BASE_URL` | あり。国内は同梱 JSON、海外は API 未設定/失敗時は非表示 | 国内は repo 同梱 JSON、海外は `earnings-calendar/overseas/*` API を読む |
+| `earnings-calendar` | サーバーで `loadEarningsCalendarPageData()` を呼ぶ | クライアント再 fetch なし | `MARKET_INFO_API_BASE_URL` | あり。国内・海外ともに API 失敗時フォールバック（国内のみ同梱 JSON へ）、海外は API 未設定/失敗時は非表示 | 国内・海外ともに `earnings-calendar/{domestic\|overseas}/*` API を優先取得し、国内は API 失敗時のみ repo 同梱 JSON にフォールバック |
 
 ## `topix33` の具体的な流れ
 


### PR DESCRIPTION
## 概要

国内決算カレンダーが同梱 JSON のみを読んでいたため、market_info 側で publish 済みの 2026-05 データが mini-tools に表示されていなかった。

`loadDomesticData()` を API-first に切り替え、`MARKET_INFO_API_BASE_URL` 経由で最新データを取得するよう修正する。API 失敗時は従来の同梱 JSON にフォールバックする。

## 変更内容

- `app/tools/earnings-calendar/data-loader.ts` — `loadApiDomesticManifest()` / `loadApiDomesticMonthData()` / `loadApiDomesticLatest()` を追加し、`loadDomesticData()` を API-first（失敗時のみ同梱 JSON fallback）に変更
- `app/tools/earnings-calendar/__tests__/data-loader.test.ts` — API 未設定時ローカル fallback / API 正常 / API 失敗 fallback の 3 ケースを整理
- `app/tools/earnings-calendar/ToolClient.tsx` — 空状態テキストの「国内版は同梱 JSON」記述を削除
- `docs/market-tools-data-fetch-paths.md` — earnings-calendar 行を実態に合わせて更新
- `docs/decision-log/2026-04-25-domestic-earnings-calendar-api-first.md` — 判断ログを追加

## 確認項目

- [x] `npm run lint` → pass
- [x] `npx vitest run` → 8 tests passed
- [x] API エンドポイント（`/earnings-calendar/domestic/{manifest,latest,monthly/*}`）が market-info-api に実装済みであることを確認
- [x] R2 に 2026-05 データが publish 済みであることを確認