### PR TITLE
fix(econ-calendar): 時刻・国・インパクトの位置ずれを修正

### DIFF
--- a/app/tools/econ-calendar/ToolClient.tsx
+++ b/app/tools/econ-calendar/ToolClient.tsx
@@ -604,13 +604,16 @@ const styles: Record<string, CSSProperties> = {
     fontSize: 13,
     fontWeight: 800,
     color: "#374151",
-    minWidth: 38,
+    width: 60,
+    flexShrink: 0,
     fontVariantNumeric: "tabular-nums",
   },
   eventFlag: {
     fontSize: 12,
     color: "#6b7280",
     fontWeight: 700,
+    width: 28,
+    flexShrink: 0,
   },
   eventIndicator: {
     flex: "1 1 0",


### PR DESCRIPTION
時刻フィールドを固定幅にして、国・インパクットドットが時刻の文字数に関わらず常に同じ位置に並ぶよう修正。「時刻未定」も1行に収まるよう width:60px に設定。