### PR TITLE
feat(market-rankings): 表示月を前後ナビゲーション（← →）に変更

### DIFF
--- a/app/tools/market-rankings/ToolClient.tsx
+++ b/app/tools/market-rankings/ToolClient.tsx
@@ -415,21 +415,34 @@ export default function ToolClient({ data }: { data: MarketRankingPageData }) {
 
               <div style={styles.section}>
                 <div style={styles.sectionLabel}>表示月</div>
-                <div style={styles.monthList}>
-                  {availableMonths.map((month) => {
-                    const active = month === data.selectedMonth;
-                    return (
+                {(() => {
+                  const idx = availableMonths.indexOf(data.selectedMonth);
+                  const hasPrev = idx > 0;
+                  const hasNext = idx < availableMonths.length - 1;
+                  return (
+                    <div style={styles.monthNav}>
                       <button
-                        key={month}
                         type="button"
-                        onClick={() => replaceQuery({ month })}
-                        style={active ? styles.monthButtonActive : styles.monthButton}
+                        disabled={!hasPrev}
+                        onClick={() => hasPrev && replaceQuery({ month: availableMonths[idx - 1] })}
+                        style={hasPrev ? styles.monthNavArrow : styles.monthNavArrowDisabled}
+                        aria-label="前の月"
                       >
-                        {formatMonth(month)}
+                        ←
                       </button>
-                    );
-                  })}
-                </div>
+                      <span style={styles.monthNavLabel}>{formatMonth(data.selectedMonth)}</span>
+                      <button
+                        type="button"
+                        disabled={!hasNext}
+                        onClick={() => hasNext && replaceQuery({ month: availableMonths[idx + 1] })}
+                        style={hasNext ? styles.monthNavArrow : styles.monthNavArrowDisabled}
+                        aria-label="次の月"
+                      >
+                        →
+                      </button>
+                    </div>
+                  );
+                })()}
               </div>
 
               <div style={styles.section}>
@@ -645,30 +658,45 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 700,
     color: "#0f766e",
   },
-  monthList: {
+  monthNav: {
     display: "flex",
-    flexWrap: "wrap",
+    alignItems: "center",
     gap: 8,
   },
-  monthButton: {
-    padding: "8px 12px",
+  monthNavLabel: {
+    flex: 1,
+    textAlign: "center" as const,
+    fontSize: 14,
+    fontWeight: 700,
+    color: "#0f766e",
+  },
+  monthNavArrow: {
+    width: 32,
+    height: 32,
     borderRadius: 999,
-    border: "1px solid rgba(15,23,42,0.08)",
+    border: "1px solid rgba(15,23,42,0.12)",
     background: "#f8fafc",
     color: "#475569",
-    fontSize: 13,
-    fontWeight: 700,
+    fontSize: 15,
     cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
   },
-  monthButtonActive: {
-    padding: "8px 12px",
+  monthNavArrowDisabled: {
+    width: 32,
+    height: 32,
     borderRadius: 999,
-    border: "1.5px solid #0f766e",
-    background: "#ecfeff",
-    color: "#0f766e",
-    fontSize: 13,
-    fontWeight: 800,
+    border: "1px solid rgba(15,23,42,0.06)",
+    background: "transparent",
+    color: "#cbd5e1",
+    fontSize: 15,
     cursor: "default",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
   },
   marketTabs: {
     display: "flex",

--- a/app/tools/market-rankings/ToolClient.tsx
+++ b/app/tools/market-rankings/ToolClient.tsx
@@ -416,16 +416,17 @@ export default function ToolClient({ data }: { data: MarketRankingPageData }) {
               <div style={styles.section}>
                 <div style={styles.sectionLabel}>表示月</div>
                 {(() => {
+                  // availableMonths は降順（新しい月が先頭）のため idx-1 が未来、idx+1 が過去
                   const idx = availableMonths.indexOf(data.selectedMonth);
-                  const hasPrev = idx > 0;
-                  const hasNext = idx < availableMonths.length - 1;
+                  const hasPast = idx < availableMonths.length - 1;
+                  const hasFuture = idx > 0;
                   return (
                     <div style={styles.monthNav}>
                       <button
                         type="button"
-                        disabled={!hasPrev}
-                        onClick={() => hasPrev && replaceQuery({ month: availableMonths[idx - 1] })}
-                        style={hasPrev ? styles.monthNavArrow : styles.monthNavArrowDisabled}
+                        disabled={!hasPast}
+                        onClick={() => hasPast && replaceQuery({ month: availableMonths[idx + 1] })}
+                        style={hasPast ? styles.monthNavArrow : styles.monthNavArrowDisabled}
                         aria-label="前の月"
                       >
                         ←
@@ -433,9 +434,9 @@ export default function ToolClient({ data }: { data: MarketRankingPageData }) {
                       <span style={styles.monthNavLabel}>{formatMonth(data.selectedMonth)}</span>
                       <button
                         type="button"
-                        disabled={!hasNext}
-                        onClick={() => hasNext && replaceQuery({ month: availableMonths[idx + 1] })}
-                        style={hasNext ? styles.monthNavArrow : styles.monthNavArrowDisabled}
+                        disabled={!hasFuture}
+                        onClick={() => hasFuture && replaceQuery({ month: availableMonths[idx - 1] })}
+                        style={hasFuture ? styles.monthNavArrow : styles.monthNavArrowDisabled}
                         aria-label="次の月"
                       >
                         →

--- a/app/tools/market-rankings/ToolClient.tsx
+++ b/app/tools/market-rankings/ToolClient.tsx
@@ -290,6 +290,55 @@ function RankingTable({
   );
 }
 
+function MonthNav({
+  months,
+  selected,
+  onChange,
+}: {
+  months: string[];
+  selected: string;
+  onChange: (month: string) => void;
+}) {
+  // months は降順（新しい月が先頭）のため idx-1 が未来、idx+1 が過去
+  const idx = months.indexOf(selected);
+  if (idx === -1) return null;
+  const hasPast = idx < months.length - 1;
+  const hasFuture = idx > 0;
+  const arrowBase: React.CSSProperties = {
+    width: 32,
+    height: 32,
+    borderRadius: 999,
+    fontSize: 15,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  };
+  return (
+    <div style={styles.monthNav}>
+      <button
+        type="button"
+        disabled={!hasPast}
+        onClick={() => onChange(months[idx + 1])}
+        style={hasPast ? { ...arrowBase, ...styles.monthNavArrow } : { ...arrowBase, ...styles.monthNavArrowDisabled }}
+        aria-label="前の月"
+      >
+        ←
+      </button>
+      <span style={styles.monthNavLabel}>{formatMonth(selected)}</span>
+      <button
+        type="button"
+        disabled={!hasFuture}
+        onClick={() => onChange(months[idx - 1])}
+        style={hasFuture ? { ...arrowBase, ...styles.monthNavArrow } : { ...arrowBase, ...styles.monthNavArrowDisabled }}
+        aria-label="次の月"
+      >
+        →
+      </button>
+    </div>
+  );
+}
+
 export default function ToolClient({ data }: { data: MarketRankingPageData }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -415,35 +464,11 @@ export default function ToolClient({ data }: { data: MarketRankingPageData }) {
 
               <div style={styles.section}>
                 <div style={styles.sectionLabel}>表示月</div>
-                {(() => {
-                  // availableMonths は降順（新しい月が先頭）のため idx-1 が未来、idx+1 が過去
-                  const idx = availableMonths.indexOf(data.selectedMonth);
-                  const hasPast = idx < availableMonths.length - 1;
-                  const hasFuture = idx > 0;
-                  return (
-                    <div style={styles.monthNav}>
-                      <button
-                        type="button"
-                        disabled={!hasPast}
-                        onClick={() => hasPast && replaceQuery({ month: availableMonths[idx + 1] })}
-                        style={hasPast ? styles.monthNavArrow : styles.monthNavArrowDisabled}
-                        aria-label="前の月"
-                      >
-                        ←
-                      </button>
-                      <span style={styles.monthNavLabel}>{formatMonth(data.selectedMonth)}</span>
-                      <button
-                        type="button"
-                        disabled={!hasFuture}
-                        onClick={() => hasFuture && replaceQuery({ month: availableMonths[idx - 1] })}
-                        style={hasFuture ? styles.monthNavArrow : styles.monthNavArrowDisabled}
-                        aria-label="次の月"
-                      >
-                        →
-                      </button>
-                    </div>
-                  );
-                })()}
+                <MonthNav
+                  months={availableMonths}
+                  selected={data.selectedMonth}
+                  onChange={(month) => replaceQuery({ month })}
+                />
               </div>
 
               <div style={styles.section}>
@@ -672,32 +697,16 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#0f766e",
   },
   monthNavArrow: {
-    width: 32,
-    height: 32,
-    borderRadius: 999,
     border: "1px solid rgba(15,23,42,0.12)",
     background: "#f8fafc",
     color: "#475569",
-    fontSize: 15,
     cursor: "pointer",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    flexShrink: 0,
   },
   monthNavArrowDisabled: {
-    width: 32,
-    height: 32,
-    borderRadius: 999,
     border: "1px solid rgba(15,23,42,0.06)",
     background: "transparent",
     color: "#cbd5e1",
-    fontSize: 15,
     cursor: "default",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    flexShrink: 0,
   },
   marketTabs: {
     display: "flex",


### PR DESCRIPTION
## Summary
- 月が増えると横並びが崩れる問題を解消するため、pill ボタン一覧を廃止
- `← 2026年5月 →` 形式のナビゲーターに変更
- 月数・年数が何件増えても常に1行で収まる
- 端（最古月・最新月）では対応する矢印をグレーアウト・disabled に

## Test plan
- [ ] ← → で前後の月に切り替えられること
- [ ] 最新月では → がグレーアウトされること
- [ ] 最古月では ← がグレーアウトされること
- [ ] URLクエリパラメータが正しく更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)