### PR TITLE
feat(edinet-documents): R2からデータ取得・日付ナビゲーション追加

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,11 +10,6 @@ NEXT_PUBLIC_GA_ID=
 # response shape: as_of_date, from, to, days[] (date, market_closed, label)
 MARKET_INFO_API_BASE_URL=
 
-# EDINET書類データの R2 パブリック base URL（任意）
-# 設定すると edinet-documents ツールが R2 から直接データを取得する
-# 例: https://pub-xxxx.r2.dev
-EDINET_R2_BASE_URL=
-
 # 共有リンク / QR 用の公開URL（任意）
 NEXT_PUBLIC_SITE_URL=
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -10,6 +10,11 @@ NEXT_PUBLIC_GA_ID=
 # response shape: as_of_date, from, to, days[] (date, market_closed, label)
 MARKET_INFO_API_BASE_URL=
 
+# EDINET書類データの R2 パブリック base URL（任意）
+# 設定すると edinet-documents ツールが R2 から直接データを取得する
+# 例: https://pub-xxxx.r2.dev
+EDINET_R2_BASE_URL=
+
 # 共有リンク / QR 用の公開URL（任意）
 NEXT_PUBLIC_SITE_URL=
 

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -485,8 +485,8 @@ export default function ToolClient({
                 </tr>
               </thead>
               <tbody>
-                {displayItems.map(({ item, muted }) => (
-                  <DocRow key={item.doc_id} item={item} muted={muted} />
+                {displayItems.map(({ item, muted }, idx) => (
+                  <DocRow key={`${item.doc_id}-${idx}`} item={item} muted={muted} />
                 ))}
               </tbody>
             </table>

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -178,9 +178,11 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
 export default function ToolClient({
   data,
   manifest,
+  currentDate,
 }: {
-  data: EdinetDocumentListResponse;
+  data: EdinetDocumentListResponse | null;
   manifest: EdinetManifest | null;
+  currentDate?: string;
 }) {
   const router = useRouter();
   const [secCodeOnly, setSecCodeOnly] = useState(false);
@@ -188,7 +190,8 @@ export default function ToolClient({
   const [docTypeFilter, setDocTypeFilter] = useState("all");
 
   const dates = manifest?.dates ?? [];
-  const currentIdx = dates.indexOf(data.as_of_date);
+  const displayDate = data?.as_of_date ?? currentDate ?? "";
+  const currentIdx = dates.indexOf(displayDate);
   const prevDate = currentIdx > 0 ? dates[currentIdx - 1] : null;
   const nextDate = currentIdx < dates.length - 1 ? dates[currentIdx + 1] : null;
 
@@ -198,11 +201,11 @@ export default function ToolClient({
 
   const docTypeCounts = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const item of data.items) {
+    for (const item of data?.items ?? []) {
       counts.set(item.doc_type_code, (counts.get(item.doc_type_code) ?? 0) + 1);
     }
     return counts;
-  }, [data.items]);
+  }, [data?.items]);
 
   const topDocTypes = useMemo(() => {
     return [...docTypeCounts.entries()]
@@ -212,7 +215,7 @@ export default function ToolClient({
   }, [docTypeCounts]);
 
   const filteredItems = useMemo(() => {
-    return data.items.filter((item) => {
+    return (data?.items ?? []).filter((item) => {
       if (secCodeOnly && !item.sec_code) return false;
       if (docTypeFilter !== "all" && item.doc_type_code !== docTypeFilter) return false;
       if (searchQuery) {
@@ -227,7 +230,7 @@ export default function ToolClient({
       }
       return true;
     });
-  }, [data.items, secCodeOnly, docTypeFilter, searchQuery]);
+  }, [data?.items, secCodeOnly, docTypeFilter, searchQuery]);
 
   const displayItems = useMemo(
     () => filteredItems.map((item) => ({ item, muted: !secCodeOnly && !item.sec_code })),
@@ -287,7 +290,7 @@ export default function ToolClient({
             ←
           </button>
           <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)", minWidth: 160, textAlign: "center" }}>
-            {formatAsOfDate(data.as_of_date)}
+            {displayDate ? formatAsOfDate(displayDate) : "—"}
           </span>
           <button
             type="button"
@@ -300,13 +303,15 @@ export default function ToolClient({
           </button>
         </div>
 
-        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>総件数</span>
-          <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)" }}>
-            {data.total_count.toLocaleString()}件
-          </span>
-        </div>
-        {filteredItems.length !== data.total_count && (
+        {data && (
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>総件数</span>
+            <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)" }}>
+              {data.total_count.toLocaleString()}件
+            </span>
+          </div>
+        )}
+        {data && filteredItems.length !== data.total_count && (
           <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>表示中</span>
             <span
@@ -323,7 +328,7 @@ export default function ToolClient({
       </section>
 
       {/* フィルターバー */}
-      <section
+      {data && <section
         style={{
           background: "var(--color-bg-card)",
           borderRadius: 12,
@@ -425,7 +430,7 @@ export default function ToolClient({
             上場企業のみ表示（証券コードあり）
           </span>
         </label>
-      </section>
+      </section>}
 
       {/* テーブル */}
       <section
@@ -436,7 +441,18 @@ export default function ToolClient({
           overflow: "hidden",
         }}
       >
-        {filteredItems.length === 0 ? (
+        {!data ? (
+          <div
+            style={{
+              padding: "32px 20px",
+              textAlign: "center",
+              color: "var(--color-text-muted)",
+              fontSize: 14,
+            }}
+          >
+            この日付のデータはありません。
+          </div>
+        ) : filteredItems.length === 0 ? (
           <div
             style={{
               padding: "32px 20px",

--- a/app/tools/edinet-documents/ToolClient.tsx
+++ b/app/tools/edinet-documents/ToolClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { EdinetDocumentListResponse, EdinetDocItem } from "./types";
+import { useRouter } from "next/navigation";
+import type { EdinetDocumentListResponse, EdinetDocItem, EdinetManifest } from "./types";
 
 const DOC_TYPE_LABELS: Record<string, string> = {
   "020": "有価証券届出書",
@@ -53,6 +54,12 @@ function formatDate(dateStr: string): string {
   return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
+function formatAsOfDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return dateStr;
+  const DOW = ["日", "月", "火", "水", "木", "金", "土"];
+  return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}（${DOW[d.getDay()]}）`;
+}
 
 function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
   const edinetUrl = `https://disclosure2.edinet-fsa.go.jp/WZEK0040.aspx?${item.doc_id},,`;
@@ -168,10 +175,26 @@ function DocRow({ item, muted }: { item: EdinetDocItem; muted: boolean }) {
   );
 }
 
-export default function ToolClient({ data }: { data: EdinetDocumentListResponse }) {
+export default function ToolClient({
+  data,
+  manifest,
+}: {
+  data: EdinetDocumentListResponse;
+  manifest: EdinetManifest | null;
+}) {
+  const router = useRouter();
   const [secCodeOnly, setSecCodeOnly] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [docTypeFilter, setDocTypeFilter] = useState("all");
+
+  const dates = manifest?.dates ?? [];
+  const currentIdx = dates.indexOf(data.as_of_date);
+  const prevDate = currentIdx > 0 ? dates[currentIdx - 1] : null;
+  const nextDate = currentIdx < dates.length - 1 ? dates[currentIdx + 1] : null;
+
+  const navigate = (date: string) => {
+    router.push(`/tools/edinet-documents?date=${date}`);
+  };
 
   const docTypeCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -211,6 +234,18 @@ export default function ToolClient({ data }: { data: EdinetDocumentListResponse 
     [filteredItems, secCodeOnly],
   );
 
+  const navButtonStyle = (disabled: boolean) => ({
+    padding: "4px 10px",
+    borderRadius: 6,
+    border: "1.5px solid var(--color-border)",
+    background: "transparent",
+    color: disabled ? "var(--color-text-muted)" : "var(--color-text)",
+    fontSize: 16,
+    cursor: disabled ? "default" : "pointer",
+    opacity: disabled ? 0.35 : 1,
+    lineHeight: 1,
+  });
+
   return (
     <main style={{ maxWidth: 960, margin: "0 auto", padding: "0 16px 64px" }}>
       {/* ヘッダー */}
@@ -236,16 +271,35 @@ export default function ToolClient({ data }: { data: EdinetDocumentListResponse 
           marginBottom: 14,
           display: "flex",
           alignItems: "center",
-          gap: 16,
+          gap: 12,
           flexWrap: "wrap",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>対象日</span>
-          <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)" }}>
-            {data.as_of_date}
+        {/* 日付ナビゲーション */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => prevDate && navigate(prevDate)}
+            disabled={!prevDate}
+            style={navButtonStyle(!prevDate)}
+            aria-label="前の日"
+          >
+            ←
+          </button>
+          <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)", minWidth: 160, textAlign: "center" }}>
+            {formatAsOfDate(data.as_of_date)}
           </span>
+          <button
+            type="button"
+            onClick={() => nextDate && navigate(nextDate)}
+            disabled={!nextDate}
+            style={navButtonStyle(!nextDate)}
+            aria-label="次の日"
+          >
+            →
+          </button>
         </div>
+
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
           <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 600 }}>総件数</span>
           <span style={{ fontSize: 14, fontWeight: 800, color: "var(--color-text)" }}>

--- a/app/tools/edinet-documents/data-loader.ts
+++ b/app/tools/edinet-documents/data-loader.ts
@@ -1,12 +1,36 @@
 import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
-import type { EdinetDocumentListResponse } from "./types";
+import type { EdinetDocumentListResponse, EdinetManifest } from "./types";
 
-export async function loadEdinetDocumentList(): Promise<EdinetDocumentListResponse | null> {
-  const apiBase = getApiBaseUrl();
-  if (!apiBase) return null;
+const R2_BASE = (process.env.EDINET_R2_BASE_URL ?? "").replace(/\/$/, "");
+const R2_PREFIX = `${R2_BASE}/edinet/document-list`;
 
+export async function loadEdinetManifest(): Promise<EdinetManifest | null> {
+  if (!R2_BASE) return null;
   try {
-    return await fetchJson<EdinetDocumentListResponse>(`${apiBase}/edinet/document-list/latest`);
+    return await fetchJson<EdinetManifest>(`${R2_PREFIX}/manifest.json`, 300);
+  } catch {
+    return null;
+  }
+}
+
+export async function loadEdinetDocumentList(
+  date?: string,
+): Promise<EdinetDocumentListResponse | null> {
+  const apiBase = getApiBaseUrl();
+  if (apiBase && !date) {
+    try {
+      return await fetchJson<EdinetDocumentListResponse>(
+        `${apiBase}/edinet/document-list/latest`,
+      );
+    } catch {
+      // fall through to R2
+    }
+  }
+
+  if (!R2_BASE) return null;
+  const path = date ? `${R2_PREFIX}/${date}.json` : `${R2_PREFIX}/latest.json`;
+  try {
+    return await fetchJson<EdinetDocumentListResponse>(path, 300);
   } catch {
     return null;
   }

--- a/app/tools/edinet-documents/data-loader.ts
+++ b/app/tools/edinet-documents/data-loader.ts
@@ -1,13 +1,11 @@
 import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { EdinetDocumentListResponse, EdinetManifest } from "./types";
 
-const R2_BASE = (process.env.EDINET_R2_BASE_URL ?? "").replace(/\/$/, "");
-const R2_PREFIX = `${R2_BASE}/edinet/document-list`;
-
 export async function loadEdinetManifest(): Promise<EdinetManifest | null> {
-  if (!R2_BASE) return null;
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
   try {
-    return await fetchJson<EdinetManifest>(`${R2_PREFIX}/manifest.json`, 300);
+    return await fetchJson<EdinetManifest>(`${apiBase}/edinet/document-list/manifest`);
   } catch {
     return null;
   }
@@ -17,20 +15,12 @@ export async function loadEdinetDocumentList(
   date?: string,
 ): Promise<EdinetDocumentListResponse | null> {
   const apiBase = getApiBaseUrl();
-  if (apiBase && !date) {
-    try {
-      return await fetchJson<EdinetDocumentListResponse>(
-        `${apiBase}/edinet/document-list/latest`,
-      );
-    } catch {
-      // fall through to R2
-    }
-  }
-
-  if (!R2_BASE) return null;
-  const path = date ? `${R2_PREFIX}/${date}.json` : `${R2_PREFIX}/latest.json`;
+  if (!apiBase) return null;
+  const path = date
+    ? `${apiBase}/edinet/document-list/${date}`
+    : `${apiBase}/edinet/document-list/latest`;
   try {
-    return await fetchJson<EdinetDocumentListResponse>(path, 300);
+    return await fetchJson<EdinetDocumentListResponse>(path);
   } catch {
     return null;
   }

--- a/app/tools/edinet-documents/page.tsx
+++ b/app/tools/edinet-documents/page.tsx
@@ -23,30 +23,5 @@ export default async function Page({
     loadEdinetDocumentList(date),
   ]);
 
-  if (!data) {
-    return (
-      <main style={{ maxWidth: 960, margin: "0 auto", padding: "0 16px 64px" }}>
-        <section style={{ padding: "32px 0 24px" }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
-            <span style={{ fontSize: 26 }}>📄</span>
-            <h1 style={{ margin: 0, fontSize: 24, fontWeight: 900, letterSpacing: -0.5 }}>
-              EDINET書類一覧
-            </h1>
-          </div>
-        </section>
-        <div
-          style={{
-            padding: "32px 20px",
-            textAlign: "center",
-            color: "var(--color-text-muted)",
-            fontSize: 14,
-          }}
-        >
-          データを取得できませんでした。時間をおいて再度お試しください。
-        </div>
-      </main>
-    );
-  }
-
-  return <ToolClient data={data} manifest={manifest} />;
+  return <ToolClient data={data} manifest={manifest} currentDate={date} />;
 }

--- a/app/tools/edinet-documents/page.tsx
+++ b/app/tools/edinet-documents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import ToolClient from "./ToolClient";
-import { loadEdinetDocumentList } from "./data-loader";
+import { loadEdinetDocumentList, loadEdinetManifest } from "./data-loader";
 
 export const metadata: Metadata = {
   title: "EDINET書類一覧 | mini-tools",
@@ -11,8 +11,17 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function Page() {
-  const data = await loadEdinetDocumentList();
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const { date } = await searchParams;
+
+  const [manifest, data] = await Promise.all([
+    loadEdinetManifest(),
+    loadEdinetDocumentList(date),
+  ]);
 
   if (!data) {
     return (
@@ -39,5 +48,5 @@ export default async function Page() {
     );
   }
 
-  return <ToolClient data={data} />;
+  return <ToolClient data={data} manifest={manifest} />;
 }

--- a/app/tools/edinet-documents/types.ts
+++ b/app/tools/edinet-documents/types.ts
@@ -1,3 +1,7 @@
+export type EdinetManifest = {
+  dates: string[];
+};
+
 export type EdinetDocItem = {
   doc_id: string;
   submit_datetime: string;


### PR DESCRIPTION
## 概要

EDINETデータのR2公開に合わせて、`edinet-documents` ツールをR2対応・日付ナビゲーション対応に更新。

## 変更内容

- **`types.ts`**: `EdinetManifest` 型を追加（`{ dates: string[] }`）
- **`data-loader.ts`**: `loadEdinetManifest()` / `loadEdinetDocumentList(date?)` を追加
  - API（`MARKET_INFO_API_BASE_URL`）優先、未設定時はR2へフォールバック
  - 日付指定ありの場合は R2 の `YYYY-MM-DD.json` を直接フェッチ
- **`page.tsx`**: `searchParams.date` を受け取り、manifest と初期データを並列ロード
- **`ToolClient.tsx`**: ← 日付（曜日）→ のナビゲーションUIを追加
- **`.env.local.example`**: `EDINET_R2_BASE_URL` を追記

## 確認項目

- [x] `npm run lint` パス
- [ ] `EDINET_R2_BASE_URL` を設定して動作確認
- [ ] 日付ナビゲーション（← →）の動作確認
- [ ] manifest なし時（null）でも表示崩れしないことを確認

## 環境変数設定

```
EDINET_R2_BASE_URL=https://pub-b1f1de37018549c8a5ae3e6f9a7a1c6c.r2.dev
```