### PR TITLE
fix(yutai-candidates): refine nikko credit badges

### DIFF
--- a/app/tools/yutai-candidates/ToolClient.tsx
+++ b/app/tools/yutai-candidates/ToolClient.tsx
@@ -10,7 +10,7 @@ const PICKED_KEY = "monthly_yutai_picks_v1";
 
 type StatusFilter = "all" | "picked" | "added" | "unselected";
 type LinkFilter = "all" | "with" | "without";
-type CrossFilter = "all" | "general" | "institutional" | "any";
+type CrossFilter = "all" | "general" | "general_watch" | "institutional" | "any";
 type SbiFilter = "all" | "sbi_any";
 type SortKey = "company" | "code" | "investment" | "available_shares";
 
@@ -60,6 +60,30 @@ function savePickedCodes(codes: Set<string>) {
   window.localStorage.setItem(PICKED_KEY, JSON.stringify([...codes]));
 }
 
+type NikkoCreditRecord = NonNullable<MonthlyYutaiPageData["nikkoCredit"]>["by_code"][string];
+
+function hasNikkoSellStop(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit?.regulation_details?.some((detail) => (
+    detail.includes("新規売建規制") && detail.includes("取引停止")
+  )));
+}
+
+function hasNikkoLendingCaution(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit?.regulation_details?.some((detail) => detail.includes("貸株注意喚起")));
+}
+
+function canNikkoGeneralCrossNow(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit?.general_short && (credit.available_shares ?? 0) > 0);
+}
+
+function shouldWatchNikkoGeneral(credit: NikkoCreditRecord | undefined) {
+  if (!credit) return false;
+  return hasNikkoSellStop(credit) || canNikkoGeneralCrossNow(credit) || (
+    !credit.general_short &&
+    (credit.available_shares ?? 0) > 0 &&
+    !hasNikkoSellStop(credit)
+  );
+}
 
 function renderCreditBadges(
   nikkoCredit: import("./types").NikkoCreditData | null,
@@ -68,16 +92,17 @@ function renderCreditBadges(
 ): React.ReactNode {
   if (!nikkoCredit) return null;
   const credit = nikkoCredit.by_code[code];
-  if (!credit) return <span style={styles.creditChipNone}>日興対象外</span>;
+  if (!credit) return null;
   const badges: React.ReactNode[] = [];
-  if (credit.general_short) {
+  if (hasNikkoSellStop(credit)) {
+    badges.push(<span key="gen-regulated" style={styles.creditChipGeneralRegulation}>一般規制</span>);
+  } else if (canNikkoGeneralCrossNow(credit) && hasNikkoLendingCaution(credit)) {
+    badges.push(<span key="gen-caution" style={styles.creditChipGeneralCaution}>一般注意</span>);
+  } else if (canNikkoGeneralCrossNow(credit)) {
     badges.push(<span key="gen" style={styles.creditChipGeneral}>一般売可</span>);
   }
   if (credit.institutional_short) {
     badges.push(<span key="inst" style={styles.creditChipInstitutional}>制度売可</span>);
-  }
-  if (badges.length === 0) {
-    badges.push(<span key="none" style={styles.creditChipNoCross}>クロス不可</span>);
   }
   return badges;
 }
@@ -179,9 +204,10 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
 
         if (crossFilter !== "all" && byCode) {
           const credit = byCode[item.code];
-          if (crossFilter === "general" && !credit?.general_short) return false;
+          if (crossFilter === "general" && !canNikkoGeneralCrossNow(credit)) return false;
+          if (crossFilter === "general_watch" && !shouldWatchNikkoGeneral(credit)) return false;
           if (crossFilter === "institutional" && !credit?.institutional_short) return false;
-          if (crossFilter === "any" && !credit?.general_short && !credit?.institutional_short) return false;
+          if (crossFilter === "any" && !canNikkoGeneralCrossNow(credit) && !credit?.institutional_short) return false;
         }
 
         if (sbiFilter === "sbi_any" && data.sbiCredit) {
@@ -361,10 +387,11 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
               </select>
               {data.nikkoCredit && (
                 <select value={crossFilter} onChange={(e) => setCrossFilter(e.target.value as CrossFilter)} style={styles.select}>
-                  <option value="all">クロス: すべて</option>
-                  <option value="any">クロス: 一般または制度</option>
-                  <option value="general">クロス: 一般信用のみ</option>
-                  <option value="institutional">クロス: 制度信用のみ</option>
+                  <option value="all">日興: すべて</option>
+                  <option value="general">日興: 一般売可</option>
+                  <option value="general_watch">日興: 一般監視</option>
+                  <option value="institutional">日興: 制度売可</option>
+                  <option value="any">日興: 売可あり</option>
                 </select>
               )}
               {data.sbiCredit && (
@@ -908,6 +935,20 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#15803d",
     fontWeight: 800,
     border: "1px solid rgba(34,197,94,0.25)",
+  },
+  creditChipGeneralCaution: {
+    ...baseCreditChip,
+    background: "#fef3c7",
+    color: "#92400e",
+    fontWeight: 800,
+    border: "1px solid rgba(245,158,11,0.25)",
+  },
+  creditChipGeneralRegulation: {
+    ...baseCreditChip,
+    background: "#fee2e2",
+    color: "#b91c1c",
+    fontWeight: 800,
+    border: "1px solid rgba(239,68,68,0.25)",
   },
   creditChipInstitutional: {
     ...baseCreditChip,

--- a/app/tools/yutai-candidates/ToolClient.tsx
+++ b/app/tools/yutai-candidates/ToolClient.tsx
@@ -73,7 +73,7 @@ function hasNikkoLendingCaution(credit: NikkoCreditRecord | undefined) {
 }
 
 function canNikkoGeneralCrossNow(credit: NikkoCreditRecord | undefined) {
-  return Boolean(credit?.general_short && (credit.available_shares ?? 0) > 0);
+  return Boolean(credit?.general_short && (credit.available_shares ?? 0) > 0 && !hasNikkoSellStop(credit));
 }
 
 function shouldWatchNikkoGeneral(credit: NikkoCreditRecord | undefined) {

--- a/app/tools/yutai-candidates/data/nikko_credit_sample.json
+++ b/app/tools/yutai-candidates/data/nikko_credit_sample.json
@@ -1,49 +1,105 @@
 {
   "date": "2026-04-04",
   "generated_at": "2026-04-04T12:00:00+09:00",
-  "record_count": 6,
+  "record_count": 8,
   "by_code": {
     "2702": {
       "institutional_buy": true,
       "institutional_short": true,
       "general_buy": true,
       "general_short": true,
-      "available_shares": 900
+      "available_shares": 900,
+      "has_exchange_regulation": false,
+      "has_internal_regulation": false,
+      "regulation_sources": [],
+      "regulation_details": []
     },
     "1305": {
       "institutional_buy": true,
       "institutional_short": true,
       "general_buy": true,
       "general_short": false,
-      "available_shares": null
+      "available_shares": null,
+      "has_exchange_regulation": false,
+      "has_internal_regulation": true,
+      "regulation_sources": ["internal"],
+      "regulation_details": [
+        "internal|新規売建規制 取引停止|2026/04/04"
+      ]
     },
     "9831": {
       "institutional_buy": true,
       "institutional_short": false,
       "general_buy": true,
       "general_short": true,
-      "available_shares": 300
+      "available_shares": 300,
+      "has_exchange_regulation": true,
+      "has_internal_regulation": false,
+      "regulation_sources": ["exchange"],
+      "regulation_details": [
+        "exchange|日証金（東証）|新規売建規制 取引停止|2026/04/04"
+      ]
     },
     "3088": {
       "institutional_buy": true,
       "institutional_short": false,
       "general_buy": false,
       "general_short": false,
-      "available_shares": null
+      "available_shares": null,
+      "has_exchange_regulation": false,
+      "has_internal_regulation": false,
+      "regulation_sources": [],
+      "regulation_details": []
     },
     "7816": {
       "institutional_buy": true,
       "institutional_short": true,
       "general_buy": true,
       "general_short": true,
-      "available_shares": 0
+      "available_shares": 0,
+      "has_exchange_regulation": false,
+      "has_internal_regulation": false,
+      "regulation_sources": [],
+      "regulation_details": []
     },
     "2413": {
       "institutional_buy": false,
       "institutional_short": false,
       "general_buy": false,
       "general_short": false,
-      "available_shares": null
+      "available_shares": null,
+      "has_exchange_regulation": false,
+      "has_internal_regulation": true,
+      "regulation_sources": ["internal"],
+      "regulation_details": [
+        "internal|新規買建停止|2026/04/04"
+      ]
+    },
+    "3549": {
+      "institutional_buy": true,
+      "institutional_short": false,
+      "general_buy": true,
+      "general_short": false,
+      "available_shares": 1200,
+      "has_exchange_regulation": false,
+      "has_internal_regulation": true,
+      "regulation_sources": ["internal"],
+      "regulation_details": [
+        "internal|新規売建規制 取引停止|2026/04/04"
+      ]
+    },
+    "9999": {
+      "institutional_buy": true,
+      "institutional_short": true,
+      "general_buy": true,
+      "general_short": true,
+      "available_shares": 100,
+      "has_exchange_regulation": true,
+      "has_internal_regulation": false,
+      "regulation_sources": ["exchange"],
+      "regulation_details": [
+        "exchange|日証金（東証）|貸株注意喚起|2026/04/04"
+      ]
     }
   }
 }

--- a/app/tools/yutai-candidates/types.ts
+++ b/app/tools/yutai-candidates/types.ts
@@ -44,6 +44,10 @@ export type NikkoCreditRecord = {
   general_buy: boolean;
   general_short: boolean;
   available_shares: number | null;
+  has_exchange_regulation: boolean;
+  has_internal_regulation: boolean;
+  regulation_sources: Array<"exchange" | "internal">;
+  regulation_details: string[];
 };
 
 export type NikkoCreditData = {

--- a/docs/decision-log/2026-05-14-nikko-credit-json-contract.md
+++ b/docs/decision-log/2026-05-14-nikko-credit-json-contract.md
@@ -1,0 +1,45 @@
+# 2026-05-14 日興信用 JSON contract
+
+## 背景
+
+- `yutai-candidates` は `MARKET_INFO_API_BASE_URL/nikko/credit` から日興信用情報を取得している。
+- これまでは信用買い・売り可否と一般売建可能数量のみを UI 側の型とサンプルに持っていた。
+- upstream で公的規制・社内規制も含む JSON format を扱うため、mini-tools 側の参照仕様を固定する必要が出た。
+
+## 今回決めたこと
+
+- `GET /nikko/credit` はトップレベルに `date`、`generated_at`、`record_count`、`by_code` を持つ。
+- `by_code` の各銘柄レコードは信用可否、一般売建可能数量に加えて、次の規制情報を持つ。
+  - `has_exchange_regulation`
+  - `has_internal_regulation`
+  - `regulation_sources`
+  - `regulation_details`
+- `regulation_sources` の値は `exchange` / `internal` に限定する。
+- `regulation_details` は `source|market|restriction|effective_date` を基本形にする。
+- 日興の現行社内規制ページのように市場列がない場合は、`source|restriction|effective_date` として `market` を省略する。
+- `yutai-candidates` の表示は `一般売可` / `一般注意` / `一般規制` / `制度売可` の 4 種類を基本にする。
+- `一般在庫?` は UI に出さず、内部的な監視継続対象として扱う。
+- `3549` は `新規売建規制 取引停止` により `一般規制` として表示する。
+
+## 判断理由
+
+- 公的規制と社内規制を boolean と sources で持つと、UI では有無を低コストに判定できる。
+- `regulation_details` を配列で保持すると、同一銘柄に複数規制があるケースをそのまま表現できる。
+- 社内規制ページに市場列がない現状に合わせ、欠けた市場名を空文字で埋めず、形式自体を短くする方が元データとの差分が少ない。
+- 優待カレンダーでは一般信用クロス可否の判断が主目的なので、制度信用は一般クロス判定と混ぜず別 badge として表示する。
+- `general_short=false` かつ `available_shares>0` のような曖昧な状態は、画面に推測ラベルを出すより、監視継続対象として内部分類する方が誤解が少ない。
+
+## 影響範囲
+
+- `yutai-candidates` の日興信用データ型
+- `yutai-candidates` の開発用サンプル JSON
+- market tools のデータ取得・外部 API contract docs
+
+## 残課題
+
+- 規制情報のうち `新規売建規制 取引停止` と `貸株注意喚起` 以外を UI でどう扱うかは今回決めない。
+- `regulation_details` を将来 structured object にするかどうかは、表示要件が固まってから判断する。
+
+## 関連
+
+- 参照 docs: [Market Tools データ取得経路一覧](../specs/cross-cutting/market-tools-data-fetch-paths.md)

--- a/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
+++ b/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
@@ -89,6 +89,87 @@
 - 特に `stock-ranking` は、repo 同梱 JSON を履歴アーカイブとして増やし続けない
 - `public/data/jpx_listed_companies.json` は現時点では repo 同梱維持でよい
 
+## `GET /nikko/credit` response contract
+
+日興信用情報は `yutai-candidates` の信用バッジ、クロス可否フィルタ、一般売建可能数量ソートで使う。
+規制情報を含める判断理由は [2026-05-14 日興信用 JSON contract](../../decision-log/2026-05-14-nikko-credit-json-contract.md) を参照。
+
+トップレベル:
+
+| field | 型 | 内容 |
+|---|---|---|
+| `date` | string | データ日付。`YYYY-MM-DD` |
+| `generated_at` | string | JSON 生成時刻。ISO 文字列 |
+| `record_count` | number | `by_code` の銘柄数 |
+| `by_code` | object | 銘柄コードを key にした辞書 |
+
+各銘柄レコード:
+
+| field | 型 | 内容 |
+|---|---|---|
+| `institutional_buy` | boolean | 制度信用買い可否 |
+| `institutional_short` | boolean | 制度信用売り可否 |
+| `general_buy` | boolean | 一般信用買い可否 |
+| `general_short` | boolean | 一般信用売り可否 |
+| `available_shares` | number \| null | 一般信用売り可能数量。未取得・空欄は `null` |
+| `has_exchange_regulation` | boolean | 公的規制あり |
+| `has_internal_regulation` | boolean | 社内規制あり |
+| `regulation_sources` | array | 規制ソース配列。値は `exchange` / `internal` |
+| `regulation_details` | string[] | 規制明細配列 |
+
+`regulation_details` は次の文字列形式にする。
+
+```text
+source|market|restriction|effective_date
+```
+
+日興の現行社内規制ページのように市場列がない場合は、`market` を省略して次の形式にする。
+
+```text
+source|restriction|effective_date
+```
+
+例:
+
+```json
+[
+  "exchange|日証金（東証）|新規売建規制 取引停止|2022/07/06",
+  "internal|新規売建規制 取引停止|2011/12/05"
+]
+```
+
+### `yutai-candidates` の日興信用 badge 判定
+
+UI は「今、一般信用売りでクロス可能か」と「監視継続すべきか」を分けて扱う。
+一般信用の表示は `一般売可` / `一般注意` / `一般規制` の 3 種類に限定し、`一般在庫?` は表示しない。
+制度信用は一般クロス可否とは別表示として `制度売可` を出す。
+
+| ケース | Before 表示 | After 表示 | クロス対象 | 監視継続 |
+|---|---|---|---|---|
+| `general_short=true` かつ `available_shares>0` | 一般売可 | 一般売可 | Yes | Yes |
+| 上記 + 貸株注意喚起 | 一般売可 | 一般注意 | Yes | Yes |
+| 新規売建規制 + 取引停止 | 表示なし | 一般規制 | No | Yes |
+| `general_short=false` かつ `available_shares>0`、売建規制なし | 表示なし | 表示なし | No | Yes |
+| `general_short=false` かつ `available_shares=0/null`、売建規制なし | 表示なし | 表示なし | No | 低頻度 |
+| `institutional_short=true` | 制度売可 | 制度売可 | 一般クロス判定には使わない | 任意 |
+| `institutional_short=true` かつ一般は不可 | 制度売可 | 制度売可 のみ | No | 任意 |
+| 一般・制度どちらも不可 | 表示なし | 表示なし | No | 低頻度 |
+
+判定順:
+
+```ts
+if (hasSellStop) show "一般規制";
+else if (canCrossNow && hasLendingCaution) show "一般注意";
+else if (canCrossNow) show "一般売可";
+
+if (institutional_short) show "制度売可";
+```
+
+- `hasSellStop`: `regulation_details` に `新規売建規制` と `取引停止` を含む明細がある
+- `hasLendingCaution`: `regulation_details` に `貸株注意喚起` を含む明細がある
+- `canCrossNow`: `general_short=true` かつ `available_shares>0`
+- `3549` は After 表示で `一般規制` として扱う
+
 ## 関連ファイル
 
 - [app/tools/topix33/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data-loader.ts)
@@ -100,5 +181,6 @@
 - [app/tools/us-stock-ranking/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/us-stock-ranking/data-loader.ts)
 - [app/tools/market-rankings/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/market-rankings/data-loader.ts)
 - [app/tools/yutai-candidates/data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/yutai-candidates/data-loader.ts)
+- [app/tools/yutai-candidates/types.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/yutai-candidates/types.ts)
 - [app/tools/earnings-calendar/page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/earnings-calendar/page.tsx)
 - [.env.local.example](/c:/Users/yutaz/dev/mini-tools/.env.local.example)

--- a/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
+++ b/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
@@ -167,7 +167,7 @@ if (institutional_short) show "制度売可";
 
 - `hasSellStop`: `regulation_details` に `新規売建規制` と `取引停止` を含む明細がある
 - `hasLendingCaution`: `regulation_details` に `貸株注意喚起` を含む明細がある
-- `canCrossNow`: `general_short=true` かつ `available_shares>0`
+- `canCrossNow`: `general_short=true` かつ `available_shares>0` かつ売建停止なし
 - `3549` は After 表示で `一般規制` として扱う
 
 ## 関連ファイル


### PR DESCRIPTION
## 概要

優待カレンダーの日興信用 badge を、一般信用クロス可否と制度信用可否を分けて判断する表示に見直しました。

## 変更内容

- 日興一般信用の表示を `一般売可` / `一般注意` / `一般規制` に整理
- `general_short=true` でも `available_shares` が `0/null` の場合は `一般売可` にしない判定へ変更
- `制度売可` は一般クロス判定とは別 badge として表示
- 日興フィルタを `日興: 一般売可` / `日興: 一般監視` / `日興: 制度売可` / `日興: 売可あり` に更新
- 日興信用 JSON contract と badge 判定ルールを docs / decision-log に記録
- 開発用 sample に `3549` の `一般規制` ケースと `貸株注意喚起` ケースを追加

## 確認項目

- `npm run lint` passed
- `npm run test -- app/tools/yutai-candidates/__tests__/data-loader.test.ts` passed
- `npm run build` passed
- `codex review --uncommitted` で actionable issue なし
- `npm test` は既存の `tests/ui-smoke/ui-smoke.spec.ts` が Vitest に拾われる設定問題で失敗

## 関連 Issue

- なし
