### PR TITLE
fix(market): disable production JSON fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ npm run dev
   - `as_of_date`, `from`, `to`, `days[]`
   - `days[]` は `date`, `market_closed`, `label`
   - `earnings-calendar/overseas` は `manifest + monthly` を主導線として使い、`latest` は補助表示に使う
-  - 未設定時は各 tool の同梱 JSON / sample fallback を使う
+  - production では未設定時や取得失敗時に同梱 JSON / sample fallback を自動表示しない
+  - 非 production では開発確認用に同梱 JSON / sample fallback を使う
+  - production で明示的に fallback を使う場合のみ `MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK=1` を設定する
   - 参照:
     - `app/tools/topix33/data-loader.ts`
     - `app/tools/nikkei-contribution/data-loader.ts`

--- a/app/tools/earnings-calendar/__tests__/data-loader.test.ts
+++ b/app/tools/earnings-calendar/__tests__/data-loader.test.ts
@@ -128,7 +128,9 @@ function makeFetch404(): Response {
 describe("loadEarningsCalendarPageData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -183,6 +185,24 @@ describe("loadEarningsCalendarPageData", () => {
     expect(result.domestic.monthData["2025-04"]).toEqual(SAMPLE_DOMESTIC_MONTH_DATA);
   });
 
+  it("production で domestic API 失敗時はローカル JSON にフォールバックしない", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    makeLocalFiles();
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes("/earnings-calendar/domestic/")) return makeFetch404();
+      if (u.includes("/earnings-calendar/overseas/")) return makeFetch404();
+      return makeFetch404();
+    });
+
+    const result = await loadEarningsCalendarPageData();
+
+    expect(result.domestic.manifest).toBeNull();
+    expect(result.domestic.monthData).toEqual({});
+    expect(result.domestic.latest).toBeNull();
+  });
+
   it("domestic manifest 成功・monthly 失敗のとき同梱 JSON の同一月で補完する", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     makeLocalFiles();
@@ -199,6 +219,26 @@ describe("loadEarningsCalendarPageData", () => {
 
     expect(result.domestic.manifest).toEqual(SAMPLE_DOMESTIC_MANIFEST);
     expect(result.domestic.monthData["2025-04"]).toEqual(SAMPLE_DOMESTIC_MONTH_DATA);
+  });
+
+  it("production で domestic monthly 失敗時は同梱 JSON で補完しない", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    makeLocalFiles();
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes("/earnings-calendar/domestic/manifest")) return makeFetchOk(SAMPLE_DOMESTIC_MANIFEST);
+      if (u.includes("/earnings-calendar/domestic/latest")) return makeFetchOk(SAMPLE_DOMESTIC_LATEST);
+      if (u.includes("/earnings-calendar/domestic/monthly/")) return makeFetch404();
+      if (u.includes("/earnings-calendar/overseas/")) return makeFetch404();
+      return makeFetch404();
+    });
+
+    const result = await loadEarningsCalendarPageData();
+
+    expect(result.domestic.manifest).toEqual(SAMPLE_DOMESTIC_MANIFEST);
+    expect(result.domestic.monthData).toEqual({});
+    expect(result.domestic.latest).toEqual(SAMPLE_DOMESTIC_LATEST);
   });
 
   it("API 未設定のとき overseas は空構造を返す（fetch しない）", async () => {

--- a/app/tools/earnings-calendar/data-loader.ts
+++ b/app/tools/earnings-calendar/data-loader.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadUsMarketClosedData } from "@/lib/us-market-closed";
-import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { JpxMarketClosedResponse } from "@/app/tools/_shared/market-calendar-types";
 import type {
   EarningsCalendarManifest,
@@ -86,15 +86,18 @@ async function loadApiDomesticLatest(): Promise<EarningsCalendarResponse | null>
 }
 
 async function loadDomesticData(): Promise<EarningsCalendarMarketData> {
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
   const apiManifest = await loadApiDomesticManifest();
 
   if (apiManifest) {
-    // 月別データが API から取れない場合は同梱 JSON で補完するため、先にローカル manifest を読む
+    // 非 production では月別データが API から取れない場合に同梱 JSON で補完する
     let localManifest: EarningsCalendarManifest | null = null;
-    try {
-      localManifest = await loadLocalDomesticManifest();
-    } catch {
-      // 同梱 JSON がなくても続行
+    if (canUseLocalFallback) {
+      try {
+        localManifest = await loadLocalDomesticManifest();
+      } catch {
+        // 同梱 JSON がなくても続行
+      }
     }
 
     const [monthEntries, latest, holidays] = await Promise.all([
@@ -118,7 +121,7 @@ async function loadDomesticData(): Promise<EarningsCalendarMarketData> {
         }),
       ),
       loadApiDomesticLatest(),
-      loadLocalDomesticHolidays(),
+      canUseLocalFallback ? loadLocalDomesticHolidays() : Promise.resolve(null),
     ]);
 
     return {
@@ -129,7 +132,16 @@ async function loadDomesticData(): Promise<EarningsCalendarMarketData> {
     };
   }
 
-  // API 未設定 or 失敗時は同梱 JSON にフォールバック
+  if (!canUseLocalFallback) {
+    return {
+      manifest: null,
+      monthData: {},
+      latest: null,
+      holidays: null,
+    };
+  }
+
+  // 非 production では API 未設定 or 失敗時に同梱 JSON にフォールバック
   const manifest = await loadLocalDomesticManifest();
   const monthEntries = await Promise.all(
     manifest.months.map(async (entry) => {

--- a/app/tools/nikkei-contribution/__tests__/data-loader.test.ts
+++ b/app/tools/nikkei-contribution/__tests__/data-loader.test.ts
@@ -38,7 +38,9 @@ function makeFetch404(): Response {
 describe("loadContributionManifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -88,6 +90,19 @@ describe("loadContributionManifest", () => {
     expect(result).toEqual(SAMPLE_MANIFEST);
   });
 
+  it("production で API 失敗時はローカル fallback せず EMPTY_MANIFEST を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_MANIFEST));
+
+    const result = await loadContributionManifest();
+
+    expect(result).toEqual({ dates: [], latest_date: null });
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
   it("ローカルファイルも存在しないとき EMPTY_MANIFEST を返す（例外を throw しない）", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
@@ -102,7 +117,9 @@ describe("loadContributionManifest", () => {
 describe("loadContributionDayData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -157,6 +174,19 @@ describe("loadContributionDayData", () => {
     const result = await loadContributionDayData("2025-04-02");
 
     expect(result).toEqual(SAMPLE_DAY_DATA);
+  });
+
+  it("production で API 失敗時はローカル fallback せず null を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_DAY_DATA));
+
+    const result = await loadContributionDayData("2025-04-02");
+
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it("ローカルファイルも存在しないとき null を返す", async () => {

--- a/app/tools/nikkei-contribution/data-loader.ts
+++ b/app/tools/nikkei-contribution/data-loader.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { NikkeiContributionDayData, NikkeiContributionManifest } from "./types";
 
 const EMPTY_MANIFEST: NikkeiContributionManifest = {
@@ -32,15 +32,16 @@ async function loadLocalDayData(dateStr: string): Promise<NikkeiContributionDayD
 
 export async function loadContributionManifest(): Promise<NikkeiContributionManifest> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalManifest();
+    return canUseLocalFallback ? loadLocalManifest() : EMPTY_MANIFEST;
   }
 
   try {
     return await fetchJson<NikkeiContributionManifest>(`${apiBase}/nikkei/manifest`);
   } catch {
-    return loadLocalManifest();
+    return canUseLocalFallback ? loadLocalManifest() : EMPTY_MANIFEST;
   }
 }
 
@@ -50,14 +51,15 @@ export async function loadContributionDayData(dateStr: string): Promise<NikkeiCo
   }
 
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalDayData(dateStr);
+    return canUseLocalFallback ? loadLocalDayData(dateStr) : null;
   }
 
   try {
     return await fetchJson<NikkeiContributionDayData>(`${apiBase}/nikkei/${dateStr}`);
   } catch {
-    return loadLocalDayData(dateStr);
+    return canUseLocalFallback ? loadLocalDayData(dateStr) : null;
   }
 }

--- a/app/tools/stock-ranking/__tests__/data-loader.test.ts
+++ b/app/tools/stock-ranking/__tests__/data-loader.test.ts
@@ -24,7 +24,9 @@ function makeFetch404(): Response {
 describe("loadRankingManifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -74,6 +76,19 @@ describe("loadRankingManifest", () => {
     expect(result).toEqual(SAMPLE_MANIFEST);
   });
 
+  it("production で API 失敗時はローカル fallback せず null を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_MANIFEST));
+
+    const result = await loadRankingManifest();
+
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
   it("API 設定あり・fetch 失敗かつローカルファイル欠損のとき null を返す", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
@@ -117,7 +132,9 @@ describe("loadRankingManifest", () => {
 describe("loadRankingDayData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -165,6 +182,19 @@ describe("loadRankingDayData", () => {
     const result = await loadRankingDayData("2025-04-02");
 
     expect(result).toEqual(SAMPLE_DAY_DATA);
+  });
+
+  it("production で API 失敗時はローカル fallback せず null を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_DAY_DATA));
+
+    const result = await loadRankingDayData("2025-04-02");
+
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it("ローカルファイルも存在しないとき null を返す", async () => {

--- a/app/tools/stock-ranking/data-loader.ts
+++ b/app/tools/stock-ranking/data-loader.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { RankingDayData, RankingManifest } from "./types";
 
 type NodeErrorLike = Error & { code?: string };
@@ -34,28 +34,30 @@ async function loadLocalRankingDayData(dateStr: string): Promise<RankingDayData 
 
 export async function loadRankingManifest(): Promise<RankingManifest | null> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalRankingManifest();
+    return canUseLocalFallback ? loadLocalRankingManifest() : null;
   }
 
   try {
     return await fetchJson<RankingManifest>(`${apiBase}/ranking/manifest`);
   } catch {
-    return loadLocalRankingManifest();
+    return canUseLocalFallback ? loadLocalRankingManifest() : null;
   }
 }
 
 export async function loadRankingDayData(dateStr: string): Promise<RankingDayData | null> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalRankingDayData(dateStr);
+    return canUseLocalFallback ? loadLocalRankingDayData(dateStr) : null;
   }
 
   try {
     return await fetchJson<RankingDayData>(`${apiBase}/ranking/${dateStr}`);
   } catch {
-    return loadLocalRankingDayData(dateStr);
+    return canUseLocalFallback ? loadLocalRankingDayData(dateStr) : null;
   }
 }

--- a/app/tools/topix33/__tests__/data-loader.test.ts
+++ b/app/tools/topix33/__tests__/data-loader.test.ts
@@ -39,7 +39,9 @@ function makeFetch404(): Response {
 describe("loadTopix33Manifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -89,6 +91,19 @@ describe("loadTopix33Manifest", () => {
     expect(result).toEqual(SAMPLE_MANIFEST);
   });
 
+  it("production で API 失敗時はローカル fallback せず EMPTY_MANIFEST を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_MANIFEST));
+
+    const result = await loadTopix33Manifest();
+
+    expect(result).toEqual({ dates: [], latest_date: null });
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
   it("ローカルファイルも存在しないとき EMPTY_MANIFEST を返す", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
@@ -103,7 +118,9 @@ describe("loadTopix33Manifest", () => {
 describe("loadTopix33DayData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -158,6 +175,19 @@ describe("loadTopix33DayData", () => {
     const result = await loadTopix33DayData("2025-04-02");
 
     expect(result).toEqual(SAMPLE_DAY_DATA);
+  });
+
+  it("production で API 失敗時はローカル fallback せず null を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_DAY_DATA));
+
+    const result = await loadTopix33DayData("2025-04-02");
+
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it("ローカルファイルも存在しないとき null を返す", async () => {

--- a/app/tools/topix33/data-loader.ts
+++ b/app/tools/topix33/data-loader.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { Topix33DayData, Topix33Manifest } from "./types";
 
 const EMPTY_MANIFEST: Topix33Manifest = {
@@ -32,15 +32,16 @@ async function loadLocalDayData(dateStr: string): Promise<Topix33DayData | null>
 
 export async function loadTopix33Manifest(): Promise<Topix33Manifest> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalManifest();
+    return canUseLocalFallback ? loadLocalManifest() : EMPTY_MANIFEST;
   }
 
   try {
     return await fetchJson<Topix33Manifest>(`${apiBase}/topix33/manifest`);
   } catch {
-    return loadLocalManifest();
+    return canUseLocalFallback ? loadLocalManifest() : EMPTY_MANIFEST;
   }
 }
 
@@ -50,14 +51,15 @@ export async function loadTopix33DayData(dateStr: string): Promise<Topix33DayDat
   }
 
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalDayData(dateStr);
+    return canUseLocalFallback ? loadLocalDayData(dateStr) : null;
   }
 
   try {
     return await fetchJson<Topix33DayData>(`${apiBase}/topix33/${dateStr}`);
   } catch {
-    return loadLocalDayData(dateStr);
+    return canUseLocalFallback ? loadLocalDayData(dateStr) : null;
   }
 }

--- a/app/tools/yutai-candidates/__tests__/data-loader.test.ts
+++ b/app/tools/yutai-candidates/__tests__/data-loader.test.ts
@@ -64,7 +64,9 @@ function makeFetch404(): Response {
 describe("loadMonthlyYutaiManifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -114,6 +116,19 @@ describe("loadMonthlyYutaiManifest", () => {
     expect(result).toEqual(SAMPLE_MANIFEST);
   });
 
+  it("production で API 失敗時はローカル fallback せず null を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_MANIFEST));
+
+    const result = await loadMonthlyYutaiManifest();
+
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
   it("ローカルファイルも存在しないとき null を返す（例外を throw しない）", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
@@ -128,7 +143,9 @@ describe("loadMonthlyYutaiManifest", () => {
 describe("loadMonthlyYutaiMonthData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {
@@ -168,6 +185,19 @@ describe("loadMonthlyYutaiMonthData", () => {
     expect(result).toEqual(SAMPLE_MONTH_DATA);
   });
 
+  it("production で API 失敗時はローカル fallback せず null を返す", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+    mockReadFile.mockClear();
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE_MONTH_DATA));
+
+    const result = await loadMonthlyYutaiMonthData("2025-04");
+
+    expect(result).toBeNull();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
   it("ローカルファイルも存在しないとき null を返す", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
@@ -182,12 +212,14 @@ describe("loadMonthlyYutaiMonthData", () => {
 describe("nikko/SBI credit: API あり・fetch 失敗時はサンプルを返さない", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   it("API 未設定のとき nikkoCredit にサンプルデータが入る", async () => {
@@ -243,7 +275,9 @@ describe("nikko/SBI credit: API あり・fetch 失敗時はサンプルを返さ
 describe("loadMonthlyYutaiPageData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
 
   afterEach(() => {

--- a/app/tools/yutai-candidates/data-loader.ts
+++ b/app/tools/yutai-candidates/data-loader.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type {
   MonthlyYutaiManifest,
   MonthlyYutaiMonthData,
@@ -134,29 +134,31 @@ async function loadLocalMonthData(yearMonth: string): Promise<MonthlyYutaiMonthD
 
 export async function loadMonthlyYutaiManifest(): Promise<MonthlyYutaiManifest | null> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalManifest();
+    return canUseLocalFallback ? loadLocalManifest() : null;
   }
 
   try {
     return await fetchJson<MonthlyYutaiManifest>(`${apiBase}/yutai/manifest`);
   } catch {
-    return loadLocalManifest();
+    return canUseLocalFallback ? loadLocalManifest() : null;
   }
 }
 
 export async function loadMonthlyYutaiMonthData(yearMonth: string): Promise<MonthlyYutaiMonthData | null> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalMonthData(yearMonth);
+    return canUseLocalFallback ? loadLocalMonthData(yearMonth) : null;
   }
 
   try {
     return await fetchJson<MonthlyYutaiMonthData>(`${apiBase}/yutai/monthly/${yearMonth}`);
   } catch {
-    return loadLocalMonthData(yearMonth);
+    return canUseLocalFallback ? loadLocalMonthData(yearMonth) : null;
   }
 }
 
@@ -172,7 +174,9 @@ async function loadLocalNikkoCreditSample(): Promise<NikkoCreditData | null> {
 async function loadNikkoCreditData(): Promise<NikkoCreditData | null> {
   const apiBase = getApiBaseUrl();
   // API未設定時のみサンプルにフォールバック（開発用）
-  if (!apiBase) return loadLocalNikkoCreditSample();
+  if (!apiBase) {
+    return canUseLocalMarketDataFallback() ? loadLocalNikkoCreditSample() : null;
+  }
 
   try {
     return await fetchJson<NikkoCreditData>(`${apiBase}/nikko/credit`);
@@ -201,7 +205,9 @@ async function loadLocalSbiCreditSample(): Promise<SbiCreditData | null> {
  */
 async function loadSbiCreditData(selectedMonthId: string): Promise<SbiCreditData | null> {
   const apiBase = getApiBaseUrl();
-  if (!apiBase) return loadLocalSbiCreditSample();
+  if (!apiBase) {
+    return canUseLocalMarketDataFallback() ? loadLocalSbiCreditSample() : null;
+  }
 
   const { year, month } = getJstToday();
   const currentMonthId = `${year}-${String(month).padStart(2, "0")}`;

--- a/docs/decision-log/2026-05-19-market-data-fallback-production-policy.md
+++ b/docs/decision-log/2026-05-19-market-data-fallback-production-policy.md
@@ -1,0 +1,42 @@
+# 2026-05-19 market data fallback の production 運用方針
+
+## 背景
+
+- market-info と mini-tools の責務境界を整理した。
+- market-info は市場データの正本・生成・更新・配信 API を担当する。
+- mini-tools は API から受け取ったデータの表示、操作、短期キャッシュ、エラー表示を担当する。
+- これまで一部 market tools は API 未設定時や fetch 失敗時に repo 同梱 JSON を自動 fallback 表示していた。
+
+## 今回決めたこと
+
+- production では、market API の取得失敗時に repo 同梱 JSON を自動表示しない。
+- repo 同梱 JSON は、非 production の開発確認・テスト・緊急退避用に限定する。
+- production で repo 同梱 JSON fallback を使う必要がある場合は、`MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK=1` を明示的に設定したときだけ許可する。
+- API 未設定または API 取得失敗時は、画面側ではデータなし・API 未接続・取得失敗として扱う。
+- `jpx_listed_companies.json` のような低頻度マスタは、この判断の主対象外とする。
+
+## 判断理由
+
+- mini-tools 側が古い同梱 JSON を正常データのように表示すると、ユーザーが鮮度の低い市場データを現在情報と誤認するリスクがある。
+- ランキング、信用在庫、決算予定、開示情報などは鮮度が価値の中心であり、古い fallback 表示より明示的な取得失敗表示の方が安全。
+- repo 同梱 JSON は開発時の取り回しや API 障害時の手動退避には有用なので、完全削除ではなく production 自動 fallback だけを止める。
+
+## 影響範囲
+
+- `topix33`
+- `nikkei-contribution`
+- `stock-ranking`
+- `yutai-candidates`
+- `earnings-calendar` 国内データ
+- JPX 休場日 loader
+
+## 残課題
+
+- fallback が無効な場合の各 tool のエラー文言や空状態表示を、必要に応じて tool spec / UAT で細かく見直す。
+- repo 同梱 JSON をどこまで削減するかは、別のデータ整理 PR で扱う。
+
+## 関連
+
+- 参照 docs:
+  - [Market Tools データ取得経路一覧](../specs/cross-cutting/market-tools-data-fetch-paths.md)
+  - [mini-tools システム構成概要](../specs/cross-cutting/system-architecture-overview.md)

--- a/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
+++ b/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
@@ -18,6 +18,9 @@
 - `MARKET_INFO_API_BASE_URL` は market tools の標準 API 入口
   - mini-tools は upstream の内部実装や period 付き filename を意識しない
   - `jpx-closed` も `GET {baseUrl}/market-calendar/jpx-closed` に統一する
+- production では、API 未設定 / fetch 失敗時に repo 同梱 JSON を自動表示しない
+  - repo 同梱 JSON fallback は非 production の開発確認・テスト・緊急退避用
+  - production で明示的に有効化する場合のみ `MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK=1` を設定する
 - `res.json()` で受けているため、HTTP レスポンス形式は JSON
   - ただし、その JSON が upstream の保存ファイルそのものか、API が加工して返した JSON かは、この repo だけでは分からない
 
@@ -25,13 +28,13 @@
 
 | Tool | 初回表示 | 画面操作後 | 設定 | Fallback | 備考 |
 | --- | --- | --- | --- | --- | --- |
-| `topix33` | サーバーで `loadTopix33Manifest()` / `loadTopix33DayData()` | クライアントは `/tools/topix33/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/topix33/data` のローカル JSON | 同じデータソースを、SSR と client route の 2 入口で使っている |
-| `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
-| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | あり。未設定時 / fetch 失敗時は `app/tools/stock-ranking/data` とローカル休場日 JSON を使う | fallback は開発・緊急退避用。repo 同梱 JSON は履歴保管の主用途にしない |
+| `topix33` | サーバーで `loadTopix33Manifest()` / `loadTopix33DayData()` | クライアントは `/tools/topix33/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | production ではなし。非 production / 明示 env のみ `app/tools/topix33/data` のローカル JSON | 同じデータソースを、SSR と client route の 2 入口で使っている |
+| `nikkei-contribution` | サーバーで `loadContributionManifest()` / `loadContributionDayData()` | クライアントは `/tools/nikkei-contribution/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | production ではなし。非 production / 明示 env のみ `app/tools/nikkei-contribution/data` のローカル JSON | `topix33` とほぼ同じ構成 |
+| `stock-ranking` | サーバーで `loadRankingManifest()` / `loadRankingDayData()` と共通休場日 loader を呼ぶ | クライアントは `/tools/stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | production ではなし。非 production / 明示 env のみ `app/tools/stock-ranking/data` とローカル休場日 JSON | repo 同梱 JSON は履歴保管の主用途にしない |
 | `us-stock-ranking` | サーバーで `loadUsRankingManifest()` を読み、`manifest.dates` を最大 5 件試して最初に取得できた日次データを初期表示に使う | クライアントは `/tools/us-stock-ranking/data/[date]` を叩き、route 内で同じ loader を呼ぶ | `MARKET_INFO_API_BASE_URL` | なし。未設定時 / fetch 失敗時は「データ取得不可」表示 | API パスは `/us-stock-ranking/*` ではなく `/us-ranking/*` |
 | `market-rankings` | サーバーで `loadMarketRankingManifest()` / `loadMarketRankingMonthData()` を呼び、`type` / `month` を正規化して初期表示を決める | クライアント再 fetch は基本なし。`type` / `month` の変更は query string を更新して server を再評価する | `MARKET_INFO_API_BASE_URL` | なし。未設定時は「API 未接続」表示、対象月 fetch 失敗時は error card 表示 | 月次 API 前提。repo 同梱 JSON は持たない |
-| `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | あり。manifest / month data はローカル JSON fallback。`nikko/credit` は API 未設定時のみ sample fallback | SBI は `is_short=true` の扱い有無だけを表示し、在庫状態では除外しない |
-| `earnings-calendar` | サーバーで `loadEarningsCalendarPageData()` を呼ぶ | クライアント再 fetch なし | `MARKET_INFO_API_BASE_URL` | あり。国内・海外ともに API 失敗時フォールバック（国内のみ同梱 JSON へ）、海外は API 未設定/失敗時は非表示 | 国内・海外ともに `earnings-calendar/{domestic\|overseas}/*` API を優先取得し、国内は API 失敗時のみ repo 同梱 JSON にフォールバック |
+| `yutai-candidates` | サーバーで `loadMonthlyYutaiPageData()` | クライアント再 fetch は基本なし。月切替は route 遷移でサーバー再評価 | `MARKET_INFO_API_BASE_URL` | production ではなし。非 production / 明示 env のみ manifest / month data / sample を使用 | SBI は `is_short=true` の扱い有無だけを表示し、在庫状態では除外しない |
+| `earnings-calendar` | サーバーで `loadEarningsCalendarPageData()` を呼ぶ | クライアント再 fetch なし | `MARKET_INFO_API_BASE_URL` | production ではなし。非 production / 明示 env のみ国内同梱 JSON を使用。海外は API 未設定/失敗時は非表示 | 国内・海外ともに `earnings-calendar/{domestic\|overseas}/*` API を優先取得する |
 
 ## `topix33` の具体的な流れ
 
@@ -40,14 +43,14 @@
 1. [page.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/page.tsx) がサーバー上で実行される
 2. [data-loader.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data-loader.ts) の `loadTopix33Manifest()` / `loadTopix33DayData()` を呼ぶ
 3. `MARKET_INFO_API_BASE_URL` があれば `GET {baseUrl}/topix33/...`
-4. 失敗したら `app/tools/topix33/data/*.json` を読む
+4. 失敗時は production ではデータなしとして扱い、非 production / 明示 env のみ `app/tools/topix33/data/*.json` を読む
 
 ### 日付切り替え
 
 1. [ToolClient.tsx](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/ToolClient.tsx) がブラウザから `GET /tools/topix33/data/{date}` を呼ぶ
 2. [route.ts](/c:/Users/yutaz/dev/mini-tools/app/tools/topix33/data/[date]/route.ts) が受ける
 3. route 内で `loadTopix33DayData(date)` を呼ぶ
-4. その内部では初回表示時と同じく `MARKET_INFO_API_BASE_URL` またはローカル JSON を使う
+4. その内部では初回表示時と同じく `MARKET_INFO_API_BASE_URL` を優先し、production ではローカル JSON へ自動 fallback しない
 
 つまり `topix33` は、
 
@@ -71,14 +74,14 @@
 - `topix33` / `nikkei-contribution` / `stock-ranking` / `us-stock-ranking` の日次 route は `_shared/`（`buildDateDataRoute`）、営業日 helper は `lib/`（`market-trading-dates.ts`）に PR #221 で整理済み
 - ただし月次系（`market-rankings`）・ローカル保存系（`yutai-candidates`）は取得パターンが異なり、`_shared/` の恩恵を受けない
 - `MARKET_INFO_API_BASE_URL` の upstream 実体は repo 単体では見えないが、mini-tools 側の入口は endpoint 単位で固定される
-- fallback ポリシーは「JP market tools は repo 同梱 JSON あり」「`us-stock-ranking` / `market-rankings` は API 専用」と tool ごとの差分が明示的に残っている
+- fallback ポリシーは「production では repo 同梱 JSON を自動表示しない」「非 production / 明示 env では開発・緊急退避用に fallback 可」に寄せている
 - 月次系は query string ベース、日次系は internal route ベースで、操作後の再取得経路が 2 パターンある（設計判断は decision-log 参照）
 
 ## 今後そろえたい観点
 
 - 初回表示と画面操作後で、取得経路をどこまで統一するか
 - **internal route を置く tool / 置かない tool の基準**（現状: 日次データを client 側で切り替える tool は internal route を持つ。月次系は query string + server 再評価で代替）
-- fallback の原則（現状: JP 日次系は同梱 JSON あり、US・月次系は API 専用）
+- fallback の原則（production では古い同梱 JSON を自動表示しない。非 production / 明示 env のみ許可）
 - **cache-control / `revalidate` の原則**（現状: `fetchJson` は 300 秒 revalidate、`buildDateDataRoute` は `Cache-Control: s-maxage=300` を設定済み）
 - 「外部 API の JSON をそのまま返す route」と「加工して返す route」の区別
 
@@ -86,6 +89,8 @@
 
 - market tools の本番主経路は `MARKET_INFO_API_BASE_URL`
 - repo 同梱 JSON fallback は当面残すが、役割は `開発` と `緊急退避`
+- production では API 未設定 / fetch 失敗時に repo 同梱 JSON を自動表示しない
+- production で repo 同梱 JSON fallback を使う場合は `MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK=1` を明示する
 - 特に `stock-ranking` は、repo 同梱 JSON を履歴アーカイブとして増やし続けない
 - `public/data/jpx_listed_companies.json` は現時点では repo 同梱維持でよい
 

--- a/docs/specs/cross-cutting/system-architecture-overview.md
+++ b/docs/specs/cross-cutting/system-architecture-overview.md
@@ -125,9 +125,13 @@ UI は主に `app/` と `components/` にあります。
 
 用途:
 
-- fallback
+- 非 production の fallback
 - 開発時のローカル確認
-- 外部 API がなくても最低限動かすための同梱データ
+- 外部 API がなくても開発確認できるようにするための同梱データ
+
+production では、market API 未設定 / fetch 失敗時に repo 同梱 JSON を自動表示しない。  
+古い市場データを現在情報として誤表示しないため、production の標準挙動は API 未接続・取得失敗として扱う。
+明示的な緊急退避として使う場合のみ `MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK=1` を設定する。
 
 ### 2. Browser localStorage
 

--- a/lib/jpx-market-closed.ts
+++ b/lib/jpx-market-closed.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
 import type { JpxMarketClosedResponse } from "@/lib/market-calendar-types";
 
 const LOCAL_HOLIDAY_DATA_PATH =
@@ -17,14 +17,15 @@ async function loadLocalJpxMarketClosedData(): Promise<JpxMarketClosedResponse |
 
 export async function loadJpxMarketClosedData(): Promise<JpxMarketClosedResponse | null> {
   const apiBase = getApiBaseUrl();
+  const canUseLocalFallback = canUseLocalMarketDataFallback();
 
   if (!apiBase) {
-    return loadLocalJpxMarketClosedData();
+    return canUseLocalFallback ? loadLocalJpxMarketClosedData() : null;
   }
 
   try {
     return await fetchJson<JpxMarketClosedResponse>(`${apiBase}/market-calendar/jpx-closed`);
   } catch {
-    return loadLocalJpxMarketClosedData();
+    return canUseLocalFallback ? loadLocalJpxMarketClosedData() : null;
   }
 }

--- a/lib/market-api.ts
+++ b/lib/market-api.ts
@@ -8,6 +8,17 @@ export function getApiBaseUrl(): string {
 }
 
 /**
+ * repo 同梱 JSON fallback は production では自動使用しない。
+ * production で使う場合は、運用者が明示的に env を立てたときだけ許可する。
+ */
+export function canUseLocalMarketDataFallback(): boolean {
+  return (
+    process.env.NODE_ENV !== "production" ||
+    process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK === "1"
+  );
+}
+
+/**
  * JSON を fetch して型付きで返す。5秒タイムアウト付き。
  * revalidate はデータの更新頻度に合わせて呼び出し側で指定する（デフォルト 300 秒）。
  */


### PR DESCRIPTION
## 概要

market-info と mini-tools の責務境界に合わせ、production では market API 失敗時に古い repo 同梱 JSON を自動表示しないようにします。

## 変更内容

- market data の local JSON fallback 可否を `canUseLocalMarketDataFallback()` に集約
- production では `MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK=1` の明示時だけ repo 同梱 JSON fallback を許可
- `topix33` / `nikkei-contribution` / `stock-ranking` / `yutai-candidates` / 国内 `earnings-calendar` / JPX 休場日 loader を新方針へ更新
- production で fallback しないテストを追加
- 方針を README / 横断仕様 / decision-log に記録

## 確認項目

- `npm test -- --run app/tools/topix33/__tests__/data-loader.test.ts app/tools/nikkei-contribution/__tests__/data-loader.test.ts app/tools/stock-ranking/__tests__/data-loader.test.ts app/tools/yutai-candidates/__tests__/data-loader.test.ts app/tools/earnings-calendar/__tests__/data-loader.test.ts`
- `npm run lint`
- `npm run build`

## 関連 Issue

- なし
