### PR TITLE
fix(yutai-expiry): UI整合と入出力データ消失の修正

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -119,6 +119,7 @@
 }
 
 .topBar {
+  --ctl-h: 44px;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -182,7 +183,7 @@
 }
 
 .controlShell {
-  height: var(--ctl-h);
+  height: var(--ctl-h, 44px);
   box-sizing: border-box;
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 999px;
@@ -221,6 +222,27 @@
   border-color: rgba(37, 84, 255, 0.28);
 }
 
+.searchClear {
+  flex: 0 0 auto;
+  margin-right: 8px;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 0;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--color-text-sub);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.searchClear:hover {
+  background: rgba(15, 23, 42, 0.12);
+}
+
 .compactRow {
   display: flex;
   flex-wrap: wrap;
@@ -245,15 +267,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 0 16px;
+  gap: 12px;
+  padding: 0 18px;
   color: var(--color-text-sub);
   font-size: 14px;
   font-weight: 700;
   line-height: 1.2;
   user-select: none;
   white-space: nowrap;
-  overflow: hidden;
   width: 100%;
 }
 
@@ -269,6 +290,7 @@
   display: inline-flex;
   align-items: center;
   height: 100%;
+  flex: 0 0 auto;
 }
 
 .toggleInput {
@@ -281,6 +303,7 @@
 
 .toggleCheck {
   position: relative;
+  display: inline-block;
   width: 19px;
   height: 19px;
   border-radius: 999px;
@@ -352,7 +375,7 @@
   border-radius: 0;
   padding: 0 38px 0 16px;
   font-size: 14px;
-  line-height: calc(var(--ctl-h) - 2px);
+  line-height: calc(var(--ctl-h, 44px) - 2px);
   background: transparent;
   color: var(--color-text);
   appearance: none;
@@ -365,16 +388,19 @@
   display: inline-flex;
   align-items: stretch;
   overflow: hidden;
-  padding: 3px;
-  background: rgba(244, 247, 253, 0.95);
+  padding: 4px;
   gap: 0;
+  /* controlShell の白背景を打ち消し、凹んだ単一トラックにする（iOS 風） */
+  background: #dfe4ef;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.09);
 }
 
 .segBtn {
-  border: 0;
+  border: 1px solid transparent;
   background: transparent;
-  padding: 0 18px;
-  height: calc(var(--ctl-h) - 8px);
+  padding: 0 16px;
+  height: 100%;
+  min-width: 72px;
   min-height: 0;
   font-size: 13px;
   line-height: 1.2;
@@ -384,8 +410,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 10px;
+  gap: 6px;
+  border-radius: 999px;
   flex: 1 1 0;
+  transition:
+    background-color 0.16s ease,
+    color 0.16s ease,
+    box-shadow 0.16s ease;
 }
 
 .segIcon {
@@ -395,7 +426,10 @@
 .segActive {
   background: #ffffff;
   color: var(--color-accent);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  border-color: var(--color-border);
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 2px 6px rgba(15, 23, 42, 0.1);
 }
 
 .addBtnDesktop,
@@ -415,7 +449,7 @@
 }
 
 .addBtnDesktop {
-  padding-top: 1px;
+  white-space: nowrap;
 }
 
 .ghostBtn,
@@ -444,6 +478,12 @@
 .dangerBtn {
   border-color: rgba(220, 38, 38, 0.16);
   color: var(--color-error);
+}
+
+.smallBtnOn {
+  border-color: color-mix(in srgb, var(--color-success) 28%, transparent);
+  background: color-mix(in srgb, var(--color-success) 12%, #fff);
+  color: var(--color-success);
 }
 
 .empty {
@@ -481,7 +521,7 @@
 }
 
 .card {
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--color-border);
   border-radius: 24px;
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 255, 0.94));
@@ -516,7 +556,7 @@
   font-size: 11px;
   padding: 5px 9px;
   border-radius: 999px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--color-border);
   white-space: nowrap;
   font-weight: 800;
 }
@@ -527,13 +567,13 @@
 }
 
 .badgeWarn {
-  background: rgba(245, 158, 11, 0.16);
-  color: #b45309;
+  background: color-mix(in srgb, var(--color-warning) 16%, transparent);
+  color: var(--color-warning);
 }
 
 .badgeDanger {
-  background: rgba(239, 68, 68, 0.14);
-  color: #b91c1c;
+  background: color-mix(in srgb, var(--color-error) 14%, transparent);
+  color: var(--color-error);
 }
 
 .cardMeta {
@@ -620,7 +660,7 @@
 }
 
 .rowUsed {
-  opacity: 0.62;
+  opacity: 0.58;
 }
 
 .mono {
@@ -648,7 +688,7 @@
 
 .rowBtns {
   display: grid;
-  grid-template-columns: 88px 56px 56px;
+  grid-template-columns: minmax(76px, 1.3fr) minmax(56px, 1fr) minmax(56px, 1fr);
   gap: 8px;
   align-items: center;
 }
@@ -656,6 +696,9 @@
 .rowBtns > button {
   width: 100%;
   justify-content: center;
+  white-space: nowrap;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
 .bottomBar {
@@ -697,11 +740,27 @@
 }
 
 .dialogInner {
+  display: flex;
+  flex-direction: column;
+  max-height: min(90vh, 720px);
   background: rgba(255, 255, 255, 0.98);
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--color-border);
   border-radius: 24px;
   overflow: hidden;
   box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+}
+
+/* ヘッダ/フッタは固定、本文だけスクロール */
+.formGrid {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.dialogHeader,
+.dialogBtns,
+.dialogFooter,
+.errorBox {
+  flex: 0 0 auto;
 }
 
 .dialogHeader {
@@ -868,6 +927,24 @@
   display: none;
 }
 
+@media (min-width: 768px) {
+  .compactRow {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .compactRow .toggle,
+  .compactRow .selectWrap,
+  .compactRow .segment,
+  .compactRow .addBtnDesktop {
+    width: auto;
+  }
+
+  .compactRow .segment {
+    min-width: 168px;
+  }
+}
+
 @media (min-width: 880px) {
   .actionsRow {
     grid-template-columns: minmax(320px, 1fr) auto;
@@ -996,7 +1073,7 @@
   }
 
   .mobileControlRow .segBtn {
-    height: calc(var(--ctl-h) - 6px);
+    height: 100%;
     padding: 0 12px;
     font-size: 13px;
     gap: 6px;

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -20,12 +20,13 @@ import {
   BenefitItemV2,
   normalizeLegacyToV2,
   safeUUID,
+  coerceNumber,
 } from "./benefits/store";
 
 import EditBenefitDialog from "./components/EditBenefitDialog";
 import ImportBenefitDialog from "./components/ImportBenefitDialog";
 
-type TabKey = "thisMonth" | "later" | "all";
+type TabKey = "thisMonth" | "later" | "all" | "overdue";
 type ViewMode = "cards" | "table";
 type SortKey = "expiryAsc" | "companyAsc" | "createdDesc";
 
@@ -213,13 +214,6 @@ function useHydrated() {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
-function parseNumberOrNull(v: string): number | null {
-  const t = v.trim();
-  if (!t) return null;
-  const n = Number(t);
-  if (Number.isNaN(n)) return null;
-  return n;
-}
 
 export default function ToolClient() {
   const hydrated = useHydrated();
@@ -246,7 +240,16 @@ export default function ToolClient() {
   const [tab, setTab] = useState<TabKey>("all");
   const isMobile = useMediaQuery("(max-width: 699px)");
 
-  const [viewMode, setViewMode] = useState<ViewMode>("table");
+  // WHY: レンダー中の localStorage 直読みは再レンダー乖離バグの原因になるため、
+  // 遅延初期化で一度だけ読む。readSavedViewMode は SSR で null を返し hydration 安全。
+  const [viewMode, setViewMode] = useState<ViewMode | null>(() =>
+    readSavedViewMode()
+  );
+
+  const selectViewMode = (m: ViewMode) => {
+    setViewMode(m);
+    saveViewMode(m);
+  };
 
   const [showUsed, setShowUsed] = useState(true);
   const [sortKey, setSortKey] = useState<SortKey>("expiryAsc");
@@ -272,6 +275,7 @@ export default function ToolClient() {
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
+    const today = todayISODate();
 
     const base = items.filter((it) => {
       if (!showUsed && it.isUsed) return false;
@@ -297,6 +301,11 @@ export default function ToolClient() {
         if (!it.expiresOn) return false;
         const d = parseLocalDate(it.expiresOn);
         return d.getTime() >= nextMonthStart.getTime();
+      }
+
+      if (tab === "overdue") {
+        if (!it.expiresOn) return false;
+        return it.expiresOn < today;
       }
 
       // all
@@ -385,8 +394,8 @@ export default function ToolClient() {
       company: draft.company.trim(),
       expiresOn,
       isUsed: draft.isUsed,
-      quantity: parseNumberOrNull(draft.quantity),
-      amountYen: parseNumberOrNull(draft.amountYen),
+      quantity: coerceNumber(draft.quantity),
+      amountYen: coerceNumber(draft.amountYen),
       memo: draft.memo?.trim() ?? "",
       link: draft.link.trim() ? draft.link.trim() : undefined,
       createdAt: nowIso,
@@ -489,14 +498,13 @@ export default function ToolClient() {
   const emptyMessage = useMemo(() => {
     if (tab === "thisMonth") return "今月の期限はありません";
     if (tab === "later") return "今後の期限（来月以降）はありません";
+    if (tab === "overdue") return "期限切れの優待はありません";
     return "まだデータがありません";
   }, [tab]);
 
-  const savedViewMode: ViewMode | null = hydrated ? readSavedViewMode() : null;
-
   const effectiveViewMode: ViewMode = !hydrated
     ? "table"
-    : savedViewMode ?? (isMobile ? "cards" : viewMode);
+    : viewMode ?? (isMobile ? "cards" : "table");
 
   // ===== layout parts =====
   const header = (
@@ -577,6 +585,19 @@ export default function ToolClient() {
               {laterCount}
             </span>
           </button>
+
+          <button
+            className={`${styles.tabBtn} ${
+              tab === "overdue" ? styles.tabActive : ""
+            }`}
+            onClick={() => setTab("overdue")}
+            type="button"
+          >
+            期限切れ
+            <span className={styles.countPill} suppressHydrationWarning>
+              {overdueCount}
+            </span>
+          </button>
         </div>
 
         <div className={styles.actionsRow}>
@@ -588,11 +609,21 @@ export default function ToolClient() {
               placeholder="検索（企業名 / 優待名 / メモ / リンク）"
               aria-label="検索"
             />
+            {query && (
+              <button
+                type="button"
+                className={styles.searchClear}
+                onClick={() => setQuery("")}
+                aria-label="検索をクリア"
+              >
+                ✕
+              </button>
+            )}
           </div>
 
           <div className={styles.compactRow}>
             <label
-              className={`${styles.controlShell} ${styles.toggle} ${styles.desktopOnly}`}
+              className={`${styles.controlShell} ${styles.toggle}`}
             >
               <input
                 type="checkbox"
@@ -610,7 +641,7 @@ export default function ToolClient() {
             </label>
 
             <div
-              className={`${styles.controlShell} ${styles.selectWrap} ${styles.desktopOnly}`}
+              className={`${styles.controlShell} ${styles.selectWrap}`}
             >
               <select
                 className={styles.select}
@@ -625,17 +656,14 @@ export default function ToolClient() {
             </div>
 
             <div
-              className={`${styles.controlShell} ${styles.segment} ${styles.desktopOnly}`}
+              className={`${styles.controlShell} ${styles.segment}`}
             >
               <button
                 type="button"
                 className={`${styles.segBtn} ${
                   effectiveViewMode === "cards" ? styles.segActive : ""
                 }`}
-                onClick={() => {
-                  setViewMode("cards");
-                  saveViewMode("cards");
-                }}
+                onClick={() => selectViewMode("cards")}
                 aria-label="カード表示"
               >
                 カード
@@ -645,10 +673,7 @@ export default function ToolClient() {
                 className={`${styles.segBtn} ${
                   effectiveViewMode === "table" ? styles.segActive : ""
                 }`}
-                onClick={() => {
-                  setViewMode("table");
-                  saveViewMode("table");
-                }}
+                onClick={() => selectViewMode("table")}
                 aria-label="表表示"
               >
                 リスト
@@ -684,10 +709,7 @@ export default function ToolClient() {
                 className={`${styles.segBtn} ${
                   effectiveViewMode === "cards" ? styles.segActive : ""
                 }`}
-                onClick={() => {
-                  setViewMode("cards");
-                  saveViewMode("cards");
-                }}
+                onClick={() => selectViewMode("cards")}
                 aria-label="カード表示"
               >
                 <span className={styles.segIcon} aria-hidden="true">
@@ -700,10 +722,7 @@ export default function ToolClient() {
                 className={`${styles.segBtn} ${
                   effectiveViewMode === "table" ? styles.segActive : ""
                 }`}
-                onClick={() => {
-                  setViewMode("table");
-                  saveViewMode("table");
-                }}
+                onClick={() => selectViewMode("table")}
                 aria-label="表表示"
               >
                 <span className={styles.segIcon} aria-hidden="true">
@@ -869,10 +888,12 @@ export default function ToolClient() {
                 <div className={styles.cardActions}>
                   <button
                     type="button"
-                    className={styles.smallBtn}
+                    className={`${styles.smallBtn} ${
+                      it.isUsed ? styles.smallBtnOn : ""
+                    }`}
                     onClick={() => toggleUsed(it.id)}
                   >
-                    {it.isUsed ? "使用済" : "未使用"}
+                    {it.isUsed ? "使用済み" : "未使用"}
                   </button>
                   <button
                     type="button"
@@ -962,10 +983,12 @@ export default function ToolClient() {
                     <div className={styles.rowBtns}>
                       <button
                         type="button"
-                        className={styles.smallBtn}
+                        className={`${styles.smallBtn} ${
+                          it.isUsed ? styles.smallBtnOn : ""
+                        }`}
                         onClick={() => toggleUsed(it.id)}
                       >
-                        {it.isUsed ? "未使用" : "使用済み"}
+                        {it.isUsed ? "使用済み" : "未使用"}
                       </button>
                       <button
                         type="button"

--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -49,6 +49,23 @@ function toNumberOrNull(v: string): number | null {
   return n;
 }
 
+// 数値/文字列(¥1,000 等)/混在を number|null に寄せる
+export function coerceNumber(v: unknown): number | null {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v === "string") return toNumberOrNull(v.replace(/[^\d.-]/g, ""));
+  return null;
+}
+
+// 期限を YYYY-MM-DD に正規化（2026/01/31・ISO・空 などを吸収）
+function normalizeDate(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const s = v.trim();
+  if (!s) return null;
+  // 区切りを - に寄せて先頭10文字を見る
+  const head = s.replace(/[./]/g, "-").slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(head) ? head : null;
+}
+
 export function normalizeLegacyToV2(raw: unknown): BenefitItemV2[] {
   if (!Array.isArray(raw)) return [];
 
@@ -65,35 +82,24 @@ export function normalizeLegacyToV2(raw: unknown): BenefitItemV2[] {
       const title = typeof obj.title === "string" ? obj.title : "";
       const company = typeof obj.company === "string" ? obj.company : "";
 
-      const expiresAt =
-        typeof obj.expiresAt === "string" ? obj.expiresAt : null;
-      // expiresAt が ISO の日付だったりするケースもあるので YYYY-MM-DD に寄せる
-      const expiresOn = expiresAt ? expiresAt.slice(0, 10) : null;
+      // V2(expiresOn) を優先し、旧 v1(expiresAt) にフォールバック
+      const expiresOn =
+        normalizeDate(obj.expiresOn) ?? normalizeDate(obj.expiresAt);
 
       const isUsed = typeof obj.isUsed === "boolean" ? obj.isUsed : false;
 
-      const quantity = (() => {
-        if (typeof obj.quantity === "number") return obj.quantity;
-        if (typeof obj.quantity === "string")
-          return toNumberOrNull(obj.quantity);
-        return null;
-      })();
+      const quantity = coerceNumber(obj.quantity);
 
-      const amountYen = (() => {
-        if (typeof obj.amount === "number") return obj.amount;
-        // v1で amount が "¥1,000" みたいに入ってる可能性を拾う
-        if (typeof obj.amount === "string") {
-          const cleaned = obj.amount.replace(/[^\d.-]/g, "");
-          return toNumberOrNull(cleaned);
-        }
-        return null;
-      })();
+      // V2(amountYen) を優先し、旧 v1(amount: "¥1,000" 等) にフォールバック
+      const amountYen =
+        coerceNumber(obj.amountYen) ?? coerceNumber(obj.amount);
 
+      // V2(memo) を優先し、旧 v1(note) にフォールバック
       const memo =
-        typeof obj.note === "string"
-          ? obj.note
-          : typeof obj.memo === "string"
+        typeof obj.memo === "string"
           ? obj.memo
+          : typeof obj.note === "string"
+          ? obj.note
           : "";
 
       const createdAt =

--- a/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
+++ b/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
@@ -45,13 +45,9 @@ export default function EditBenefitDialog({
           </button>
         </div>
 
-        {draftError ? (
-          <div className={styles.errorBox}>{draftError}</div>
-        ) : null}
-
         <div className={styles.formGrid}>
           <label className={styles.field}>
-            <span>タイトル *</span>
+            <span>優待名 *</span>
             <input
               value={draft.title}
               onChange={(e) => setDraft({ ...draft, title: e.target.value })}
@@ -62,7 +58,7 @@ export default function EditBenefitDialog({
 
           <div className={styles.row2}>
             <label className={styles.field}>
-              <span>企業名</span>
+              <span>企業名 *</span>
               <input
                 value={draft.company}
                 onChange={(e) =>
@@ -143,6 +139,12 @@ export default function EditBenefitDialog({
             <span>使用済みにする</span>
           </label>
         </div>
+
+        {draftError ? (
+          <div className={styles.errorBox} role="alert">
+            {draftError}
+          </div>
+        ) : null}
 
         <div className={styles.dialogBtns}>
           <button

--- a/app/tools/yutai-expiry/components/ImportBenefitDialog.tsx
+++ b/app/tools/yutai-expiry/components/ImportBenefitDialog.tsx
@@ -20,6 +20,14 @@ export default function ImportBenefitDialog({
   onImportReplace,
   onImportMerge,
 }: Props) {
+  // 全データ破棄は不可逆なので置き換え時のみ確認を挟む
+  const handleReplace = () => {
+    const ok = window.confirm(
+      "現在のデータをすべて破棄して置き換えます。よろしいですか？（元に戻せません）"
+    );
+    if (ok) onImportReplace();
+  };
+
   return (
     <dialog ref={dialogRef} className={styles.dialog}>
       <form method="dialog" className={styles.dialogInner}>
@@ -61,18 +69,19 @@ export default function ImportBenefitDialog({
           </button>
           <button
             type="button"
-            className={styles.ghostBtn}
-            onClick={onImportMerge}
-            title="既存とマージ（同じidは上書き）"
+            className={`${styles.ghostBtn} ${styles.dangerBtn}`}
+            onClick={handleReplace}
+            title="現在のデータを全消去して置き換える"
           >
-            マージ
+            すべて置き換え
           </button>
           <button
             type="button"
             className={styles.primaryBtn}
-            onClick={onImportReplace}
+            onClick={onImportMerge}
+            title="既存に追加マージ（同じidは上書き、それ以外は保持）"
           >
-            置き換え
+            マージして取り込み
           </button>
         </div>
       </form>

--- a/docs/decision-log/2026-05-19-yutai-expiry-ui-and-data-policy.md
+++ b/docs/decision-log/2026-05-19-yutai-expiry-ui-and-data-policy.md
@@ -1,0 +1,54 @@
+# 2026-05-19 優待期限台帳 UI と入出力データ方針
+
+## 背景
+
+- 対象 tool: 優待期限台帳 `/tools/yutai-expiry`（`app/tools/yutai-expiry/`）
+- スクショレビューでコントロール列・セグメント・トグルの不整合、リスト/カード切替の未反映バグが判明。
+- あわせてポップアップ導線、エクスポート/インポートの正規化を調査し、データ消失バグを発見。
+- 関連 PR: 本ファイルと同 PR。
+
+## 今回決めたこと
+
+### データ contract（入出力）
+- インポート正規化 `normalizeLegacyToV2` は **現行 V2 キーを優先し、旧 v1 キーへフォールバック**する。
+  - `expiresOn`→（無ければ）`expiresAt` / `amountYen`→`amount` / `memo`→`note` / `link`→`url`。
+  - 日付は `YYYY-MM-DD` に正規化（`/` `.` 区切り・ISO・空を吸収。不正は `null`）。
+- 結論: **エクスポート(V2形状) → インポートの往復で期限・金額を保持する**ことを正式な仕様とする。
+
+### UI 役割分担
+- ヒーローの統計カード（今月の未使用 / 期限切れ注意 / 期限未設定）は **KPI 表示専用（クリック不可）**。
+- 絞り込み導線は **タブ 1 系統**（すべて / 今月 / 先の期限 / 期限切れ）に統一。「期限切れ」タブを新設。
+- 統計カードとタブの機能を二重化しない。
+
+### 状態管理方針（localStorage / hydration）
+- 表示モード（cards/table）は **React state を唯一の真実**とする。
+- localStorage は「マウント時に遅延初期化で一度読む／選択時に保存」のみ。**レンダー中の localStorage 直読みを禁止**。
+
+### ポップアップ安全性
+- 破壊的操作（インポート全置換）は `window.confirm` で確認し、視覚序列は安全な「マージ」を primary、「すべて置き換え」を danger とする。
+- 必須項目は UI 表示（`*`）と実装バリデーションを一致させる（優待名・企業名）。
+
+## 判断理由
+
+- 正規化が旧キーのみ参照だったため、自前バックアップ（エクスポートJSON）の復元で期限/金額が全消失していた。バックアップ導線として致命的なので contract を明文化。
+- 統計カードをタブのショートカットにすると「期限未設定だけ表示」等の期待を生むがフィルタが無く不整合になる。データ件数が少なく KPI は一覧性が本質のため、表示専用が最小で破綻しない（案A採用、ショートカット案B/折衷案Cは不採用）。
+- localStorage 直読みは「保存値で描画／state で再レンダー」の乖離を生み、同値クリックで no-op→未反映バグになっていた。state を真実にすることで恒久解消。
+
+## 影響範囲
+
+- `app/tools/yutai-expiry/benefits/store.ts`（`coerceNumber`/`normalizeDate` 追加・export、`normalizeLegacyToV2` 改修）
+- `app/tools/yutai-expiry/ToolClient.tsx`（viewMode 遅延初期化＋`selectViewMode`、overdue タブ、検索クリア、トグル状態色、ラベル統一）
+- `app/tools/yutai-expiry/components/{EditBenefitDialog,ImportBenefitDialog}.tsx`（必須表示・語彙・エラー位置・確認）
+- `app/tools/yutai-expiry/ToolClient.module.css`（コントロール高 `--ctl-h`、セグメント、ダイアログスクロール、トークン化）
+- 互換性: 旧 v1 JSON は従来どおり取り込み可。V2 JSON の往復が新たに保持される（改善方向、破壊的変更なし）。
+
+## 残課題
+
+- 旧キー自動移行 `loadFromLocalStorage` は `getBenefitsSnapshot` から未接続（手動インポート以外でレガシー移行が走らない）。要否は別途判断。
+- `fmtJPDate` と共通 `formatToolDate` の重複、`dueBadge` と overdue 判定の二重定義は将来統一候補（今回はスコープ外）。
+
+## 関連
+
+- Issue: （なし）
+- PR: 本 PR
+- 参照 docs: [docs-writing-workflow](../docs-writing-workflow.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 
 - [2026-05-06 ペンギン・エイリアンシューター 敵キャラクター変更](./decision-log/2026-05-06-penguin-alien-enemy-visual.md)
 - [2026-05-16 TDNET適時開示一覧の初期実装方針](./decision-log/2026-05-16-tdnet-disclosures-page.md)
+- [2026-05-19 優待期限台帳 UI と入出力データ方針](./decision-log/2026-05-19-yutai-expiry-ui-and-data-policy.md)
 - [2026-05-09 ペンギンシューター豪華版・新技術トライアル方針](./decision-log/2026-05-09-penguin-shooter-rich-game-trial.md)
 - [2026-05-09 ペンギンシューター 100小ステージデータ構造](./decision-log/2026-05-09-penguin-shooter-stage-data-structure.md)
 - [2026-05-09 ペンギンシューター ボス設計とPR8凍結](./decision-log/2026-05-09-penguin-shooter-boss-design-and-pr8-freeze.md)


### PR DESCRIPTION
## 概要

優待期限台帳 `/tools/yutai-expiry` の UI 整合性と、エクスポート/インポートのデータ消失バグを修正。スクショレビューと3エージェントのコードレビューを反映。

## 変更内容

### データ安全性（最重要）
- `normalizeLegacyToV2` を V2キー(`expiresOn`/`amountYen`/`memo`/`link`)優先＋旧v1フォールバックに改修。日付正規化を追加。
- → エクスポート(V2形状)→インポートの往復で**期限・金額が消えなく**なった。

### バグ修正
- リスト/カード切替がリロードまで反映されない問題を解消（`viewMode` を state 唯一の真実に、レンダー中の localStorage 直読みを廃止）。

### UI 整合
- コントロール列/セグメント/トグルの寸法・配色を整合（`--ctl-h`、iOS風トラック、状態色のトークン化）。
- 統計カードは KPI 表示専用に統一、絞り込みはタブ1系統（「期限切れ」タブ新設、検索クリア追加）。
- ダイアログ: 必須表示/語彙統一/エラー位置/スクロール対応、全置換に確認ダイアログ。

### レビュー反映
- `coerceNumber` 共通化（重複関数削減）、`selectViewMode` 抽出、`today` 巻き上げ、トグルラベル統一。

### docs
- decision-log 追加、`docs/index.md` にリンク。

## 確認項目
- `npm run lint`: パス
- ESLint（変更ファイル個別）: パス
- 動作確認: ローカルで要確認（カード/リスト切替の即時反映、エクスポート→全置換でのデータ保持、ダイアログのスクロール、期限切れタブ）

## 関連 Issue
- なし
