### PR TITLE
feat(yutai-expiry): 消費モデル（枚数/金額）と簡易履歴・金額集計

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -80,8 +80,42 @@
 
 .heroStats {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 12px;
+}
+
+.rowActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.history {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.history > summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: var(--color-text-sub);
+}
+
+.history ul {
+  margin: 6px 0 0;
+  padding-left: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.statValueYen {
+  font-size: clamp(20px, 3vw, 26px);
+  line-height: 1.1;
+  font-weight: 900;
+  color: #1f3fb8;
 }
 
 .statCard {
@@ -478,12 +512,6 @@
 .dangerBtn {
   border-color: rgba(220, 38, 38, 0.16);
   color: var(--color-error);
-}
-
-.smallBtnOn {
-  border-color: color-mix(in srgb, var(--color-success) 28%, transparent);
-  background: color-mix(in srgb, var(--color-success) 12%, #fff);
-  color: var(--color-success);
 }
 
 .empty {
@@ -972,7 +1000,7 @@
 
 @media (max-width: 879px) {
   .heroStats {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 10px;
   }
 

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -195,8 +195,14 @@ function validateDraft(d: Draft): { ok: boolean; message?: string } {
     const q = coerceNumber(d.qty);
     if (q == null || q < 0)
       return { ok: false, message: "枚数を0以上の数値で入力してください。" };
-    if (d.unitYen.trim() && coerceNumber(d.unitYen) == null)
-      return { ok: false, message: "1枚あたり額面は数値で入力してください。" };
+    if (d.unitYen.trim()) {
+      const u = coerceNumber(d.unitYen);
+      if (u == null || u < 0)
+        return {
+          ok: false,
+          message: "1枚あたり額面は0以上の数値で入力してください。",
+        };
+    }
   } else {
     const b = coerceNumber(d.balanceYen);
     if (b == null || b < 0)
@@ -464,7 +470,10 @@ export default function ToolClient() {
 
     setItems((prev) => {
       const prevItem = prev.find((p) => p.id === id);
-      // 編集時は initial / history / createdAt を保全（残のみユーザー編集を反映）
+      // 編集時は initial / history / createdAt を保全（残のみユーザー編集を反映）。
+      // ただしモード(枚数/金額)を変えた場合は単位が変わるので initial を新値で取り直す。
+      const keepInitial =
+        prevItem && prevItem.trackMode === draft.trackMode;
       const built = coerceItem({
         id,
         title: draft.title.trim(),
@@ -472,9 +481,9 @@ export default function ToolClient() {
         expiresOn,
         trackMode: draft.trackMode,
         unitYen,
-        initial: prevItem?.initial ?? remainingInput,
+        initial: keepInitial ? prevItem!.initial : remainingInput,
         remaining: remainingInput,
-        history: prevItem?.history ?? [],
+        history: keepInitial ? prevItem!.history : [],
         memo: draft.memo?.trim() ?? "",
         link: draft.link.trim() ? draft.link.trim() : undefined,
         createdAt: prevItem?.createdAt ?? nowIso,

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -21,6 +21,13 @@ import {
   normalizeLegacyToV2,
   safeUUID,
   coerceNumber,
+  coerceItem,
+  consume,
+  restock,
+  setUsedAll,
+  itemValueYen,
+  TrackMode,
+  UsageEntry,
 } from "./benefits/store";
 
 import EditBenefitDialog from "./components/EditBenefitDialog";
@@ -99,27 +106,57 @@ function formatMonthLabel(d: Date): string {
   return `${d.getFullYear()}年${d.getMonth() + 1}月`;
 }
 
+function fmtYen(n: number): string {
+  return `¥${Math.round(n).toLocaleString()}`;
+}
+
+function remainingText(it: BenefitItemV2): string {
+  const rem = it.remaining ?? 0;
+  if (it.trackMode === "amount") return `残高 ${fmtYen(rem)}`;
+  const base = `残${rem}枚`;
+  if (it.unitYen != null)
+    return `${base} ×${fmtYen(it.unitYen)}（合計 ${fmtYen(itemValueYen(it))}）`;
+  return base;
+}
+
+function historyText(h: UsageEntry): string {
+  const d = h.at ? h.at.slice(0, 10) : "";
+  if (h.deltaYen != null) {
+    const sign = h.deltaYen < 0 ? "使用" : "追加";
+    return `${d} ${sign} ${fmtYen(Math.abs(h.deltaYen))}${
+      h.note ? `（${h.note}）` : ""
+    }`;
+  }
+  const q = h.deltaQty ?? 0;
+  const sign = q < 0 ? "使用" : "追加";
+  return `${d} ${sign} ${Math.abs(q)}枚${h.note ? `（${h.note}）` : ""}`;
+}
+
 export type Draft = {
   id?: string;
   title: string;
   company: string;
   expiresOn: string; // 入力では空文字もあり得る
-  isUsed: boolean;
-  quantity: string;
-  amountYen: string;
+  trackMode: TrackMode; // 枚数 / 金額
+  qty: string; // count: 残枚数（編集時は現在値）
+  unitYen: string; // count: 1枚あたり額面（任意）
+  balanceYen: string; // amount: 残高(円)
   memo: string;
   link: string; // URL（任意）
 };
 
 function toDraft(x?: BenefitItemV2): Draft {
+  const mode: TrackMode = x?.trackMode ?? "count";
   return {
     id: x?.id,
     title: x?.title ?? "",
     company: x?.company ?? "",
     expiresOn: x?.expiresOn ?? "",
-    isUsed: x?.isUsed ?? false,
-    quantity: x?.quantity != null ? String(x.quantity) : "",
-    amountYen: x?.amountYen != null ? String(x.amountYen) : "",
+    trackMode: mode,
+    qty: mode === "count" && x?.remaining != null ? String(x.remaining) : "",
+    unitYen: x?.unitYen != null ? String(x.unitYen) : "",
+    balanceYen:
+      mode === "amount" && x?.remaining != null ? String(x.remaining) : "",
     memo: x?.memo ?? "",
     link: x?.link ?? "",
   };
@@ -152,6 +189,18 @@ function validateDraft(d: Draft): { ok: boolean; message?: string } {
         message: "期限は YYYY-MM-DD 形式で入力してください（例: 2026-03-31）。",
       };
     }
+  }
+
+  if (d.trackMode === "count") {
+    const q = coerceNumber(d.qty);
+    if (q == null || q < 0)
+      return { ok: false, message: "枚数を0以上の数値で入力してください。" };
+    if (d.unitYen.trim() && coerceNumber(d.unitYen) == null)
+      return { ok: false, message: "1枚あたり額面は数値で入力してください。" };
+  } else {
+    const b = coerceNumber(d.balanceYen);
+    if (b == null || b < 0)
+      return { ok: false, message: "残高を0以上の金額で入力してください。" };
   }
 
   const linkErr = validateHttpUrl(d.link);
@@ -363,6 +412,21 @@ export default function ToolClient() {
     return items.filter((it) => !it.isUsed && !it.expiresOn).length;
   }, [items]);
 
+  const unusedTotalYen = useMemo(() => {
+    return items.reduce(
+      (sum, it) => (it.isUsed ? sum : sum + itemValueYen(it)),
+      0
+    );
+  }, [items]);
+
+  const expiringThisMonthYen = useMemo(() => {
+    return items.reduce((sum, it) => {
+      if (it.isUsed || !it.expiresOn) return sum;
+      if (!isSameMonth(parseLocalDate(it.expiresOn), now)) return sum;
+      return sum + itemValueYen(it);
+    }, 0);
+  }, [items, now]);
+
   // --- actions ---
   function openAdd() {
     setEditMode("add");
@@ -387,34 +451,40 @@ export default function ToolClient() {
 
     const nowIso = new Date().toISOString();
     const expiresOn = draft.expiresOn.trim() ? draft.expiresOn.trim() : null;
-
-    const next: BenefitItemV2 = {
-      id: draft.id ?? safeUUID(),
-      title: draft.title.trim(),
-      company: draft.company.trim(),
-      expiresOn,
-      isUsed: draft.isUsed,
-      quantity: coerceNumber(draft.quantity),
-      amountYen: coerceNumber(draft.amountYen),
-      memo: draft.memo?.trim() ?? "",
-      link: draft.link.trim() ? draft.link.trim() : undefined,
-      createdAt: nowIso,
-      updatedAt: nowIso,
-    };
+    const id = draft.id ?? safeUUID();
+    const isAmount = draft.trackMode === "amount";
+    const remainingInput = isAmount
+      ? coerceNumber(draft.balanceYen)
+      : coerceNumber(draft.qty);
+    const unitYen = isAmount
+      ? null
+      : draft.unitYen.trim()
+      ? coerceNumber(draft.unitYen)
+      : null;
 
     setItems((prev) => {
-      const idx = prev.findIndex((p) => p.id === next.id);
-      if (idx === -1) {
-        return [next, ...prev];
-      }
-      const merged: BenefitItemV2 = {
-        ...prev[idx],
-        ...next,
-        createdAt: prev[idx].createdAt,
+      const prevItem = prev.find((p) => p.id === id);
+      // 編集時は initial / history / createdAt を保全（残のみユーザー編集を反映）
+      const built = coerceItem({
+        id,
+        title: draft.title.trim(),
+        company: draft.company.trim(),
+        expiresOn,
+        trackMode: draft.trackMode,
+        unitYen,
+        initial: prevItem?.initial ?? remainingInput,
+        remaining: remainingInput,
+        history: prevItem?.history ?? [],
+        memo: draft.memo?.trim() ?? "",
+        link: draft.link.trim() ? draft.link.trim() : undefined,
+        createdAt: prevItem?.createdAt ?? nowIso,
         updatedAt: nowIso,
-      };
+      });
+      if (!built) return prev;
+      const idx = prev.findIndex((p) => p.id === id);
+      if (idx === -1) return [built, ...prev];
       const copy = [...prev];
-      copy[idx] = merged;
+      copy[idx] = built;
       return copy;
     });
 
@@ -424,12 +494,34 @@ export default function ToolClient() {
 
   function toggleUsed(id: string) {
     setItems((prev) =>
-      prev.map((p) =>
-        p.id === id
-          ? { ...p, isUsed: !p.isUsed, updatedAt: new Date().toISOString() }
-          : p
-      )
+      prev.map((p) => (p.id === id ? setUsedAll(p, !p.isUsed) : p))
     );
+  }
+
+  function applyConsume(id: string, amount: number) {
+    setItems((prev) =>
+      prev.map((p) => (p.id === id ? consume(p, amount) : p))
+    );
+  }
+
+  function applyRestock(id: string, amount: number) {
+    setItems((prev) =>
+      prev.map((p) => (p.id === id ? restock(p, amount) : p))
+    );
+  }
+
+  // 「使う…」「＋追加」用の数値入力（割り切り: prompt）
+  function promptAmount(it: BenefitItemV2, kind: "use" | "add"): number | null {
+    const unitLabel = it.trackMode === "amount" ? "金額(円)" : "枚数";
+    const verb = kind === "use" ? "使う" : "追加する";
+    const raw = window.prompt(`${verb}${unitLabel}を入力してください`, "");
+    if (raw == null) return null;
+    const n = coerceNumber(raw);
+    if (n == null || n <= 0) {
+      setToast("数値を入力してください");
+      return null;
+    }
+    return n;
   }
 
   function removeItem(id: string) {
@@ -541,6 +633,20 @@ export default function ToolClient() {
               {noExpiryCount}
             </strong>
             <span className={styles.statHint}>あとで整理したい優待</span>
+          </div>
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>未使用合計額</span>
+            <strong className={styles.statValueYen} suppressHydrationWarning>
+              {fmtYen(unusedTotalYen)}
+            </strong>
+            <span className={styles.statHint}>残っている優待の額面合計</span>
+          </div>
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>今月失効する金額</span>
+            <strong className={styles.statValueYen} suppressHydrationWarning>
+              {fmtYen(expiringThisMonthYen)}
+            </strong>
+            <span className={styles.statHint}>{formatMonthLabel(now)}に期限切れ</span>
           </div>
         </div>
       </section>
@@ -831,29 +937,26 @@ export default function ToolClient() {
                   </div>
                 </div>
 
-                {(it.quantity != null ||
-                  it.amountYen != null ||
-                  (it.memo && it.memo.trim())) && (
-                  <div className={styles.cardBody}>
-                    {(it.quantity != null || it.amountYen != null) && (
-                      <div className={styles.kvRow}>
-                        {it.quantity != null && (
-                          <span className={styles.kv}>
-                            数量: <b>{it.quantity}</b>
-                          </span>
-                        )}
-                        {it.amountYen != null && (
-                          <span className={styles.kv}>
-                            金額: <b>{it.amountYen.toLocaleString()}円</b>
-                          </span>
-                        )}
-                      </div>
-                    )}
-                    {it.memo && it.memo.trim() && (
-                      <div className={styles.memo}>{it.memo}</div>
-                    )}
+                <div className={styles.cardBody}>
+                  <div className={styles.kvRow}>
+                    <span className={styles.kv}>
+                      <b>{remainingText(it)}</b>
+                    </span>
                   </div>
-                )}
+                  {it.memo && it.memo.trim() && (
+                    <div className={styles.memo}>{it.memo}</div>
+                  )}
+                  {it.history.length > 0 && (
+                    <details className={styles.history}>
+                      <summary>履歴（{it.history.length}）</summary>
+                      <ul>
+                        {[...it.history].reverse().map((h, i) => (
+                          <li key={i}>{historyText(h)}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
+                </div>
 
                 {it.link && (
                   <div className={styles.cardBody} style={{ paddingTop: 0 }}>
@@ -886,14 +989,43 @@ export default function ToolClient() {
                 )}
 
                 <div className={styles.cardActions}>
+                  {!it.isUsed && it.trackMode === "count" && (
+                    <button
+                      type="button"
+                      className={styles.smallBtn}
+                      onClick={() => applyConsume(it.id, 1)}
+                    >
+                      1枚使う
+                    </button>
+                  )}
+                  {!it.isUsed && (
+                    <button
+                      type="button"
+                      className={styles.smallBtn}
+                      onClick={() => {
+                        const n = promptAmount(it, "use");
+                        if (n != null) applyConsume(it.id, n);
+                      }}
+                    >
+                      使う…
+                    </button>
+                  )}
                   <button
                     type="button"
-                    className={`${styles.smallBtn} ${
-                      it.isUsed ? styles.smallBtnOn : ""
-                    }`}
+                    className={styles.smallBtn}
+                    onClick={() => {
+                      const n = promptAmount(it, "add");
+                      if (n != null) applyRestock(it.id, n);
+                    }}
+                  >
+                    ＋追加
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.smallBtn}
                     onClick={() => toggleUsed(it.id)}
                   >
-                    {it.isUsed ? "使用済み" : "未使用"}
+                    {it.isUsed ? "未使用に戻す" : "全部使う"}
                   </button>
                   <button
                     type="button"
@@ -923,8 +1055,8 @@ export default function ToolClient() {
                 <th>優待</th>
                 <th style={{ width: 180 }}>企業</th>
                 <th style={{ width: 120 }}>状態</th>
-                <th style={{ width: 180 }}>メモ</th>
-                <th style={{ width: 240 }}>操作</th>
+                <th style={{ width: 160 }}>メモ</th>
+                <th style={{ width: 260 }}>操作</th>
               </tr>
             </thead>
             <tbody>
@@ -935,15 +1067,18 @@ export default function ToolClient() {
                   </td>
                   <td>
                     <div className={styles.rowTitle}>{it.title}</div>
-                    {(it.quantity != null || it.amountYen != null) && (
-                      <div className={styles.rowSub}>
-                        {it.quantity != null && (
-                          <span>数量: {it.quantity}</span>
-                        )}
-                        {it.amountYen != null && (
-                          <span>金額: {it.amountYen.toLocaleString()}円</span>
-                        )}
-                      </div>
+                    <div className={styles.rowSub}>
+                      <span>{remainingText(it)}</span>
+                    </div>
+                    {it.history.length > 0 && (
+                      <details className={styles.history}>
+                        <summary>履歴（{it.history.length}）</summary>
+                        <ul>
+                          {[...it.history].reverse().map((h, i) => (
+                            <li key={i}>{historyText(h)}</li>
+                          ))}
+                        </ul>
+                      </details>
                     )}
 
                     {it.link && (
@@ -980,15 +1115,44 @@ export default function ToolClient() {
                   <td>{it.isUsed ? "使用済み" : "未使用"}</td>
                   <td className={styles.rowMemo}>{it.memo ?? ""}</td>
                   <td>
-                    <div className={styles.rowBtns}>
+                    <div className={styles.rowActions}>
+                      {!it.isUsed && it.trackMode === "count" && (
+                        <button
+                          type="button"
+                          className={styles.smallBtn}
+                          onClick={() => applyConsume(it.id, 1)}
+                        >
+                          1枚使う
+                        </button>
+                      )}
+                      {!it.isUsed && (
+                        <button
+                          type="button"
+                          className={styles.smallBtn}
+                          onClick={() => {
+                            const n = promptAmount(it, "use");
+                            if (n != null) applyConsume(it.id, n);
+                          }}
+                        >
+                          使う…
+                        </button>
+                      )}
                       <button
                         type="button"
-                        className={`${styles.smallBtn} ${
-                          it.isUsed ? styles.smallBtnOn : ""
-                        }`}
+                        className={styles.smallBtn}
+                        onClick={() => {
+                          const n = promptAmount(it, "add");
+                          if (n != null) applyRestock(it.id, n);
+                        }}
+                      >
+                        ＋追加
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.smallBtn}
                         onClick={() => toggleUsed(it.id)}
                       >
-                        {it.isUsed ? "使用済み" : "未使用"}
+                        {it.isUsed ? "未使用に戻す" : "全部使う"}
                       </button>
                       <button
                         type="button"

--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -1,19 +1,34 @@
 // app/tools/yutai-expiry/benefits/store.ts
 
 // 1) types
+export type TrackMode = "count" | "amount";
+
+// 簡易利用履歴（追記のみ）。count は deltaQty、amount は deltaYen を使う。
+export type UsageEntry = {
+  at: string; // ISO
+  deltaQty?: number; // count: 負=使用 / 正=追加
+  deltaYen?: number; // amount: 負=使用 / 正=チャージ
+  note?: string;
+};
+
 export type BenefitItemV2 = {
   id: string;
   title: string; // 優待名
   company: string; // 企業名
   expiresOn: string | null; // YYYY-MM-DD or null(期限なし)
-  isUsed: boolean;
+  isUsed: boolean; // remaining<=0 の派生（既存フィルタ互換のため保持）
 
-  // 任意（ユーザーの要望：隠さない、任意）
+  // 消費モデル（2026-05-20 decision-log）
+  trackMode: TrackMode; // count=枚数 / amount=金額残高
+  unitYen: number | null; // count: 1枚あたり額面 / amount: 未使用
+  initial: number | null; // 初期値（基準）
+  remaining: number | null; // count: 残枚数 / amount: 残円
+  history: UsageEntry[];
+
+  // 旧フィールド（legacy 入力としてのみ読む。今後は書かない）
   quantity?: number | null;
   amountYen?: number | null;
   memo?: string;
-
-  // ✅ 追加：任意URL
   link?: string;
 
   createdAt: string; // ISO
@@ -66,74 +81,186 @@ function normalizeDate(v: unknown): string | null {
   return /^\d{4}-\d{2}-\d{2}$/.test(head) ? head : null;
 }
 
-export function normalizeLegacyToV2(raw: unknown): BenefitItemV2[] {
-  if (!Array.isArray(raw)) return [];
+function normalizeHistory(v: unknown): UsageEntry[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .map((e) => {
+      if (!e || typeof e !== "object") return null;
+      const o = e as Record<string, unknown>;
+      const at = typeof o.at === "string" && o.at ? o.at : null;
+      if (!at) return null;
+      const entry: UsageEntry = { at };
+      const dq = coerceNumber(o.deltaQty);
+      const dy = coerceNumber(o.deltaYen);
+      if (dq != null) entry.deltaQty = dq;
+      if (dy != null) entry.deltaYen = dy;
+      if (typeof o.note === "string" && o.note) entry.note = o.note;
+      return entry;
+    })
+    .filter(Boolean) as UsageEntry[];
+}
 
+// 旧 v1 / 旧 v2 / 新 v2 / エクスポート JSON を現行 BenefitItemV2 に寄せる。
+// 新フィールドを優先し、無ければ legacy フィールドから移行する（冪等）。
+export function coerceItem(x: unknown): BenefitItemV2 | null {
+  if (!x || typeof x !== "object") return null;
+  const obj = x as Record<string, unknown>;
   const nowIso = new Date().toISOString();
 
-  return raw
-    .map((x) => {
-      if (!x || typeof x !== "object") return null;
-      const obj = x as Record<string, unknown>;
+  const id = typeof obj.id === "string" && obj.id.trim() ? obj.id : safeUUID();
+  const title = (typeof obj.title === "string" ? obj.title : "").trim();
+  const company = (typeof obj.company === "string" ? obj.company : "").trim();
 
-      const id =
-        typeof obj.id === "string" && obj.id.trim() ? obj.id : safeUUID();
+  // V2(expiresOn) 優先、旧 v1(expiresAt) フォールバック
+  const expiresOn =
+    normalizeDate(obj.expiresOn) ?? normalizeDate(obj.expiresAt);
 
-      const title = typeof obj.title === "string" ? obj.title : "";
-      const company = typeof obj.company === "string" ? obj.company : "";
+  const wasUsed = obj.isUsed === true;
 
-      // V2(expiresOn) を優先し、旧 v1(expiresAt) にフォールバック
-      const expiresOn =
-        normalizeDate(obj.expiresOn) ?? normalizeDate(obj.expiresAt);
+  // legacy 数値
+  const legacyQty = coerceNumber(obj.quantity);
+  const legacyAmount = coerceNumber(obj.amountYen) ?? coerceNumber(obj.amount);
 
-      const isUsed = typeof obj.isUsed === "boolean" ? obj.isUsed : false;
+  const trackMode: TrackMode = obj.trackMode === "amount" ? "amount" : "count";
 
-      const quantity = coerceNumber(obj.quantity);
+  let unitYen: number | null;
+  let initial: number | null;
+  let remaining: number | null;
 
-      // V2(amountYen) を優先し、旧 v1(amount: "¥1,000" 等) にフォールバック
-      const amountYen =
-        coerceNumber(obj.amountYen) ?? coerceNumber(obj.amount);
+  if (trackMode === "amount") {
+    unitYen = null;
+    initial = coerceNumber(obj.initial) ?? legacyAmount ?? null;
+    remaining =
+      coerceNumber(obj.remaining) ?? (wasUsed ? 0 : initial);
+  } else {
+    unitYen = coerceNumber(obj.unitYen) ?? legacyAmount ?? null;
+    // 単発クーポン（数量なし）は 1 個として扱う
+    initial = coerceNumber(obj.initial) ?? legacyQty ?? (wasUsed ? 0 : 1);
+    remaining =
+      coerceNumber(obj.remaining) ?? (wasUsed ? 0 : initial);
+  }
 
-      // V2(memo) を優先し、旧 v1(note) にフォールバック
-      const memo =
-        typeof obj.memo === "string"
-          ? obj.memo
-          : typeof obj.note === "string"
-          ? obj.note
-          : "";
+  if (remaining != null && remaining < 0) remaining = 0;
+  const isUsed = remaining != null ? remaining <= 0 : wasUsed;
 
-      const createdAt =
-        typeof obj.createdAt === "string" && obj.createdAt
-          ? obj.createdAt
-          : nowIso;
+  const memo =
+    typeof obj.memo === "string"
+      ? obj.memo
+      : typeof obj.note === "string"
+      ? obj.note
+      : "";
 
-      const updatedAt =
-        typeof obj.updatedAt === "string" && obj.updatedAt
-          ? obj.updatedAt
-          : nowIso;
+  const link =
+    typeof obj.link === "string"
+      ? obj.link
+      : typeof obj.url === "string"
+      ? obj.url
+      : "";
 
-      const link =
-        typeof obj.link === "string"
-          ? obj.link
-          : typeof obj.url === "string"
-          ? obj.url
-          : "";
+  const createdAt =
+    typeof obj.createdAt === "string" && obj.createdAt
+      ? obj.createdAt
+      : nowIso;
+  const updatedAt =
+    typeof obj.updatedAt === "string" && obj.updatedAt
+      ? obj.updatedAt
+      : nowIso;
 
-      return {
-        id,
-        title: title.trim(),
-        company: company.trim(),
-        expiresOn: expiresOn && expiresOn.trim() ? expiresOn.trim() : null,
-        isUsed,
-        quantity: quantity ?? null,
-        amountYen: amountYen ?? null,
-        memo: memo?.toString() ?? "",
-        link: link.trim() ? link.trim() : undefined,
-        createdAt,
-        updatedAt,
-      } satisfies BenefitItemV2;
-    })
-    .filter(Boolean) as BenefitItemV2[];
+  return {
+    id,
+    title,
+    company,
+    expiresOn: expiresOn && expiresOn.trim() ? expiresOn.trim() : null,
+    isUsed,
+    trackMode,
+    unitYen,
+    initial,
+    remaining,
+    history: normalizeHistory(obj.history),
+    memo: memo?.toString() ?? "",
+    link: link.trim() ? link.trim() : undefined,
+    createdAt,
+    updatedAt,
+  } satisfies BenefitItemV2;
+}
+
+export function normalizeLegacyToV2(raw: unknown): BenefitItemV2[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map(coerceItem).filter(Boolean) as BenefitItemV2[];
+}
+
+// ---- 消費モデル: 派生値と操作（純関数） ----
+
+// 未使用相当の金額価値（count: 残数×額面 / amount: 残円）
+export function itemValueYen(it: BenefitItemV2): number {
+  const rem = it.remaining ?? 0;
+  if (it.trackMode === "amount") return Math.max(0, rem);
+  return Math.max(0, rem) * (it.unitYen ?? 0);
+}
+
+function touch(it: BenefitItemV2, entry: UsageEntry): BenefitItemV2 {
+  const nowIso = new Date().toISOString();
+  const remaining =
+    it.remaining == null ? it.remaining : Math.max(0, it.remaining);
+  return {
+    ...it,
+    remaining,
+    isUsed: remaining != null ? remaining <= 0 : it.isUsed,
+    history: [...it.history, { ...entry, at: entry.at || nowIso }],
+    updatedAt: nowIso,
+  };
+}
+
+// 使う（amount は deltaYen、count は deltaQty）。残はマイナスにしない。
+export function consume(
+  it: BenefitItemV2,
+  amount: number,
+  note?: string
+): BenefitItemV2 {
+  if (!(amount > 0)) return it;
+  const cur = it.remaining ?? 0;
+  const used = Math.min(cur, amount);
+  if (used <= 0) return it;
+  const next: BenefitItemV2 = { ...it, remaining: cur - used };
+  return touch(
+    next,
+    it.trackMode === "amount"
+      ? { at: "", deltaYen: -used, note }
+      : { at: "", deltaQty: -used, note }
+  );
+}
+
+// 追加（補充 / チャージ）
+export function restock(
+  it: BenefitItemV2,
+  amount: number,
+  note?: string
+): BenefitItemV2 {
+  if (!(amount > 0)) return it;
+  const next: BenefitItemV2 = { ...it, remaining: (it.remaining ?? 0) + amount };
+  return touch(
+    next,
+    it.trackMode === "amount"
+      ? { at: "", deltaYen: amount, note }
+      : { at: "", deltaQty: amount, note }
+  );
+}
+
+// 使用済みトグル（全消費 / 復元）
+export function setUsedAll(it: BenefitItemV2, used: boolean): BenefitItemV2 {
+  if (used) {
+    const cur = it.remaining ?? 0;
+    if (cur <= 0) return { ...it, isUsed: true };
+    return consume(it, cur, "全部使用");
+  }
+  const back = it.initial ?? 1;
+  const next: BenefitItemV2 = { ...it, remaining: back };
+  return touch(
+    next,
+    it.trackMode === "amount"
+      ? { at: "", deltaYen: back - (it.remaining ?? 0), note: "未使用に戻す" }
+      : { at: "", deltaQty: back - (it.remaining ?? 0), note: "未使用に戻す" }
+  );
 }
 
 // 5) load/save (任意：今は未使用でもOK)
@@ -205,7 +332,10 @@ export function getBenefitsSnapshot(): BenefitItemV2[] {
 
   try {
     const parsed = JSON.parse(raw);
-    cacheParsed = Array.isArray(parsed) ? parsed : EMPTY_ITEMS;
+    // 旧 v2（消費フィールド無し）も読み込み時に移行して形を揃える
+    cacheParsed = Array.isArray(parsed)
+      ? (parsed.map(coerceItem).filter(Boolean) as BenefitItemV2[])
+      : EMPTY_ITEMS;
   } catch {
     cacheParsed = EMPTY_ITEMS;
   }

--- a/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
+++ b/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
@@ -94,31 +94,67 @@ export default function EditBenefitDialog({
             />
           </label>
 
-          <div className={styles.row2}>
-            <label className={styles.field}>
-              <span>数量</span>
-              <input
-                value={draft.quantity}
-                onChange={(e) =>
-                  setDraft({ ...draft, quantity: e.target.value })
-                }
-                placeholder="例：2"
-                inputMode="numeric"
-              />
-            </label>
+          <div className={styles.field}>
+            <span>管理方法</span>
+            <div className={styles.tabs}>
+              <button
+                type="button"
+                className={`${styles.tabBtn} ${
+                  draft.trackMode === "count" ? styles.tabActive : ""
+                }`}
+                onClick={() => setDraft({ ...draft, trackMode: "count" })}
+              >
+                枚数（券・複数枚）
+              </button>
+              <button
+                type="button"
+                className={`${styles.tabBtn} ${
+                  draft.trackMode === "amount" ? styles.tabActive : ""
+                }`}
+                onClick={() => setDraft({ ...draft, trackMode: "amount" })}
+              >
+                金額（残高・ポイント）
+              </button>
+            </div>
+          </div>
 
+          {draft.trackMode === "count" ? (
+            <div className={styles.row2}>
+              <label className={styles.field}>
+                <span>枚数 *</span>
+                <input
+                  value={draft.qty}
+                  onChange={(e) => setDraft({ ...draft, qty: e.target.value })}
+                  placeholder="例：3"
+                  inputMode="numeric"
+                />
+              </label>
+
+              <label className={styles.field}>
+                <span>1枚あたり額面（任意）</span>
+                <input
+                  value={draft.unitYen}
+                  onChange={(e) =>
+                    setDraft({ ...draft, unitYen: e.target.value })
+                  }
+                  placeholder="例：1000"
+                  inputMode="numeric"
+                />
+              </label>
+            </div>
+          ) : (
             <label className={styles.field}>
-              <span>金額</span>
+              <span>残高（円）*</span>
               <input
-                value={draft.amountYen}
+                value={draft.balanceYen}
                 onChange={(e) =>
-                  setDraft({ ...draft, amountYen: e.target.value })
+                  setDraft({ ...draft, balanceYen: e.target.value })
                 }
                 placeholder="例：1000"
                 inputMode="numeric"
               />
             </label>
-          </div>
+          )}
 
           <label className={styles.field}>
             <span>メモ</span>
@@ -128,15 +164,6 @@ export default function EditBenefitDialog({
               placeholder="使える店舗 / 条件 / 期限の補足など"
               rows={3}
             />
-          </label>
-
-          <label className={styles.checkboxRow}>
-            <input
-              type="checkbox"
-              checked={draft.isUsed}
-              onChange={(e) => setDraft({ ...draft, isUsed: e.target.checked })}
-            />
-            <span>使用済みにする</span>
           </label>
         </div>
 

--- a/docs/decision-log/2026-05-20-yutai-expiry-consumption-model.md
+++ b/docs/decision-log/2026-05-20-yutai-expiry-consumption-model.md
@@ -1,0 +1,61 @@
+# 2026-05-20 優待期限台帳 消費モデル（枚数/金額・履歴）
+
+## 背景
+
+- 対象 tool: 優待期限台帳 `/tools/yutai-expiry`
+- これまで `isUsed`（全消費 bool）のみで、QUOカードのように「複数枚を1枚ずつ使う」「部分的に残額が残る」「あとで追加でもらう」を表現できなかった。
+- ユーザー要望: ケースバイケース。割り切り（枚数）でもやり切り（金額残高）でも対応したい。簡易履歴も欲しい。
+- 関連: [2026-05-19 優待期限台帳 UI と入出力データ方針](./2026-05-19-yutai-expiry-ui-and-data-policy.md)
+
+## 今回決めたこと
+
+### データモデル（`BenefitItemV2` に optional 追加・後方互換）
+- `trackMode: "count" | "amount"`（既定 `count`）
+- `unitYen: number | null`（count: 1枚あたり額面 / amount: 未使用）
+- `initial: number | null`（初期値の基準）
+- `remaining: number | null`（count: 残枚数 / amount: 残円）
+- `history: UsageEntry[]`（`{ at, deltaQty?, deltaYen?, note? }`）
+- `isUsed` は廃止せず **`remaining <= 0` の派生**として常に同期。既存フィルタ/ソートの互換を保つ。
+- 旧 `quantity`/`amountYen` は legacy 入力としてのみ読む（今後は書かない）。
+
+### 移行ルール（normalize / 旧 v2 補完の双方）
+- `trackMode` = `obj.trackMode === "amount" ? "amount" : "count"`
+- count: `unitYen = obj.unitYen ?? amountYen ?? amount`、`initial = obj.initial ?? quantity ?? (isUsed?0:1)`、`remaining = obj.remaining ?? (isUsed?0:initial)`
+- amount: `initial = obj.initial ?? amountYen ?? amount`、`remaining = obj.remaining ?? (isUsed?0:initial)`、`unitYen=null`
+- 単発クーポン（quantity 無し）は count・initial=1 として扱う。
+- `normalizeLegacyToV2` に新フィールドのフォールバックを追加し、**エクスポート往復で保持**（前回方針と一貫）。
+
+### 操作（純関数で item を返す）
+- `consume(item, amount, note)`：残から減算（負にしない）、履歴追記、`isUsed` 再計算
+- `restock(item, amount, note)`：残に加算、履歴追記
+- `setUsedAll(item, used)`：使用済みトグル＝ remaining を 0 or initial に、履歴追記
+
+### UI
+- 追加/編集ダイアログに「管理方法」トグル（枚数/金額）。枚数→枚数＋1枚あたり額面(任意)、金額→残高(円)。
+- カード/行：`残3枚 ¥1,000（合計¥3,000）` / `残高 ¥700`。`[使う▾]`（1枚/枚数指定/全部、金額は額入力）, `[＋追加]`, 編集, 削除。
+- 簡易履歴：折りたたみ表示（日時・増減・自動メモ）。
+- 統計に「未使用合計額」「今月失効する金額」を追加。
+
+## 判断理由
+
+- 単一プリミティブに寄せきると QUO 部分消費を失う／金額固定だと枚数管理が煩雑。**item ごとに count/amount を選ぶ二択**が、割り切りとやり切りを同一の器（履歴・統計・移行）で両立できる最小設計。
+- `isUsed` を派生で残すことで、既存の `showUsed`・タブ・ソートを作り直さずに済む（手戻り最小）。
+- 履歴は `UsageEntry` の単純配列に限定（バックエンド無し・localStorage 前提のため軽量に割り切り）。
+
+## 影響範囲
+
+- `app/tools/yutai-expiry/benefits/store.ts`（型・migrate・normalize・consume/restock/setUsedAll・value 計算）
+- `app/tools/yutai-expiry/ToolClient.tsx`（統計、カード/テーブル表示、操作、履歴、ダイアログ連携）
+- `app/tools/yutai-expiry/components/EditBenefitDialog.tsx`（管理方法トグル・入力）
+- 互換性: 旧 v1 / 旧 v2 / 旧エクスポート JSON はすべて移行ルールで取り込み（破壊的変更なし）。
+
+## 残課題
+
+- レガシー自動移行 `loadFromLocalStorage` 未接続は本件スコープ外（前回 decision-log の残課題のまま）。
+- 履歴の編集/取り消し UI は今回入れない（追記のみ）。必要なら後続。
+
+## 関連
+
+- Issue: なし
+- PR: 本 PR
+- 参照 docs: [2026-05-19 UI と入出力データ方針](./2026-05-19-yutai-expiry-ui-and-data-policy.md) / [docs-writing-workflow](../docs-writing-workflow.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 - [2026-05-06 ペンギン・エイリアンシューター 敵キャラクター変更](./decision-log/2026-05-06-penguin-alien-enemy-visual.md)
 - [2026-05-16 TDNET適時開示一覧の初期実装方針](./decision-log/2026-05-16-tdnet-disclosures-page.md)
 - [2026-05-19 優待期限台帳 UI と入出力データ方針](./decision-log/2026-05-19-yutai-expiry-ui-and-data-policy.md)
+- [2026-05-20 優待期限台帳 消費モデル（枚数/金額・履歴）](./decision-log/2026-05-20-yutai-expiry-consumption-model.md)
 - [2026-05-09 ペンギンシューター豪華版・新技術トライアル方針](./decision-log/2026-05-09-penguin-shooter-rich-game-trial.md)
 - [2026-05-09 ペンギンシューター 100小ステージデータ構造](./decision-log/2026-05-09-penguin-shooter-stage-data-structure.md)
 - [2026-05-09 ペンギンシューター ボス設計とPR8凍結](./decision-log/2026-05-09-penguin-shooter-boss-design-and-pr8-freeze.md)


### PR DESCRIPTION
## 概要

QUO カード等の「複数枚」「1枚ずつ使う」「残額が残る」「後で追加でもらう」を扱えるよう、消費モデルを `count`（枚数型）と `amount`（金額残高型）の二択に拡張。簡易履歴と金額集計も追加。設計は [decision-log 2026-05-20](../blob/main/docs/decision-log/2026-05-20-yutai-expiry-consumption-model.md) に固定。

## 変更内容

### データモデル（後方互換 optional 追加）
- `trackMode: "count" | "amount"`、`unitYen`、`initial`、`remaining`、`history: UsageEntry[]`
- `isUsed` は `remaining <= 0` の派生として同期（既存フィルタ/ソート互換）
- `coerceItem` で旧 v1 / 旧 v2 / 新 v2 / エクスポート JSON を**冪等に移行**

### 操作（純関数）
- `consume(item, amount)` / `restock(item, amount)` / `setUsedAll(item, used)` / `itemValueYen(item)`
- 履歴に日時・増減・自動メモを追記

### UI
- 追加/編集に「管理方法（枚数/金額）」トグル、モード別入力
- 一覧（カード/テーブル）に残量表示と「**1枚使う / 使う… / ＋追加 / 全部使う / 編集 / 削除**」
- 履歴は折りたたみ表示
- 統計に「**未使用合計額**」「**今月失効する金額**」を追加、auto-fit グリッドで5枚に再配置

## 確認項目
- `npm run lint` パス
- `tsc --noEmit` で yutai-expiry にエラーなし
- 動作確認（要実機）: 既存 localStorage の自動移行、枚数/金額モードの追加・編集、1枚/任意量の使用、＋追加、履歴表示、合計額の計算、エクスポート→インポート往復

## 関連
- [docs/decision-log/2026-05-20-yutai-expiry-consumption-model.md](../tree/feature/yutai-expiry-consumption-model/docs/decision-log/2026-05-20-yutai-expiry-consumption-model.md)
- 前提: PR #307（UI整合とデータ消失修正、merged）
