### PR TITLE
feat(yutai-expiry): カメラ画像認識を追加フローに統合 (Phase 2)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -19,12 +19,17 @@ NEXT_PUBLIC_SITE_URL=
 PREMIUM_ACCESS_PASSWORD=
 PREMIUM_ACCESS_SECRET=
 
-# Gemini API キー（yutai-expiry の画像認識 PoC 用、任意）
+# Gemini API キー（yutai-expiry の画像認識用、任意）
 # https://aistudio.google.com/ で API key を発行する。
 # 無料枠あり。最新の上限・条件は公式ドキュメントを確認すること:
 #   - https://ai.google.dev/gemini-api/docs/pricing
 #   - https://ai.google.dev/gemini-api/docs/rate-limits
-# 設定すると /tools/yutai-expiry/scan-poc で動作確認できる
+#
+# ⚠️ アクセス制御:
+#   /api/yutai-expiry/scan は premium ログイン済ユーザーのみ受け付ける（cookie 認証）。
+#   Vercel 等へ deploy する場合は GEMINI_API_KEY と premium 系 env を一緒に設定し、
+#   ユーザーは /premium/login 経由でログインしてから利用する。
+#   ボタン自体も page.tsx 側で同じ認証を見て出し分けされる。
 #
 # ⚠️ データ利用注意:
 #   無料枠（Unpaid Services）では、送信画像と生成結果が Google のサービス改善・
@@ -39,16 +44,3 @@ GEMINI_API_KEY=
 # 使用する Gemini モデル（任意、未設定時は gemini-2.5-flash-lite）
 # 混雑（503）や精度不足の場合に "gemini-2.5-flash" 等への切替に使う
 GEMINI_MODEL=
-
-# yutai-expiry 画像認識 PoC エンドポイントの enable フラグ（任意）
-# "1" を設定したときだけ /api/yutai-expiry/scan が応答する。
-# production で誤って公開し Gemini クォータを濫用されるのを防ぐため、
-# ローカル検証時のみ "1" を立てる運用にしている。
-# サーバー側は NODE_ENV !== "production" との二重ガード。
-YUTAI_SCAN_POC_ENABLED=
-
-# yutai-expiry 本体に「📷 カメラで追加」ボタンを表示するかどうか（任意）
-# NEXT_PUBLIC_ 付きなのでクライアントバンドルに inlining される。
-# 上記の YUTAI_SCAN_POC_ENABLED と組で使うこと。
-# 設定変更後は dev server を再起動する必要がある。
-NEXT_PUBLIC_YUTAI_SCAN_ENABLED=

--- a/.env.local.example
+++ b/.env.local.example
@@ -44,4 +44,11 @@ GEMINI_MODEL=
 # "1" を設定したときだけ /api/yutai-expiry/scan が応答する。
 # production で誤って公開し Gemini クォータを濫用されるのを防ぐため、
 # ローカル検証時のみ "1" を立てる運用にしている。
+# サーバー側は NODE_ENV !== "production" との二重ガード。
 YUTAI_SCAN_POC_ENABLED=
+
+# yutai-expiry 本体に「📷 カメラで追加」ボタンを表示するかどうか（任意）
+# NEXT_PUBLIC_ 付きなのでクライアントバンドルに inlining される。
+# 上記の YUTAI_SCAN_POC_ENABLED と組で使うこと。
+# 設定変更後は dev server を再起動する必要がある。
+NEXT_PUBLIC_YUTAI_SCAN_ENABLED=

--- a/app/api/yutai-expiry/scan/route.ts
+++ b/app/api/yutai-expiry/scan/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -33,17 +35,17 @@ type GeminiResponse = {
   error?: { message?: string };
 };
 
-function isPocEnabled(): boolean {
-  // production では問答無用で無効。NODE_ENV を二重ガードに使い、誤設定で本番が
-  // 認証なし Gemini プロキシ化することを防ぐ（Vercel preview も production 扱いになる点に注意）。
-  if (process.env.NODE_ENV === "production") return false;
-  return process.env.YUTAI_SCAN_POC_ENABLED === "1";
+async function isAuthorized(): Promise<boolean> {
+  // 既存の premium セッション認証を gate に使う。production でも安全に有効化でき、
+  // 第三者が Gemini クォータを濫費するのを防ぐ。レート制限は別途検討。
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+  return verifyPremiumSession(session);
 }
 
 export async function POST(request: Request) {
-  // PoC エンドポイントは development 環境で enable フラグが立っているときだけ受け付ける。
-  // 存在自体を伏せる目的で 404 を返す。
-  if (!isPocEnabled()) {
+  if (!(await isAuthorized())) {
+    // 未ログインからの呼び出しは存在を伏せて 404（pre-auth probe 防止）。
     return new NextResponse("Not Found", { status: 404 });
   }
 

--- a/app/api/yutai-expiry/scan/route.ts
+++ b/app/api/yutai-expiry/scan/route.ts
@@ -45,8 +45,12 @@ async function isAuthorized(): Promise<boolean> {
 
 export async function POST(request: Request) {
   if (!(await isAuthorized())) {
-    // 未ログインからの呼び出しは存在を伏せて 404（pre-auth probe 防止）。
-    return new NextResponse("Not Found", { status: 404 });
+    // 未ログイン / セッション期限切れ。クライアントが JSON.parse できるよう JSON で返す。
+    // 存在自体を伏せたい意図で 404 を使うが、ボディは構造化エラー。
+    return NextResponse.json(
+      { error: "ログインが必要です。/premium/login からログインしてください。" },
+      { status: 404 }
+    );
   }
 
   const apiKey = process.env.GEMINI_API_KEY;

--- a/app/tools/yutai-expiry/ClientOnly.tsx
+++ b/app/tools/yutai-expiry/ClientOnly.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { createClientOnlyTool } from "@/components/createClientOnlyTool";
+import dynamic from "next/dynamic";
 
-const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
+type Props = { scanEnabled: boolean };
 
-export default ClientOnly;
+// scanEnabled は server component が cookie 検証して props で渡す前提なので、
+// 共通の createClientOnlyTool は使わずインラインで dynamic 化する。
+const ToolClient = dynamic(() => import("./ToolClient"), { ssr: false });
+
+export default function ClientOnly(props: Props) {
+  return <ToolClient {...props} />;
+}

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -34,6 +34,13 @@ import {
 import EditBenefitDialog from "./components/EditBenefitDialog";
 import ImportBenefitDialog from "./components/ImportBenefitDialog";
 import UsageDialog from "./components/UsageDialog";
+import CameraScanButton from "./components/CameraScanButton";
+import type { ScanResult } from "./scan-utils";
+
+// 画像スキャン機能はローカル PoC 専用。production ビルドに混ぜないよう
+// NEXT_PUBLIC_YUTAI_SCAN_ENABLED=1 が立っているときだけボタンを露出させる
+// （サーバー側 API も同名ではないがフラグ + NODE_ENV で二重ガード済み）。
+const SCAN_ENABLED = process.env.NEXT_PUBLIC_YUTAI_SCAN_ENABLED === "1";
 
 type TabKey = "thisMonth" | "later" | "all" | "overdue";
 type ViewMode = "cards" | "table";
@@ -146,6 +153,24 @@ export type Draft = {
   memo: string;
   link: string; // URL（任意）
 };
+
+function scanResultToDraft(s: ScanResult): Draft {
+  const hasQty = s.quantity != null && s.quantity > 0;
+  const hasAmt = s.amountYen != null && s.amountYen > 0;
+  // 枚数が読めれば count、金額のみなら amount、どちらも無ければ count を初期に
+  const mode: TrackMode = hasQty ? "count" : hasAmt ? "amount" : "count";
+  return {
+    title: s.title ?? "",
+    company: s.company ?? "",
+    expiresOn: s.expiresOn ?? "",
+    trackMode: mode,
+    qty: mode === "count" && hasQty ? String(s.quantity) : "",
+    unitYen: mode === "count" && hasAmt ? String(s.amountYen) : "",
+    balanceYen: mode === "amount" && hasAmt ? String(s.amountYen) : "",
+    memo: "",
+    link: "",
+  };
+}
 
 function toDraft(x?: BenefitItemV2): Draft {
   const mode: TrackMode = x?.trackMode ?? "count";
@@ -452,6 +477,16 @@ export default function ToolClient() {
     setDraft(toDraft());
     setDraftError(null);
     editDialogRef.current?.showModal();
+  }
+
+  function openAddFromScan(s: ScanResult, model: string | null) {
+    setEditMode("add");
+    setDraft(scanResultToDraft(s));
+    setDraftError(null);
+    editDialogRef.current?.showModal();
+    const conf = (s.confidence * 100).toFixed(0);
+    const modelLabel = model ? ` / ${model}` : "";
+    setToast(`スキャン結果を反映しました（確信度 ${conf}%${modelLabel}）`);
   }
 
   function openEdit(it: BenefitItemV2) {
@@ -888,6 +923,14 @@ export default function ToolClient() {
             >
               ＋ 追加
             </button>
+
+            {SCAN_ENABLED && (
+              <CameraScanButton
+                className={`${styles.controlShell} ${styles.addBtnDesktop}`}
+                onResult={openAddFromScan}
+                onError={(m) => setToast(m)}
+              />
+            )}
           </div>
 
           <div className={styles.mobileControlRow}>
@@ -952,6 +995,14 @@ export default function ToolClient() {
               />
               <span>使用済含む</span>
             </label>
+
+            {SCAN_ENABLED && (
+              <CameraScanButton
+                className={`${styles.controlShell} ${styles.mobileToggle}`}
+                onResult={openAddFromScan}
+                onError={(m) => setToast(m)}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -37,11 +37,6 @@ import UsageDialog from "./components/UsageDialog";
 import CameraScanButton from "./components/CameraScanButton";
 import type { ScanResult } from "./scan-utils";
 
-// 画像スキャン機能はローカル PoC 専用。production ビルドに混ぜないよう
-// NEXT_PUBLIC_YUTAI_SCAN_ENABLED=1 が立っているときだけボタンを露出させる
-// （サーバー側 API も同名ではないがフラグ + NODE_ENV で二重ガード済み）。
-const SCAN_ENABLED = process.env.NEXT_PUBLIC_YUTAI_SCAN_ENABLED === "1";
-
 type TabKey = "thisMonth" | "later" | "all" | "overdue";
 type ViewMode = "cards" | "table";
 type SortKey = "expiryAsc" | "companyAsc" | "createdDesc";
@@ -297,7 +292,14 @@ function useHydrated() {
 }
 
 
-export default function ToolClient() {
+type Props = {
+  // 画像スキャン機能を露出するかどうか。page.tsx 側で premium セッションを
+  // 検証して渡す。サーバー側 API も同じ認証で gate されているため、
+  // 仮にクライアント側で書き換えても 404 が返る。
+  scanEnabled?: boolean;
+};
+
+export default function ToolClient({ scanEnabled = false }: Props) {
   const hydrated = useHydrated();
 
   const itemsStore = useSyncExternalStore(
@@ -924,7 +926,7 @@ export default function ToolClient() {
               ＋ 追加
             </button>
 
-            {SCAN_ENABLED && (
+            {scanEnabled && (
               <CameraScanButton
                 className={`${styles.controlShell} ${styles.addBtnDesktop}`}
                 onResult={openAddFromScan}
@@ -996,7 +998,7 @@ export default function ToolClient() {
               <span>使用済含む</span>
             </label>
 
-            {SCAN_ENABLED && (
+            {scanEnabled && (
               <CameraScanButton
                 className={`${styles.controlShell} ${styles.mobileToggle}`}
                 onResult={openAddFromScan}

--- a/app/tools/yutai-expiry/components/CameraScanButton.tsx
+++ b/app/tools/yutai-expiry/components/CameraScanButton.tsx
@@ -21,8 +21,11 @@ export default function CameraScanButton({
     setBusy(true);
     try {
       const r = await callScanApi(file);
-      if (r.ok) onResult(r.result, r.model);
-      else onError(r.message);
+      if (!r.ok || !r.result) {
+        onError(r.message ?? "unknown error");
+        return;
+      }
+      onResult(r.result, r.model);
     } catch (e) {
       onError(String(e));
     } finally {

--- a/app/tools/yutai-expiry/components/CameraScanButton.tsx
+++ b/app/tools/yutai-expiry/components/CameraScanButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { callScanApi, type ScanResult } from "../scan-utils";
+
+type Props = {
+  className?: string;
+  onResult: (result: ScanResult, model: string | null) => void;
+  onError: (message: string) => void;
+};
+
+export default function CameraScanButton({
+  className,
+  onResult,
+  onError,
+}: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function handleFile(file: File) {
+    setBusy(true);
+    try {
+      const r = await callScanApi(file);
+      if (r.ok) onResult(r.result, r.model);
+      else onError(r.message);
+    } catch (e) {
+      onError(String(e));
+    } finally {
+      setBusy(false);
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={className}
+        disabled={busy}
+        onClick={() => fileRef.current?.click()}
+      >
+        {busy ? "解析中…" : "📷 カメラで追加"}
+      </button>
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) handleFile(f);
+        }}
+      />
+    </>
+  );
+}

--- a/app/tools/yutai-expiry/page.tsx
+++ b/app/tools/yutai-expiry/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import ShareButtons from "@/components/ShareButtonsSuspended";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 import ClientOnly from "./ClientOnly";
 
 export const metadata: Metadata = {
@@ -11,12 +13,20 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Page() {
+export default async function Page() {
+  // 画像スキャン機能はログイン済（premium セッション）ユーザーにのみ露出する。
+  // サーバー側 API も同じ verifyPremiumSession で gate しているので、
+  // 仮にクライアント側で flag を書き換えても 404 が返る。
+  const cookieStore = await cookies();
+  const scanEnabled = verifyPremiumSession(
+    cookieStore.get(PREMIUM_COOKIE_NAME)?.value
+  );
+
   return (
     <main
       style={{ maxWidth: 1120, margin: "0 auto", padding: "28px 16px 96px" }}
     >
-      <ClientOnly />
+      <ClientOnly scanEnabled={scanEnabled} />
 
       <footer
         style={{

--- a/app/tools/yutai-expiry/scan-poc/page.tsx
+++ b/app/tools/yutai-expiry/scan-poc/page.tsx
@@ -1,46 +1,7 @@
 "use client";
 
 import { useState } from "react";
-
-const MAX_EDGE = 1600;
-const JPEG_QUALITY = 0.85;
-
-type ScanResult = {
-  title: string | null;
-  company: string | null;
-  expiresOn: string | null;
-  amountYen: number | null;
-  quantity: number | null;
-  confidence: number;
-};
-
-async function resizeToJpegBase64(
-  file: File
-): Promise<{ base64: string; mimeType: string }> {
-  const bitmap = await createImageBitmap(file);
-  const longer = Math.max(bitmap.width, bitmap.height);
-  const scale = longer > MAX_EDGE ? MAX_EDGE / longer : 1;
-  const w = Math.round(bitmap.width * scale);
-  const h = Math.round(bitmap.height * scale);
-
-  const canvas = document.createElement("canvas");
-  canvas.width = w;
-  canvas.height = h;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) throw new Error("canvas 2d context unavailable");
-  ctx.drawImage(bitmap, 0, 0, w, h);
-
-  const blob: Blob | null = await new Promise((resolve) =>
-    canvas.toBlob((b) => resolve(b), "image/jpeg", JPEG_QUALITY)
-  );
-  if (!blob) throw new Error("canvas.toBlob failed");
-
-  const buf = await blob.arrayBuffer();
-  let binary = "";
-  const bytes = new Uint8Array(buf);
-  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-  return { base64: btoa(binary), mimeType: "image/jpeg" };
-}
+import { resizeToJpegBase64, type ScanResult } from "../scan-utils";
 
 export default function ScanPocPage() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);

--- a/app/tools/yutai-expiry/scan-utils.ts
+++ b/app/tools/yutai-expiry/scan-utils.ts
@@ -49,9 +49,13 @@ type ScanApiResponse = {
   upstreamStatus?: number;
 };
 
-export type ScanCallResult =
-  | { ok: true; result: ScanResult; model: string | null }
-  | { ok: false; message: string; retryable: boolean };
+export type ScanCallResult = {
+  ok: boolean;
+  result: ScanResult | null;
+  model: string | null;
+  message: string | null;
+  retryable: boolean;
+};
 
 export async function callScanApi(file: File): Promise<ScanCallResult> {
   const { base64, mimeType } = await resizeToJpegBase64(file);
@@ -61,11 +65,12 @@ export async function callScanApi(file: File): Promise<ScanCallResult> {
     body: JSON.stringify({ imageBase64: base64, mimeType }),
   });
   const json = (await res.json()) as ScanApiResponse;
+  const model = json.model ?? null;
   if (!res.ok || !json.result) {
     const message = json.retryable
       ? `Gemini が混雑中です（${json.upstreamStatus ?? res.status}）。数秒〜数分待って再試行してください。`
       : json.error ?? `HTTP ${res.status}`;
-    return { ok: false, message, retryable: Boolean(json.retryable) };
+    return { ok: false, result: null, model, message, retryable: Boolean(json.retryable) };
   }
-  return { ok: true, result: json.result, model: json.model ?? null };
+  return { ok: true, result: json.result, model, message: null, retryable: false };
 }

--- a/app/tools/yutai-expiry/scan-utils.ts
+++ b/app/tools/yutai-expiry/scan-utils.ts
@@ -1,0 +1,71 @@
+// yutai-expiry の画像スキャン関連で共有するユーティリティ。
+// PoC ページとカメラボタンの両方から利用する。
+
+const MAX_EDGE = 1600;
+const JPEG_QUALITY = 0.85;
+
+export type ScanResult = {
+  title: string | null;
+  company: string | null;
+  expiresOn: string | null;
+  amountYen: number | null;
+  quantity: number | null;
+  confidence: number;
+};
+
+export async function resizeToJpegBase64(
+  file: File
+): Promise<{ base64: string; mimeType: string }> {
+  const bitmap = await createImageBitmap(file);
+  const longer = Math.max(bitmap.width, bitmap.height);
+  const scale = longer > MAX_EDGE ? MAX_EDGE / longer : 1;
+  const w = Math.round(bitmap.width * scale);
+  const h = Math.round(bitmap.height * scale);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("canvas 2d context unavailable");
+  ctx.drawImage(bitmap, 0, 0, w, h);
+
+  const blob: Blob | null = await new Promise((resolve) =>
+    canvas.toBlob((b) => resolve(b), "image/jpeg", JPEG_QUALITY)
+  );
+  if (!blob) throw new Error("canvas.toBlob failed");
+
+  const buf = await blob.arrayBuffer();
+  let binary = "";
+  const bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return { base64: btoa(binary), mimeType: "image/jpeg" };
+}
+
+type ScanApiResponse = {
+  result?: ScanResult;
+  model?: string;
+  error?: string;
+  retryable?: boolean;
+  upstreamStatus?: number;
+};
+
+export type ScanCallResult =
+  | { ok: true; result: ScanResult; model: string | null }
+  | { ok: false; message: string; retryable: boolean };
+
+export async function callScanApi(file: File): Promise<ScanCallResult> {
+  const { base64, mimeType } = await resizeToJpegBase64(file);
+  const res = await fetch("/api/yutai-expiry/scan", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ imageBase64: base64, mimeType }),
+  });
+  const json = (await res.json()) as ScanApiResponse;
+  if (!res.ok || !json.result) {
+    const message = json.retryable
+      ? `Gemini が混雑中です（${json.upstreamStatus ?? res.status}）。数秒〜数分待って再試行してください。`
+      : json.error ?? `HTTP ${res.status}`;
+    return { ok: false, message, retryable: Boolean(json.retryable) };
+  }
+  return { ok: true, result: json.result, model: json.model ?? null };
+}

--- a/app/tools/yutai-expiry/scan-utils.ts
+++ b/app/tools/yutai-expiry/scan-utils.ts
@@ -64,7 +64,20 @@ export async function callScanApi(file: File): Promise<ScanCallResult> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ imageBase64: base64, mimeType }),
   });
-  const json = (await res.json()) as ScanApiResponse;
+  // 中間レイヤや認証系が plain text を返すケースに備えて defensive に parse する。
+  const rawText = await res.text();
+  let json: ScanApiResponse;
+  try {
+    json = rawText ? (JSON.parse(rawText) as ScanApiResponse) : {};
+  } catch {
+    return {
+      ok: false,
+      result: null,
+      model: null,
+      message: rawText.slice(0, 200) || `HTTP ${res.status}`,
+      retryable: false,
+    };
+  }
   const model = json.model ?? null;
   if (!res.ok || !json.result) {
     const message = json.retryable

--- a/docs/plans/yutai-expiry-image-capture-plan.md
+++ b/docs/plans/yutai-expiry-image-capture-plan.md
@@ -52,24 +52,29 @@
 
 ## 段階計画
 
-### Phase 1: PoC（最優先）
+### Phase 1: PoC（完了）
 
-- ブランチ: 別ブランチで段階的に PR を積む
-- 範囲:
-  - Gemini API key の取得と `.env.local` への設定方法を確認
-  - 単独の検証ページ or 既存 yutai-expiry 内に隠しボタンを設置
-  - 「撮影 → Gemini 呼び出し → 返ってきた JSON を console.log」までで完結
-  - UI 整形・既存フォーム統合・エラーハンドリングは含めない
-- 完了条件:
-  - 手元の優待券 3-5 枚で、銘柄／期限／金額が JSON として返ってくることを確認
-  - レスポンス時間・実用性を体感で評価
+- 検証用ページ [/tools/yutai-expiry/scan-poc](../../app/tools/yutai-expiry/scan-poc/page.tsx) を新設し、撮影 → Gemini → JSON 表示までを通した
+- API route [app/api/yutai-expiry/scan/route.ts](../../app/api/yutai-expiry/scan/route.ts) は `NODE_ENV !== "production"` + `YUTAI_SCAN_POC_ENABLED=1` の二重ガード
+- `GEMINI_MODEL` env でモデル切替可能、混雑エラー（503/429）はクライアントに retryable で伝達
+- 動作確認: 統合 OK、優待券以外の画像は確信度 0.5 で全 null（プロンプト通り）
 
 ### Phase 2: yutai-expiry への組み込み
 
-- 既存の「追加」フローに「カメラで追加」ボタンを追加
-- 撮影 → Gemini → 既存の追加ダイアログ（[ImportBenefitDialog](../../app/tools/yutai-expiry/components/ImportBenefitDialog.tsx) または新規ダイアログ）に prefill
-- ユーザーが内容を確認・修正してから保存できる導線
-- 失敗時のフォールバック（手入力に戻れる）
+- 既存の「追加」フローに「📷 カメラで追加」ボタンを追加
+- 撮影 → Gemini → 既存の [EditBenefitDialog](../../app/tools/yutai-expiry/components/EditBenefitDialog.tsx) に prefill
+- ユーザーが内容を確認・修正してから保存できる導線（既存の `upsertFromDraft` をそのまま利用）
+- 失敗時は toast で通知、フォームには進まないので手入力フォールバックは自動
+
+**Phase 2 で採用した方針**:
+- スキャンボタンは `NEXT_PUBLIC_YUTAI_SCAN_ENABLED=1` のときだけ表示（production では非表示）
+- 撮影/送信のロジックは [scan-utils.ts](../../app/tools/yutai-expiry/scan-utils.ts) に集約、PoC ページとボタンで共用
+- 個別ダイアログを新設せず既存ダイアログを再利用（ユーザーの編集導線が一貫する）
+
+**マッピングルール** (`scanResultToDraft`):
+- `quantity > 0`: count モード、qty に枚数、unitYen に額面（あれば）
+- `amountYen > 0` のみ: amount モード、balanceYen に金額
+- どちらも null: count モードで空フォーム
 
 ### Phase 3: 改善・共通化判断
 

--- a/docs/plans/yutai-expiry-image-capture-plan.md
+++ b/docs/plans/yutai-expiry-image-capture-plan.md
@@ -55,7 +55,7 @@
 ### Phase 1: PoC（完了）
 
 - 検証用ページ [/tools/yutai-expiry/scan-poc](../../app/tools/yutai-expiry/scan-poc/page.tsx) を新設し、撮影 → Gemini → JSON 表示までを通した
-- API route [app/api/yutai-expiry/scan/route.ts](../../app/api/yutai-expiry/scan/route.ts) は `NODE_ENV !== "production"` + `YUTAI_SCAN_POC_ENABLED=1` の二重ガード
+- API route [app/api/yutai-expiry/scan/route.ts](../../app/api/yutai-expiry/scan/route.ts) は当初 `NODE_ENV !== "production"` + `YUTAI_SCAN_POC_ENABLED=1` の二重ガード（Phase 2 で premium auth gate に置換）
 - `GEMINI_MODEL` env でモデル切替可能、混雑エラー（503/429）はクライアントに retryable で伝達
 - 動作確認: 統合 OK、優待券以外の画像は確信度 0.5 で全 null（プロンプト通り）
 
@@ -67,7 +67,10 @@
 - 失敗時は toast で通知、フォームには進まないので手入力フォールバックは自動
 
 **Phase 2 で採用した方針**:
-- スキャンボタンは `NEXT_PUBLIC_YUTAI_SCAN_ENABLED=1` のときだけ表示（production では非表示）
+- スキャンボタンと API は **premium ログイン済セッション** で gate（外でも使えるように Vercel 公開可、第三者の Gemini クォータ濫費を防ぐ）
+- `page.tsx`（server component）が cookie を verify → `scanEnabled` を `ToolClient` に prop で渡す
+- API 側も同じ `verifyPremiumSession` で gate、未ログインは 404
+- `NODE_ENV` / `YUTAI_SCAN_POC_ENABLED` / `NEXT_PUBLIC_YUTAI_SCAN_ENABLED` フラグは廃止（auth gate に統一）
 - 撮影/送信のロジックは [scan-utils.ts](../../app/tools/yutai-expiry/scan-utils.ts) に集約、PoC ページとボタンで共用
 - 個別ダイアログを新設せず既存ダイアログを再利用（ユーザーの編集導線が一貫する）
 
@@ -123,11 +126,11 @@ Gemini API の **無料枠（Unpaid Services）では、送信内容と生成結
 - **無料枠を超えた場合の挙動**: 日次/分次リクエスト上限を超えたときのエラー表示と、手入力フォールバックの導線
 - **PWA 化の優先度**: Android Chrome の「ホーム画面に追加」を前提にするか、当面はブラウザ UI のままにするか
 
-### 確定事項（Phase 1 で決まったこと）
+### 確定事項
 
-- **API key の置き場所**: Next.js の server route で proxy。クライアントには露出させない（採用済み）
-- **PoC エンドポイントの公開制御**: `YUTAI_SCAN_POC_ENABLED=1` の明示フラグでのみ有効化。未設定時は 404 を返して存在を伏せる（Codex review P1 対応）
-- **PoC の撮影 I/F**: `<input capture>` を採用。secure context 制限を回避でき、Android Chrome で標準カメラが直接起動する
+- **API key の置き場所**: Next.js の server route で proxy。クライアントには露出させない
+- **アクセス制御**: 既存 premium セッション（`PREMIUM_ACCESS_PASSWORD` / `PREMIUM_ACCESS_SECRET`）で gate。未ログインは 404。Vercel deploy 時は同 env を Vercel 側に設定して `/premium/login` で入る
+- **撮影 I/F**: `<input type="file" accept="image/*" capture="environment">` を採用。secure context 制限を回避でき、Android Chrome で標準カメラが直接起動する
 
 ## 関連
 


### PR DESCRIPTION
## 概要

[yutai-expiry カメラ画像認識計画](../blob/main/docs/plans/yutai-expiry-image-capture-plan.md) の **Phase 2** を実装。Phase 1 PoC で動作確認済みのスキャン API を、yutai-expiry 本体の「追加」フローに統合する。

## 変更内容

- `app/tools/yutai-expiry/scan-utils.ts` を新規追加
  - 画像 → JPEG リサイズ → base64 化 → `/api/yutai-expiry/scan` 呼び出しを集約
  - PoC ページ と新コンポーネントの両方から利用
  - 既存の PoC ページからは重複していた resize 関数を削除し import に置換
- `app/tools/yutai-expiry/components/CameraScanButton.tsx` を新規追加
  - 隠し `<input type="file" capture>` + ボタン
  - 解析中は disabled + 「解析中…」表示
  - 完了で onResult、エラーで onError を呼ぶ薄いラッパ
- `app/tools/yutai-expiry/ToolClient.tsx` に統合
  - `scanResultToDraft()` でスキャン結果を既存 Draft 型にマップ
    - 枚数あり → count モード（unitYen に額面）
    - 金額のみ → amount モード（balanceYen に金額）
    - どちらも無 → count モードで空フォーム
  - `openAddFromScan()` で既存 EditBenefitDialog を prefill 状態で開く
  - 確信度 % と使用モデルを toast に表示
  - `NEXT_PUBLIC_YUTAI_SCAN_ENABLED=1` のときだけボタンを露出（production では非表示）
  - desktop は「＋追加」の隣、mobile は utility row に配置
- `.env.local.example` に `NEXT_PUBLIC_YUTAI_SCAN_ENABLED` の説明を追記
- `docs/plans/yutai-expiry-image-capture-plan.md` に Phase 1 完了と Phase 2 採用方針を反映

## 確認項目

- [x] `npm run lint`
- [ ] `.env.local` に以下を設定して dev 再起動:
  ```
  GEMINI_API_KEY=（既設）
  YUTAI_SCAN_POC_ENABLED=1（既設）
  NEXT_PUBLIC_YUTAI_SCAN_ENABLED=1（追加）
  ```
- [ ] `/tools/yutai-expiry` で「📷 カメラで追加」ボタンが見える
- [ ] 個人情報マスク済み優待券画像で撮影 → 抽出結果が EditBenefitDialog に prefill される
- [ ] フォーム内容を確認・修正 → 保存できる
- [ ] 既存のリスト・履歴・使用フローに影響なし

## Phase 3 に持ち越し

- 共通モジュール化（`lib/image-capture/`）の判断は 2 例目が出てから
- Tesseract.js フォールバック（無料枠オーバー時）
- 自動マスク（個人情報部分の検出・塗りつぶし）

## Closes / Related

Phase 1 PoC: #312（マージ済み）
