### PR TITLE
docs: add market info cross references

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 - [横断仕様インデックス](./specs/cross-cutting/index.md)
   - [mini-tools システム構成概要](./specs/cross-cutting/system-architecture-overview.md)
   - [React Server / Client 責任境界](./specs/cross-cutting/react-server-client-boundaries.md)
-  - [Market Tools データ取得経路一覧](./specs/cross-cutting/market-tools-data-fetch-paths.md)
+  - [Market Tools データ取得経路一覧](./specs/cross-cutting/market-tools-data-fetch-paths.md)（market_info / market-info-api への横断参照入口を含む）
   - [QR 共有 URL 仕様](./specs/cross-cutting/share-url-spec.md)
   - [UI カラーパレット仕様](./specs/cross-cutting/ui-color-palette.md)
   - [株価ランキング UI JSON CLI 仕様](./specs/cross-cutting/stock-ranking-ui-json-cli-spec.md)

--- a/docs/specs/cross-cutting/index.md
+++ b/docs/specs/cross-cutting/index.md
@@ -6,7 +6,7 @@
 |---|---|
 | [mini-tools システム構成概要](./system-architecture-overview.md) | アプリ全体の構成、データ取得、保存、外部依存 |
 | [React Server / Client 責任境界](./react-server-client-boundaries.md) | Server Component と Client Component の役割分担 |
-| [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md) | market tools の取得元、fallback、内部 route |
+| [Market Tools データ取得経路一覧](./market-tools-data-fetch-paths.md) | market tools の取得元、fallback、内部 route、market_info / market-info-api への横断参照入口 |
 | [QR 共有 URL 仕様](./share-url-spec.md) | QR / コピー / SNS 共有 URL の生成方針 |
 | [UI カラーパレット仕様](./ui-color-palette.md) | 採用中・候補カラーパレットと CSS 変数 |
 | [株価ランキング UI JSON CLI 仕様](./stock-ranking-ui-json-cli-spec.md) | market_info 側 CLI の入出力 contract |

--- a/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
+++ b/docs/specs/cross-cutting/market-tools-data-fetch-paths.md
@@ -9,6 +9,20 @@
 
 を一覧で把握するための参照用 spec です。
 
+## 横断参照入口
+
+market tools の API 取得経路や fallback を変更する前に、次の docs を確認する。
+
+| 参照先 | 確認すること |
+|---|---|
+| [`market_info/docs/architecture.md`](https://github.com/Yuichi-TanakaJP/market_info/blob/main/docs/architecture.md) | 3 repo 全体のデータフローと関連 docs |
+| [`market_info/docs/reference/policy_decision_rules.md`](https://github.com/Yuichi-TanakaJP/market_info/blob/main/docs/reference/policy_decision_rules.md) | API / publish / UI の責務分担ルール |
+| [`market_info/docs/reference/publish_contract_inventory.md`](https://github.com/Yuichi-TanakaJP/market_info/blob/main/docs/reference/publish_contract_inventory.md) | R2 published family、object path、schema source、compact artifact 候補 |
+| [`market-info-api/docs/api-contract.md`](https://github.com/Yuichi-TanakaJP/market-info-api/blob/main/docs/api-contract.md) | API endpoint、TTL、range/search cache contract、fallback/error contract |
+| [`market-info-api/docs/resource-usage.md`](https://github.com/Yuichi-TanakaJP/market-info-api/blob/main/docs/resource-usage.md) | Cloud Run / R2 の無料枠、現行データサイズ、cache / compact publish 判断材料 |
+
+`mini-tools` は UI state、入力、表示整形、API query construction を担当する。R2 object path や publish timing を UI に直接持ち込まず、`MARKET_INFO_API_BASE_URL` と API contract を入口にする。
+
 ## 前提
 
 - 「サーバー側」は `mini-tools` の Next.js サーバーを指す


### PR DESCRIPTION
## Summary
- Add market_info and market-info-api cross-reference entry points to the market tools fetch-path spec
- Mark the fetch-path spec as the mini-tools-side entry from docs/index.md and the cross-cutting index
- Clarify that mini-tools owns UI state/input/display/API query construction and should use MARKET_INFO_API_BASE_URL rather than R2 internals

## Validation
- git diff --check -- docs/index.md docs/specs/cross-cutting/index.md docs/specs/cross-cutting/market-tools-data-fetch-paths.md
- codex review --uncommitted
