### PR TITLE
fix(premium-login): サーバー未設定エラーを 503 + 黄色アラートで区別表示

### DIFF
--- a/app/api/premium/login/route.ts
+++ b/app/api/premium/login/route.ts
@@ -10,8 +10,11 @@ import {
 export async function POST(request: Request) {
   if (!isPremiumAuthConfigured()) {
     return NextResponse.json(
-      { error: "PREMIUM_ACCESS_PASSWORD / PREMIUM_ACCESS_SECRET が未設定です。" },
-      { status: 500 }
+      {
+        error: "サーバー側で premium 認証が有効化されていません。PREMIUM_ACCESS_PASSWORD / PREMIUM_ACCESS_SECRET を Vercel の環境変数に設定してください。",
+        code: "not_configured",
+      },
+      { status: 503 }
     );
   }
 

--- a/app/premium/login/LoginForm.tsx
+++ b/app/premium/login/LoginForm.tsx
@@ -34,7 +34,7 @@ export default function LoginForm() {
   const nextPath = getSafeNextPath(searchParams.get("next"));
 
   const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string; kind: "auth" | "config" | "network" } | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -52,15 +52,16 @@ export default function LoginForm() {
       });
 
       if (!response.ok) {
-        const data = (await response.json()) as { error?: string };
-        setError(data.error ?? "ログインに失敗しました。");
+        const data = (await response.json()) as { error?: string; code?: string };
+        const kind = data.code === "not_configured" ? "config" : "auth";
+        setError({ message: data.error ?? "ログインに失敗しました。", kind });
         return;
       }
 
       router.push(nextPath);
       router.refresh();
     } catch {
-      setError("通信に失敗しました。時間をおいて再度お試しください。");
+      setError({ message: "通信に失敗しました。時間をおいて再度お試しください。", kind: "network" });
     } finally {
       setIsSubmitting(false);
     }
@@ -104,18 +105,35 @@ export default function LoginForm() {
       />
 
       {error ? (
-        <div
-          style={{
-            borderRadius: 12,
-            background: "#fef2f2",
-            border: "1px solid #fecaca",
-            color: "#991b1b",
-            padding: "10px 12px",
-            fontSize: 13,
-          }}
-        >
-          {error}
-        </div>
+        error.kind === "config" ? (
+          <div
+            style={{
+              borderRadius: 12,
+              background: "#fffbeb",
+              border: "1px solid #fcd34d",
+              color: "#78350f",
+              padding: "12px 14px",
+              fontSize: 13,
+              lineHeight: 1.6,
+            }}
+          >
+            <div style={{ fontWeight: 800, marginBottom: 4 }}>⚙ サーバー設定が未完了</div>
+            <div>{error.message}</div>
+          </div>
+        ) : (
+          <div
+            style={{
+              borderRadius: 12,
+              background: "#fef2f2",
+              border: "1px solid #fecaca",
+              color: "#991b1b",
+              padding: "10px 12px",
+              fontSize: 13,
+            }}
+          >
+            {error.message}
+          </div>
+        )
       ) : null}
 
       <button


### PR DESCRIPTION
## 概要

`/premium/login` で「サーバー側 env 未設定」と「パスワード不一致」が同じ赤エラー枠で出ていて切り分けにくかった問題を修正。

## 変更内容

- `app/api/premium/login/route.ts`
  - 未設定時の status を **500 → 503** (Service Unavailable) に変更
  - response body に `code: 'not_configured'` を追加
  - メッセージを Vercel 環境変数を設定するよう促す表現に書き換え
- `app/premium/login/LoginForm.tsx`
  - error の状態を `{ message, kind: 'auth' | 'config' | 'network' }` 形式に
  - `kind === 'config'` のときだけ **黄色 + ⚙ アイコン付きアラート** で表示

## 確認項目

- [x] `npm run lint` 通過
- [ ] PREMIUM_ACCESS_PASSWORD 未設定の環境で login → 黄色アラート表示
- [ ] パスワード不一致 → 従来通り赤エラー
- [ ] 正しいパスワード → /premium にリダイレクト