### PR TITLE
feat(yutai-expiry): カメラ強制ではなく画像ピッカーに変更

### DIFF
--- a/app/tools/yutai-expiry/components/CameraScanButton.tsx
+++ b/app/tools/yutai-expiry/components/CameraScanButton.tsx
@@ -42,13 +42,12 @@ export default function CameraScanButton({
         disabled={busy}
         onClick={() => fileRef.current?.click()}
       >
-        {busy ? "解析中…" : "📷 カメラで追加"}
+        {busy ? "解析中…" : "🖼️ 画像から追加"}
       </button>
       <input
         ref={fileRef}
         type="file"
         accept="image/*"
-        capture="environment"
         style={{ display: "none" }}
         onChange={(e) => {
           const f = e.target.files?.[0];


### PR DESCRIPTION
## 概要

旧実装は `<input capture=\"environment\">` でモバイルがカメラ直起動し、撮影済み画像をギャラリーから選べなかった。PC では capture が無視されるが、ボタン名が「カメラで追加」のためユーザーが PC でもカメラが起動すると誤解していた。

## 変更内容

- [app/tools/yutai-expiry/components/CameraScanButton.tsx](app/tools/yutai-expiry/components/CameraScanButton.tsx) の `capture=\"environment\"` を削除
- ボタン名を「📷 カメラで追加」→「🖼️ 画像から追加」に変更

## 動作

- **モバイル (Android Chrome / iOS Safari)**: カメラ起動 or ギャラリー選択 のチューザーが出る
- **PC (Chrome on Windows)**: ファイル選択ダイアログ (従来通り、ボタン名と一致)

## 確認項目

- [x] `npm run lint` 通過
- [ ] スマホで「🖼️ 画像から追加」を押すとカメラ/ギャラリーの選択肢が出る
- [ ] PC で「🖼️ 画像から追加」を押すとファイル選択ダイアログが出る
- [ ] 画像選択後、解析 → 下書きに反映される