### PR TITLE
feat(yutai-expiry): scan ボタンを 撮影/画像から選択 の 2 ボタンに分割

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -927,11 +927,20 @@ export default function ToolClient({ scanEnabled = false }: Props) {
             </button>
 
             {scanEnabled && (
-              <CameraScanButton
-                className={`${styles.controlShell} ${styles.addBtnDesktop}`}
-                onResult={openAddFromScan}
-                onError={(m) => setToast(m)}
-              />
+              <>
+                <CameraScanButton
+                  mode="camera"
+                  className={`${styles.controlShell} ${styles.addBtnDesktop}`}
+                  onResult={openAddFromScan}
+                  onError={(m) => setToast(m)}
+                />
+                <CameraScanButton
+                  mode="gallery"
+                  className={`${styles.controlShell} ${styles.addBtnDesktop}`}
+                  onResult={openAddFromScan}
+                  onError={(m) => setToast(m)}
+                />
+              </>
             )}
           </div>
 
@@ -999,11 +1008,20 @@ export default function ToolClient({ scanEnabled = false }: Props) {
             </label>
 
             {scanEnabled && (
-              <CameraScanButton
-                className={`${styles.controlShell} ${styles.mobileToggle}`}
-                onResult={openAddFromScan}
-                onError={(m) => setToast(m)}
-              />
+              <>
+                <CameraScanButton
+                  mode="camera"
+                  className={`${styles.controlShell} ${styles.mobileToggle}`}
+                  onResult={openAddFromScan}
+                  onError={(m) => setToast(m)}
+                />
+                <CameraScanButton
+                  mode="gallery"
+                  className={`${styles.controlShell} ${styles.mobileToggle}`}
+                  onResult={openAddFromScan}
+                  onError={(m) => setToast(m)}
+                />
+              </>
             )}
           </div>
         </div>

--- a/app/tools/yutai-expiry/components/CameraScanButton.tsx
+++ b/app/tools/yutai-expiry/components/CameraScanButton.tsx
@@ -3,13 +3,21 @@
 import { useRef, useState } from "react";
 import { callScanApi, type ScanResult } from "../scan-utils";
 
+type Mode = "camera" | "gallery";
+
 type Props = {
+  /**
+   * camera: capture="environment" を付け、モバイルでカメラ直起動
+   * gallery: capture を付けず、ギャラリー / ファイル選択を開く (PC ではファイル選択ダイアログ)
+   */
+  mode?: Mode;
   className?: string;
   onResult: (result: ScanResult, model: string | null) => void;
   onError: (message: string) => void;
 };
 
 export default function CameraScanButton({
+  mode = "gallery",
   className,
   onResult,
   onError,
@@ -34,6 +42,12 @@ export default function CameraScanButton({
     }
   }
 
+  const label = busy
+    ? "解析中…"
+    : mode === "camera"
+      ? "📷 撮影"
+      : "🖼️ 画像から選択";
+
   return (
     <>
       <button
@@ -42,12 +56,13 @@ export default function CameraScanButton({
         disabled={busy}
         onClick={() => fileRef.current?.click()}
       >
-        {busy ? "解析中…" : "🖼️ 画像から追加"}
+        {label}
       </button>
       <input
         ref={fileRef}
         type="file"
         accept="image/*"
+        {...(mode === "camera" ? { capture: "environment" as const } : {})}
         style={{ display: "none" }}
         onChange={(e) => {
           const f = e.target.files?.[0];


### PR DESCRIPTION
## 概要

スマホで「🖼️ 画像から追加」を押した時に **チューザー (撮影 or ギャラリー) が出ずギャラリーが直接開く** 問題への対応。Android Chrome の OS 側ファイルピッカーは端末依存で、カメラ起動を選べないケースがある。

## 変更内容

- `app/tools/yutai-expiry/components/CameraScanButton.tsx`
  - `mode?: 'camera' | 'gallery'` prop を追加 (default `gallery`)
  - `camera` → `capture=\"environment\"` 付き、ラベル「📷 撮影」
  - `gallery` → capture なし、ラベル「🖼️ 画像から選択」
- `app/tools/yutai-expiry/ToolClient.tsx`: デスクトップ / モバイル両方のレイアウトで 2 ボタン (camera + gallery) を並べる

## 確認項目

- [x] `npm run lint` 通過
- [ ] スマホで「📷 撮影」→ カメラ起動 / 「🖼️ 画像から選択」→ ギャラリー
- [ ] PC では両方ファイル選択ダイアログ (capture は無視されるため)
- [ ] 画像を選んだ後、解析 → 下書き反映が問題なく動く

## 関連

依存: GEMINI_API_KEY を Vercel 本番環境に設定する必要あり (`app/api/yutai-expiry/scan/route.ts`)。本 PR の範囲外。