### PR TITLE
fix(yutai-expiry): 未使用合計額から期限切れを除外＋これまでの失効金額を追加

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -114,6 +114,10 @@ function fmtYen(n: number): string {
   return `¥${Math.round(n).toLocaleString()}`;
 }
 
+function isExpired(it: BenefitItemV2, today: string): boolean {
+  return !!it.expiresOn && it.expiresOn < today;
+}
+
 function remainingText(it: BenefitItemV2): string {
   const rem = it.remaining ?? 0;
   if (it.trackMode === "amount") return `残高 ${fmtYen(rem)}`;
@@ -399,8 +403,7 @@ export default function ToolClient({ scanEnabled = false }: Props) {
       }
 
       if (tab === "overdue") {
-        if (!it.expiresOn) return false;
-        return it.expiresOn < today;
+        return isExpired(it, today);
       }
 
       // all
@@ -447,11 +450,7 @@ export default function ToolClient({ scanEnabled = false }: Props) {
 
   const overdueCount = useMemo(() => {
     const today = todayISODate();
-    return items.filter((it) => {
-      if (it.isUsed) return false;
-      if (!it.expiresOn) return false;
-      return it.expiresOn < today;
-    }).length;
+    return items.filter((it) => !it.isUsed && isExpired(it, today)).length;
   }, [items]);
 
   const noExpiryCount = useMemo(() => {
@@ -461,8 +460,7 @@ export default function ToolClient({ scanEnabled = false }: Props) {
   const unusedTotalYen = useMemo(() => {
     const today = todayISODate();
     return items.reduce((sum, it) => {
-      if (it.isUsed) return sum;
-      if (it.expiresOn && it.expiresOn < today) return sum;
+      if (it.isUsed || isExpired(it, today)) return sum;
       return sum + itemValueYen(it);
     }, 0);
   }, [items]);
@@ -478,8 +476,7 @@ export default function ToolClient({ scanEnabled = false }: Props) {
   const expiredTotalYen = useMemo(() => {
     const today = todayISODate();
     return items.reduce((sum, it) => {
-      if (it.isUsed || !it.expiresOn) return sum;
-      if (it.expiresOn >= today) return sum;
+      if (it.isUsed || !isExpired(it, today)) return sum;
       return sum + itemValueYen(it);
     }, 0);
   }, [items]);

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -459,10 +459,12 @@ export default function ToolClient({ scanEnabled = false }: Props) {
   }, [items]);
 
   const unusedTotalYen = useMemo(() => {
-    return items.reduce(
-      (sum, it) => (it.isUsed ? sum : sum + itemValueYen(it)),
-      0
-    );
+    const today = todayISODate();
+    return items.reduce((sum, it) => {
+      if (it.isUsed) return sum;
+      if (it.expiresOn && it.expiresOn < today) return sum;
+      return sum + itemValueYen(it);
+    }, 0);
   }, [items]);
 
   const expiringThisMonthYen = useMemo(() => {
@@ -472,6 +474,15 @@ export default function ToolClient({ scanEnabled = false }: Props) {
       return sum + itemValueYen(it);
     }, 0);
   }, [items, now]);
+
+  const expiredTotalYen = useMemo(() => {
+    const today = todayISODate();
+    return items.reduce((sum, it) => {
+      if (it.isUsed || !it.expiresOn) return sum;
+      if (it.expiresOn >= today) return sum;
+      return sum + itemValueYen(it);
+    }, 0);
+  }, [items]);
 
   // --- actions ---
   function openAdd() {
@@ -779,6 +790,13 @@ export default function ToolClient({ scanEnabled = false }: Props) {
               {fmtYen(expiringThisMonthYen)}
             </strong>
             <span className={styles.statHint}>{formatMonthLabel(now)}に期限切れ</span>
+          </div>
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>これまでの失効金額</span>
+            <strong className={styles.statValueYen} suppressHydrationWarning>
+              {fmtYen(expiredTotalYen)}
+            </strong>
+            <span className={styles.statHint}>未使用のまま期限切れ</span>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- 未使用合計額の集計から期限切れアイテムを除外（バグ修正）
- 新カード「これまでの失効金額」を追加し、未使用のまま期限切れになった額面合計を表示

## Why
未使用合計額のラベルは「残っている優待の額面合計」だが、実装は `isUsed` のみで弾いており期限切れ分も含まれていた。あわせて、これまでに失効した分の総額を一目で確認したいというユーザー要望に対応。

## Test plan
- [ ] 未使用かつ期限切れのアイテムが「未使用合計額」に含まれないこと
- [ ] 未使用かつ期限切れのアイテムが「これまでの失効金額」に合算されること
- [ ] 期限未設定（expiresOn=null）の未使用アイテムは未使用合計額に引き続き含まれること
- [ ] 「今月失効する金額」のカードは従来どおりの値になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)