### PR TITLE
feat(yutai-expiry): これまで使った優待金額のカードを追加

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -146,6 +146,10 @@
   color: #1f3fb8;
 }
 
+.statValueYenPositive {
+  color: var(--color-success);
+}
+
 .statCard {
   display: flex;
   flex-direction: column;

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -27,6 +27,7 @@ import {
   setUsedAll,
   removeHistoryEntry,
   itemValueYen,
+  itemUsedYen,
   TrackMode,
   UsageEntry,
 } from "./benefits/store";
@@ -481,6 +482,10 @@ export default function ToolClient({ scanEnabled = false }: Props) {
     }, 0);
   }, [items]);
 
+  const usedTotalYen = useMemo(() => {
+    return items.reduce((sum, it) => sum + itemUsedYen(it), 0);
+  }, [items]);
+
   // --- actions ---
   function openAdd() {
     setEditMode("add");
@@ -787,6 +792,16 @@ export default function ToolClient({ scanEnabled = false }: Props) {
               {fmtYen(expiringThisMonthYen)}
             </strong>
             <span className={styles.statHint}>{formatMonthLabel(now)}に期限切れ</span>
+          </div>
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>これまで使った金額</span>
+            <strong
+              className={`${styles.statValueYen} ${styles.statValueYenPositive}`}
+              suppressHydrationWarning
+            >
+              {fmtYen(usedTotalYen)}
+            </strong>
+            <span className={styles.statHint}>消費した優待の合計</span>
           </div>
           <div className={styles.statCard}>
             <span className={styles.statLabel}>これまでの失効金額</span>

--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -198,6 +198,17 @@ export function itemValueYen(it: BenefitItemV2): number {
   return Math.max(0, rem) * (it.unitYen ?? 0);
 }
 
+// 履歴から消費分（負デルタ）のみを合計した「使った金額」
+export function itemUsedYen(it: BenefitItemV2): number {
+  return it.history.reduce((sum, e) => {
+    const d =
+      it.trackMode === "amount"
+        ? e.deltaYen ?? 0
+        : (e.deltaQty ?? 0) * (it.unitYen ?? 0);
+    return d < 0 ? sum + -d : sum;
+  }, 0);
+}
+
 function touch(it: BenefitItemV2, entry: UsageEntry): BenefitItemV2 {
   const nowIso = new Date().toISOString();
   const remaining =


### PR DESCRIPTION
## Summary
- 履歴の負デルタを集計する `itemUsedYen` ヘルパーを `store.ts` に追加
- ヒーロー統計に「これまで使った金額」カードを追加（var(--color-success) で正のアクセント）
- 「これまでの失効金額」と隣接配置し、過去実績の正/負を対比可能に

## Why
未使用合計・失効合計だけでなく、実際に消費した優待金額も一目で確認したいというユーザー要望に対応。

## Test plan
- [ ] 消費（部分使用 / 全部使う）を行うと「これまで使った金額」が増えること
- [ ] 「未使用に戻す」直後にカードの値が整合すること
- [ ] count モード（unitYen × 残数）と amount モードの両方で正しく集計されること
- [ ] 履歴 0 件のアイテムは合計に影響しないこと
- [ ] auto-fit グリッドで 7 枚カードが破綻なく並ぶこと（Desktop / Mobile）

🤖 Generated with [Claude Code](https://claude.com/claude-code)