### PR TITLE
feat(yutai-expiry): ヒーロー統計を 3 セクション階層レイアウトに再構成

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -1068,27 +1068,8 @@
 
 @media (max-width: 879px) {
   .statDashboard {
-    padding: 18px 18px;
+    padding: 18px;
     gap: 14px;
-  }
-
-  .statCard {
-    padding: 14px 12px;
-    border-radius: 18px;
-  }
-
-  .statLabel {
-    font-size: 10px;
-    letter-spacing: 0.04em;
-  }
-
-  .statValue {
-    font-size: clamp(24px, 5vw, 30px);
-  }
-
-  .statHint {
-    font-size: 11px;
-    line-height: 1.35;
   }
 }
 

--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -78,19 +78,25 @@
   font-weight: 700;
 }
 
-.heroStats {
+.statDashboard {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  padding: 20px 22px;
+  border-radius: 22px;
+  border: 1px solid rgba(37, 84, 255, 0.12);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(239, 244, 255, 0.94));
+  box-shadow: 0 8px 24px -16px rgba(37, 84, 255, 0.25);
 }
 
-.statSection {
+.statDashHeadline {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
-.statSectionLabel {
+.statDashHeadlineLabel {
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -98,31 +104,65 @@
   text-transform: uppercase;
 }
 
-.statSectionGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 12px;
-}
-
-.statSectionPair {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-}
-
-.statCardPrimary {
-  background:
-    linear-gradient(135deg, rgba(37, 84, 255, 0.12), rgba(96, 165, 250, 0.08));
-  border-color: rgba(37, 84, 255, 0.2);
-  padding: 22px 24px;
-}
-
-.statValueYenLarge {
-  font-size: clamp(28px, 5vw, 40px);
-  line-height: 1.05;
+.statDashHeadlineValue {
+  font-size: clamp(34px, 7vw, 48px);
+  line-height: 1;
   font-weight: 900;
   color: #1f3fb8;
   letter-spacing: -0.02em;
+}
+
+.statDashHeadlineHint {
+  font-size: 12px;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.statDashRow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
+
+.statDashDivider {
+  height: 1px;
+  background: rgba(37, 84, 255, 0.12);
+  margin: 0 -6px;
+}
+
+.statTile {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.statTileLabel {
+  font-size: 11px;
+  color: rgba(15, 23, 42, 0.6);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.statTileValue {
+  font-size: clamp(18px, 4vw, 22px);
+  font-weight: 800;
+  color: #1f3fb8;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+
+.statTileValueNum {
+  font-size: clamp(22px, 5vw, 28px);
+  font-weight: 900;
+  color: #14213d;
+  line-height: 1;
+}
+
+.statTileValuePositive {
+  color: var(--color-success);
 }
 
 .rowActions {
@@ -178,51 +218,6 @@
 .historyDel:hover {
   background: color-mix(in srgb, var(--color-error) 14%, transparent);
   color: var(--color-error);
-}
-
-.statValueYen {
-  font-size: clamp(20px, 3vw, 26px);
-  line-height: 1.1;
-  font-weight: 900;
-  color: #1f3fb8;
-}
-
-.statValueYenPositive {
-  color: var(--color-success);
-}
-
-.statCard {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 18px;
-  border-radius: 22px;
-  border: 1px solid rgba(37, 84, 255, 0.1);
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(239, 244, 255, 0.92));
-  color: var(--color-text);
-  box-shadow:
-    0 14px 28px rgba(37, 84, 255, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.78);
-}
-
-.statLabel {
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-}
-
-.statValue {
-  font-size: clamp(28px, 4vw, 36px);
-  line-height: 1;
-  font-weight: 900;
-  color: #1f3fb8;
-}
-
-.statHint {
-  font-size: 12px;
-  color: var(--color-text-sub);
 }
 
 .topBar {
@@ -1072,21 +1067,9 @@
 }
 
 @media (max-width: 879px) {
-  .heroStats {
-    gap: 14px;
-  }
-
-  .statSectionGrid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 10px;
-  }
-
-  .statSectionPair {
-    gap: 10px;
-  }
-
-  .statCardPrimary {
+  .statDashboard {
     padding: 18px 18px;
+    gap: 14px;
   }
 
   .statCard {
@@ -1241,35 +1224,10 @@
     display: none;
   }
 
-  .heroStats {
-    gap: 12px;
-  }
-
-  .statSectionGrid,
-  .statSectionPair {
-    gap: 8px;
-  }
-
-  .statCard {
-    padding: 12px 10px;
-    border-radius: 16px;
-    gap: 4px;
-  }
-
-  .statCardPrimary {
+  .statDashboard {
     padding: 16px 14px;
-  }
-
-  .statValue {
-    font-size: 22px;
-  }
-
-  .statValueYenLarge {
-    font-size: clamp(26px, 7vw, 32px);
-  }
-
-  .statHint {
-    font-size: 10px;
+    gap: 12px;
+    border-radius: 18px;
   }
 
   .cardTop,

--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -79,9 +79,50 @@
 }
 
 .heroStats {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.statSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.statSectionLabel {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: rgba(31, 63, 184, 0.7);
+  text-transform: uppercase;
+}
+
+.statSectionGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 12px;
+}
+
+.statSectionPair {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.statCardPrimary {
+  background:
+    linear-gradient(135deg, rgba(37, 84, 255, 0.12), rgba(96, 165, 250, 0.08));
+  border-color: rgba(37, 84, 255, 0.2);
+  padding: 22px 24px;
+}
+
+.statValueYenLarge {
+  font-size: clamp(28px, 5vw, 40px);
+  line-height: 1.05;
+  font-weight: 900;
+  color: #1f3fb8;
+  letter-spacing: -0.02em;
 }
 
 .rowActions {
@@ -1032,8 +1073,20 @@
 
 @media (max-width: 879px) {
   .heroStats {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 14px;
+  }
+
+  .statSectionGrid {
+    grid-template-columns: repeat(2, 1fr);
     gap: 10px;
+  }
+
+  .statSectionPair {
+    gap: 10px;
+  }
+
+  .statCardPrimary {
+    padding: 18px 18px;
   }
 
   .statCard {
@@ -1189,6 +1242,11 @@
   }
 
   .heroStats {
+    gap: 12px;
+  }
+
+  .statSectionGrid,
+  .statSectionPair {
     gap: 8px;
   }
 
@@ -1198,8 +1256,16 @@
     gap: 4px;
   }
 
+  .statCardPrimary {
+    padding: 16px 14px;
+  }
+
   .statValue {
     font-size: 22px;
+  }
+
+  .statValueYenLarge {
+    font-size: clamp(26px, 7vw, 32px);
   }
 
   .statHint {

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -119,6 +119,33 @@ function isExpired(it: BenefitItemV2, today: string): boolean {
   return !!it.expiresOn && it.expiresOn < today;
 }
 
+function StatTile({
+  label,
+  value,
+  variant = "yen",
+  positive = false,
+}: {
+  label: string;
+  value: React.ReactNode;
+  variant?: "yen" | "num";
+  positive?: boolean;
+}) {
+  const valueClass = [
+    variant === "num" ? styles.statTileValueNum : styles.statTileValue,
+    positive ? styles.statTileValuePositive : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={styles.statTile}>
+      <span className={styles.statTileLabel}>{label}</span>
+      <strong className={valueClass} suppressHydrationWarning>
+        {value}
+      </strong>
+    </div>
+  );
+}
+
 function remainingText(it: BenefitItemV2): string {
   const rem = it.remaining ?? 0;
   if (it.trackMode === "amount") return `残高 ${fmtYen(rem)}`;
@@ -767,50 +794,17 @@ export default function ToolClient({ scanEnabled = false }: Props) {
           </div>
 
           <div className={styles.statDashRow}>
-            <div className={styles.statTile}>
-              <span className={styles.statTileLabel}>今月失効</span>
-              <span className={styles.statTileValue} suppressHydrationWarning>
-                {fmtYen(expiringThisMonthYen)}
-              </span>
-            </div>
-            <div className={styles.statTile}>
-              <span className={styles.statTileLabel}>使った</span>
-              <span
-                className={`${styles.statTileValue} ${styles.statTileValuePositive}`}
-                suppressHydrationWarning
-              >
-                {fmtYen(usedTotalYen)}
-              </span>
-            </div>
-            <div className={styles.statTile}>
-              <span className={styles.statTileLabel}>失効</span>
-              <span className={styles.statTileValue} suppressHydrationWarning>
-                {fmtYen(expiredTotalYen)}
-              </span>
-            </div>
+            <StatTile label="今月失効" value={fmtYen(expiringThisMonthYen)} />
+            <StatTile label="使った" value={fmtYen(usedTotalYen)} positive />
+            <StatTile label="失効" value={fmtYen(expiredTotalYen)} />
           </div>
 
           <div className={styles.statDashDivider} />
 
           <div className={styles.statDashRow}>
-            <div className={styles.statTile}>
-              <span className={styles.statTileLabel}>今月の未使用</span>
-              <span className={styles.statTileValueNum} suppressHydrationWarning>
-                {thisMonthCount}
-              </span>
-            </div>
-            <div className={styles.statTile}>
-              <span className={styles.statTileLabel}>期限切れ</span>
-              <span className={styles.statTileValueNum} suppressHydrationWarning>
-                {overdueCount}
-              </span>
-            </div>
-            <div className={styles.statTile}>
-              <span className={styles.statTileLabel}>期限未設定</span>
-              <span className={styles.statTileValueNum} suppressHydrationWarning>
-                {noExpiryCount}
-              </span>
-            </div>
+            <StatTile label="今月の未使用" value={thisMonthCount} variant="num" />
+            <StatTile label="期限切れ" value={overdueCount} variant="num" />
+            <StatTile label="期限未設定" value={noExpiryCount} variant="num" />
           </div>
         </div>
       </section>

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -758,57 +758,69 @@ export default function ToolClient({ scanEnabled = false }: Props) {
         </div>
 
         <div className={styles.heroStats}>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>今月の未使用</span>
-            <strong className={styles.statValue} suppressHydrationWarning>
-              {thisMonthCount}
-            </strong>
-            <span className={styles.statHint}>{formatMonthLabel(now)}に使う候補</span>
-          </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>期限切れ注意</span>
-            <strong className={styles.statValue} suppressHydrationWarning>
-              {overdueCount}
-            </strong>
-            <span className={styles.statHint}>未使用の期限切れ分</span>
-          </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>期限未設定</span>
-            <strong className={styles.statValue} suppressHydrationWarning>
-              {noExpiryCount}
-            </strong>
-            <span className={styles.statHint}>あとで整理したい優待</span>
-          </div>
-          <div className={styles.statCard}>
+          <div className={`${styles.statCard} ${styles.statCardPrimary}`}>
             <span className={styles.statLabel}>未使用合計額</span>
-            <strong className={styles.statValueYen} suppressHydrationWarning>
+            <strong className={styles.statValueYenLarge} suppressHydrationWarning>
               {fmtYen(unusedTotalYen)}
             </strong>
             <span className={styles.statHint}>残っている優待の額面合計</span>
           </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>今月失効する金額</span>
-            <strong className={styles.statValueYen} suppressHydrationWarning>
-              {fmtYen(expiringThisMonthYen)}
-            </strong>
-            <span className={styles.statHint}>{formatMonthLabel(now)}に期限切れ</span>
+
+          <div className={styles.statSection}>
+            <span className={styles.statSectionLabel}>今のアクション</span>
+            <div className={styles.statSectionGrid}>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>今月の未使用</span>
+                <strong className={styles.statValue} suppressHydrationWarning>
+                  {thisMonthCount}
+                </strong>
+                <span className={styles.statHint}>{formatMonthLabel(now)}に使う候補</span>
+              </div>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>期限切れ注意</span>
+                <strong className={styles.statValue} suppressHydrationWarning>
+                  {overdueCount}
+                </strong>
+                <span className={styles.statHint}>未使用の期限切れ分</span>
+              </div>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>期限未設定</span>
+                <strong className={styles.statValue} suppressHydrationWarning>
+                  {noExpiryCount}
+                </strong>
+                <span className={styles.statHint}>あとで整理したい優待</span>
+              </div>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>今月失効する金額</span>
+                <strong className={styles.statValueYen} suppressHydrationWarning>
+                  {fmtYen(expiringThisMonthYen)}
+                </strong>
+                <span className={styles.statHint}>{formatMonthLabel(now)}に期限切れ</span>
+              </div>
+            </div>
           </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>これまで使った金額</span>
-            <strong
-              className={`${styles.statValueYen} ${styles.statValueYenPositive}`}
-              suppressHydrationWarning
-            >
-              {fmtYen(usedTotalYen)}
-            </strong>
-            <span className={styles.statHint}>消費した優待の合計</span>
-          </div>
-          <div className={styles.statCard}>
-            <span className={styles.statLabel}>これまでの失効金額</span>
-            <strong className={styles.statValueYen} suppressHydrationWarning>
-              {fmtYen(expiredTotalYen)}
-            </strong>
-            <span className={styles.statHint}>未使用のまま期限切れ</span>
+
+          <div className={styles.statSection}>
+            <span className={styles.statSectionLabel}>これまでの実績</span>
+            <div className={styles.statSectionPair}>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>使った金額</span>
+                <strong
+                  className={`${styles.statValueYen} ${styles.statValueYenPositive}`}
+                  suppressHydrationWarning
+                >
+                  {fmtYen(usedTotalYen)}
+                </strong>
+                <span className={styles.statHint}>消費した優待の合計</span>
+              </div>
+              <div className={styles.statCard}>
+                <span className={styles.statLabel}>失効した金額</span>
+                <strong className={styles.statValueYen} suppressHydrationWarning>
+                  {fmtYen(expiredTotalYen)}
+                </strong>
+                <span className={styles.statHint}>未使用のまま期限切れ</span>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -757,69 +757,59 @@ export default function ToolClient({ scanEnabled = false }: Props) {
           </p>
         </div>
 
-        <div className={styles.heroStats}>
-          <div className={`${styles.statCard} ${styles.statCardPrimary}`}>
-            <span className={styles.statLabel}>未使用合計額</span>
-            <strong className={styles.statValueYenLarge} suppressHydrationWarning>
+        <div className={styles.statDashboard}>
+          <div className={styles.statDashHeadline}>
+            <span className={styles.statDashHeadlineLabel}>未使用合計額</span>
+            <strong className={styles.statDashHeadlineValue} suppressHydrationWarning>
               {fmtYen(unusedTotalYen)}
             </strong>
-            <span className={styles.statHint}>残っている優待の額面合計</span>
+            <span className={styles.statDashHeadlineHint}>残っている優待の額面合計</span>
           </div>
 
-          <div className={styles.statSection}>
-            <span className={styles.statSectionLabel}>今のアクション</span>
-            <div className={styles.statSectionGrid}>
-              <div className={styles.statCard}>
-                <span className={styles.statLabel}>今月の未使用</span>
-                <strong className={styles.statValue} suppressHydrationWarning>
-                  {thisMonthCount}
-                </strong>
-                <span className={styles.statHint}>{formatMonthLabel(now)}に使う候補</span>
-              </div>
-              <div className={styles.statCard}>
-                <span className={styles.statLabel}>期限切れ注意</span>
-                <strong className={styles.statValue} suppressHydrationWarning>
-                  {overdueCount}
-                </strong>
-                <span className={styles.statHint}>未使用の期限切れ分</span>
-              </div>
-              <div className={styles.statCard}>
-                <span className={styles.statLabel}>期限未設定</span>
-                <strong className={styles.statValue} suppressHydrationWarning>
-                  {noExpiryCount}
-                </strong>
-                <span className={styles.statHint}>あとで整理したい優待</span>
-              </div>
-              <div className={styles.statCard}>
-                <span className={styles.statLabel}>今月失効する金額</span>
-                <strong className={styles.statValueYen} suppressHydrationWarning>
-                  {fmtYen(expiringThisMonthYen)}
-                </strong>
-                <span className={styles.statHint}>{formatMonthLabel(now)}に期限切れ</span>
-              </div>
+          <div className={styles.statDashRow}>
+            <div className={styles.statTile}>
+              <span className={styles.statTileLabel}>今月失効</span>
+              <span className={styles.statTileValue} suppressHydrationWarning>
+                {fmtYen(expiringThisMonthYen)}
+              </span>
+            </div>
+            <div className={styles.statTile}>
+              <span className={styles.statTileLabel}>使った</span>
+              <span
+                className={`${styles.statTileValue} ${styles.statTileValuePositive}`}
+                suppressHydrationWarning
+              >
+                {fmtYen(usedTotalYen)}
+              </span>
+            </div>
+            <div className={styles.statTile}>
+              <span className={styles.statTileLabel}>失効</span>
+              <span className={styles.statTileValue} suppressHydrationWarning>
+                {fmtYen(expiredTotalYen)}
+              </span>
             </div>
           </div>
 
-          <div className={styles.statSection}>
-            <span className={styles.statSectionLabel}>これまでの実績</span>
-            <div className={styles.statSectionPair}>
-              <div className={styles.statCard}>
-                <span className={styles.statLabel}>使った金額</span>
-                <strong
-                  className={`${styles.statValueYen} ${styles.statValueYenPositive}`}
-                  suppressHydrationWarning
-                >
-                  {fmtYen(usedTotalYen)}
-                </strong>
-                <span className={styles.statHint}>消費した優待の合計</span>
-              </div>
-              <div className={styles.statCard}>
-                <span className={styles.statLabel}>失効した金額</span>
-                <strong className={styles.statValueYen} suppressHydrationWarning>
-                  {fmtYen(expiredTotalYen)}
-                </strong>
-                <span className={styles.statHint}>未使用のまま期限切れ</span>
-              </div>
+          <div className={styles.statDashDivider} />
+
+          <div className={styles.statDashRow}>
+            <div className={styles.statTile}>
+              <span className={styles.statTileLabel}>今月の未使用</span>
+              <span className={styles.statTileValueNum} suppressHydrationWarning>
+                {thisMonthCount}
+              </span>
+            </div>
+            <div className={styles.statTile}>
+              <span className={styles.statTileLabel}>期限切れ</span>
+              <span className={styles.statTileValueNum} suppressHydrationWarning>
+                {overdueCount}
+              </span>
+            </div>
+            <div className={styles.statTile}>
+              <span className={styles.statTileLabel}>期限未設定</span>
+              <span className={styles.statTileValueNum} suppressHydrationWarning>
+                {noExpiryCount}
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- 7 枚均一グリッド（3/3/1 で半端）を、役割で 3 層に再構成
- **Hero**: 未使用合計額を 1 枚で強調（大きめフォント + 差し色背景）
- **今のアクション**: 件数 3 + 今月失効金額の 4 枚（モバイル 2×2）
- **これまでの実績**: 使った金額 ↔ 失効金額の対比ペア（2 列固定）

## Why
7 枚均一グリッドが Pixel 10 Pro (~412px) や中間サイズで 3/3/1 などに崩れて読みづらかった。階層構造を持たせることで「在庫」「今すべき行動」「過去の実績」の文脈を明示。

## Test plan
- [ ] Pixel 10 Pro (~412px) で Hero 1 枚 / 2×2 / 2 列 のレイアウトが崩れないこと
- [ ] Desktop (>880px) で Hero / 4 列 / 2 列 が綺麗に並ぶこと
- [ ] iPad 中間サイズ (~768px) でも違和感がないこと
- [ ] 各カードの数値・ヒント文言が従来どおりであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)