### PR TITLE
fix(yutai-expiry): 「未使用に戻す」を「全部使う」の逆操作にする

### DIFF
--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -293,6 +293,13 @@ export function setUsedAll(it: BenefitItemV2, used: boolean): BenefitItemV2 {
     if (cur <= 0) return { ...it, isUsed: true };
     return consume(it, cur, "全部使用");
   }
+  // 「全部使う」と「未使用に戻す」を逆操作にする:
+  // 直近のエントリが "全部使用" ならそれを pop して残量を巻き戻す。
+  const lastIdx = it.history.length - 1;
+  if (lastIdx >= 0 && it.history[lastIdx].note === "全部使用") {
+    return removeHistoryEntry(it, lastIdx);
+  }
+  // 直近 "全部使用" が無い場合（手動で remaining=0 まで使い切ったケース等）は initial に戻す
   const back = it.initial ?? 1;
   const next: BenefitItemV2 = { ...it, remaining: back };
   return touch(


### PR DESCRIPTION
## Bug

「全部使う」を行ったあと「未使用に戻す」を押しても、想定通りに巻き戻らないケースがあった:
- `initial` が null のアイテムは `?? 1` で 1 枚にフォールバック → 複数枚アイテムでも 1 枚しか戻らない
- `initial` が正しく設定されていても、「全部使う」前の部分使用まで一緒に巻き戻してしまう

## Fix

`setUsedAll(it, false)` を「直近の `note === "全部使用"` 履歴エントリを `removeHistoryEntry` で pop する」実装に変更。これにより:

- 全部使う ↔ 未使用に戻す が完全な逆操作になる
- 部分使用の履歴は保たれる
- initial の有無に関係なく正しく動作
- 直近 "全部使用" が無い場合（手動で 1 枚ずつ使い切った等）は従来通り initial へフォールバック

## Test plan
- [ ] 10 枚アイテムで「全部使う」→「未使用に戻す」で 10 枚に戻る
- [ ] 部分使用後（例: 10 枚中 5 枚使用、残 5）→「全部使う」→「未使用に戻す」で 残 5 に戻る（10 ではなく）
- [ ] 1 枚アイテムでも従来通り動く
- [ ] amount モードでも同様
- [ ] Undo Toast 経由の取り消しも従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)