### PR TITLE
feat(yutai-expiry): 「もらった金額」カードを追加し 4 タイル収支を整合化

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -123,6 +123,14 @@
   gap: 4px;
 }
 
+.statDashRowWide {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.statDashRowWide .statTileValue {
+  font-size: clamp(15px, 3.6vw, 20px);
+}
+
 .statDashDivider {
   height: 1px;
   background: rgba(37, 84, 255, 0.12);

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -28,6 +28,7 @@ import {
   removeHistoryEntry,
   itemValueYen,
   itemUsedYen,
+  itemGrantedYen,
   TrackMode,
   UsageEntry,
 } from "./benefits/store";
@@ -532,6 +533,10 @@ export default function ToolClient({ scanEnabled = false }: Props) {
     return items.reduce((sum, it) => sum + itemUsedYen(it), 0);
   }, [items]);
 
+  const grantedTotalYen = useMemo(() => {
+    return items.reduce((sum, it) => sum + itemGrantedYen(it), 0);
+  }, [items]);
+
   // --- actions ---
   function openAdd() {
     setEditMode("add");
@@ -830,10 +835,11 @@ export default function ToolClient({ scanEnabled = false }: Props) {
             <span className={styles.statDashHeadlineHint}>残っている優待の額面合計</span>
           </div>
 
-          <div className={styles.statDashRow}>
-            <StatTile label="今月失効" value={fmtYen(expiringThisMonthYen)} />
+          <div className={`${styles.statDashRow} ${styles.statDashRowWide}`}>
+            <StatTile label="もらった" value={fmtYen(grantedTotalYen)} />
             <StatTile label="使った" value={fmtYen(usedTotalYen)} positive />
             <StatTile label="失効" value={fmtYen(expiredTotalYen)} />
+            <StatTile label="今月失効" value={fmtYen(expiringThisMonthYen)} />
           </div>
 
           <div className={styles.statDashDivider} />

--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -198,18 +198,42 @@ export function itemValueYen(it: BenefitItemV2): number {
   return Math.max(0, rem) * (it.unitYen ?? 0);
 }
 
-// 履歴の全デルタを符号付きで合計した「正味の使った金額」。
-// 正デルタ（未使用に戻す / 追加 / チャージ）が負デルタを相殺するため、
-// 「全部使う → 未使用に戻す」のような操作ミスは自動で打ち消される。
-export function itemUsedYen(it: BenefitItemV2): number {
-  const net = it.history.reduce((sum, e) => {
-    const d =
-      it.trackMode === "amount"
-        ? e.deltaYen ?? 0
-        : (e.deltaQty ?? 0) * (it.unitYen ?? 0);
-    return sum + d;
+// 「未使用に戻す」操作で追記されるエントリの識別子（note 文字列マッチ）。
+// 履歴集計でこれを除外することで restock と undo を区別する。
+const RESTORE_NOTE = "未使用に戻す";
+
+function entryYen(it: BenefitItemV2, e: UsageEntry): number {
+  return it.trackMode === "amount"
+    ? e.deltaYen ?? 0
+    : (e.deltaQty ?? 0) * (it.unitYen ?? 0);
+}
+
+// 累計でもらった金額（初期付与 + 後からの restock）。
+// 「未使用に戻す」が追記する正デルタは付与ではないので除外する。
+export function itemGrantedYen(it: BenefitItemV2): number {
+  const initial = it.initial ?? 0;
+  const baseYen =
+    it.trackMode === "amount" ? initial : initial * (it.unitYen ?? 0);
+  const grants = it.history.reduce((sum, e) => {
+    if (e.note === RESTORE_NOTE) return sum;
+    const d = entryYen(it, e);
+    return d > 0 ? sum + d : sum;
   }, 0);
-  return Math.max(0, -net);
+  return Math.max(0, baseYen + grants);
+}
+
+// 「使った金額」= gross 消費 − 未使用に戻す分。restock を相殺しないので
+// `granted − used − expired = remaining` の関係が保たれる。
+// 「全部使う → 未使用に戻す」の操作ミスは note=未使用に戻す が undo credit として効く。
+export function itemUsedYen(it: BenefitItemV2): number {
+  let usedGross = 0;
+  let undoCredits = 0;
+  for (const e of it.history) {
+    const d = entryYen(it, e);
+    if (d < 0) usedGross += -d;
+    else if (d > 0 && e.note === RESTORE_NOTE) undoCredits += d;
+  }
+  return Math.max(0, usedGross - undoCredits);
 }
 
 function touch(it: BenefitItemV2, entry: UsageEntry): BenefitItemV2 {
@@ -305,8 +329,8 @@ export function setUsedAll(it: BenefitItemV2, used: boolean): BenefitItemV2 {
   return touch(
     next,
     it.trackMode === "amount"
-      ? { at: "", deltaYen: back - (it.remaining ?? 0), note: "未使用に戻す" }
-      : { at: "", deltaQty: back - (it.remaining ?? 0), note: "未使用に戻す" }
+      ? { at: "", deltaYen: back - (it.remaining ?? 0), note: RESTORE_NOTE }
+      : { at: "", deltaQty: back - (it.remaining ?? 0), note: RESTORE_NOTE }
   );
 }
 


### PR DESCRIPTION
## Summary
- 累計付与額 `itemGrantedYen` を `store.ts` に追加（initial + restock、ただし "未使用に戻す" の正デルタは除外）
- ダッシュボードの yen 行を 4 列に拡張、**もらった → 使った → 失効 → 今月失効** のライフサイクル順で表示
- 「使った」も合わせて gross − undo 方式に再定義、4 タイルが `granted = used + expired + remaining` の関係で arithmetic に整合
- note 文字列 "未使用に戻す" は `RESTORE_NOTE` 定数に抽出

## Why
- yutai 1 銘柄あたり「もらった / 使った / 失効 / 残」の収支が一目で見える
- 投資効率の主観指標として「もらった額」を可視化（要件 H5 系の最小実装）

## Test plan
- [ ] 新規追加直後: もらった = initial × unitYen（または amount）、使った=0、残=同額
- [ ] 部分使用後: もらった 不変、使った = 消費分、残 = もらった - 使った
- [ ] restock 後: もらった 増加、使った 不変、残 = もらった - 使った
- [ ] 「全部使う → 未使用に戻す」（PR #324 pop 経由）: 全タイル元の状態に戻る
- [ ] 期限切れ後: 失効額 = 失効時の残額、もらった ≠ 0
- [ ] Pixel 10 Pro (~412px) で 4 タイル横並びが破綻しない
- [ ] 既存の Undo Toast 系がすべて従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)