### PR TITLE
feat(yutai-expiry): カードに銘柄ごとの累計（もらった/使った）表示

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -724,6 +724,13 @@
   line-height: 1.7;
 }
 
+.itemTotals {
+  font-size: 12px;
+  color: var(--color-text-sub);
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
 .cardActions {
   display: flex;
   gap: 8px;

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -156,6 +156,13 @@ function remainingText(it: BenefitItemV2): string {
   return base;
 }
 
+function itemTotalsText(it: BenefitItemV2): string | null {
+  const granted = itemGrantedYen(it);
+  const used = itemUsedYen(it);
+  if (granted === 0 && used === 0) return null;
+  return `もらった ${fmtYen(granted)} ／ 使った ${fmtYen(used)}`;
+}
+
 function historyText(h: UsageEntry): string {
   const d = h.at ? h.at.slice(0, 10) : "";
   if (h.deltaYen != null) {
@@ -1178,6 +1185,9 @@ export default function ToolClient({ scanEnabled = false }: Props) {
                       <b>{remainingText(it)}</b>
                     </span>
                   </div>
+                  {itemTotalsText(it) && (
+                    <div className={styles.itemTotals}>{itemTotalsText(it)}</div>
+                  )}
                   {it.memo && it.memo.trim() && (
                     <div className={styles.memo}>{it.memo}</div>
                   )}
@@ -1314,6 +1324,9 @@ export default function ToolClient({ scanEnabled = false }: Props) {
                     <div className={styles.rowSub}>
                       <span>{remainingText(it)}</span>
                     </div>
+                    {itemTotalsText(it) && (
+                      <div className={styles.itemTotals}>{itemTotalsText(it)}</div>
+                    )}
                     {it.history.length > 0 && (
                       <details className={styles.history}>
                         <summary>履歴（{it.history.length}）</summary>


### PR DESCRIPTION
## Summary
- 各アイテムカード（モバイル）と一覧行（PC）に「もらった ¥X ／ 使った ¥X」を表示
- 履歴が無いアイテムでは非表示にしてノイズを抑制
- 既存の `itemGrantedYen` / `itemUsedYen` を流用、データ追加なし

## Why
QUO カード等の銘柄単位で「これまでいくら消化したか」をその場で確認したい、というニーズに対応。Hero ダッシュボードの全体合計に対して、アイテム単位の内訳をカードでそのまま見られる。

## Test plan
- [ ] 履歴があるアイテムで「もらった ¥X ／ 使った ¥X」が表示される
- [ ] 履歴が無い & 未使用の新規アイテムでは表示されない
- [ ] count モード（restock 含む）と amount モード両方で値が正しい
- [ ] Pixel 10 Pro でカード幅に収まる
- [ ] PC の表でも追加行が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)