### PR TITLE
feat(yutai-expiry): スキャン時に同銘柄の既存アイテムを検出して統合可能に

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -962,6 +962,57 @@
   border-top: 1px solid rgba(15, 23, 42, 0.06);
 }
 
+.dupLead {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-text-sub);
+  padding: 0 18px;
+  margin: 12px 0 4px;
+}
+
+.dupScan {
+  font-size: 12px;
+  color: var(--color-text-sub);
+  padding: 0 18px;
+  margin: 0 0 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.dupList {
+  list-style: none;
+  margin: 0;
+  padding: 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dupItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(239, 244, 255, 0.5);
+}
+
+.dupItemTitle {
+  font-weight: 800;
+  font-size: 14px;
+}
+
+.dupItemMeta {
+  font-size: 12px;
+  color: var(--color-text-sub);
+}
+
+.dupItemHint {
+  font-size: 12px;
+  color: #1f3fb8;
+  margin-bottom: 6px;
+}
+
 .toast {
   position: fixed;
   left: 50%;

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -29,6 +29,7 @@ import {
   itemValueYen,
   itemUsedYen,
   itemGrantedYen,
+  SCAN_MERGE_NOTE,
   TrackMode,
   UsageEntry,
 } from "./benefits/store";
@@ -161,6 +162,90 @@ function itemTotalsText(it: BenefitItemV2): string | null {
   const used = itemUsedYen(it);
   if (granted === 0 && used === 0) return null;
   return `もらった ${fmtYen(granted)} ／ 使った ${fmtYen(used)}`;
+}
+
+type DuplicateMatch = {
+  item: BenefitItemV2;
+  // restock 量。null なら統合不可（スキャン情報不足）
+  restockQty: number | null;
+  restockYen: number | null;
+  hint: string;
+};
+
+function normalizeKey(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, "");
+}
+
+function findScanDuplicates(
+  items: BenefitItemV2[],
+  s: ScanResult
+): DuplicateMatch[] {
+  const sc = normalizeKey(s.company ?? "");
+  const st = normalizeKey(s.title ?? "");
+  if (!sc || !st) return [];
+  const today = todayISODate();
+  return items
+    .filter(
+      (it) =>
+        normalizeKey(it.company) === sc && normalizeKey(it.title) === st
+    )
+    .sort((a, b) => {
+      // 未期限切れ → 期限切れ、その上で期限が近いものを優先
+      const aExp = !!a.expiresOn && a.expiresOn < today;
+      const bExp = !!b.expiresOn && b.expiresOn < today;
+      if (aExp !== bExp) return aExp ? 1 : -1;
+      const ae = a.expiresOn ?? "9999-12-31";
+      const be = b.expiresOn ?? "9999-12-31";
+      return ae < be ? -1 : ae > be ? 1 : 0;
+    })
+    .map((item): DuplicateMatch => {
+      if (item.trackMode === "amount") {
+        if (s.amountYen != null && s.amountYen > 0) {
+          return {
+            item,
+            restockQty: null,
+            restockYen: s.amountYen,
+            hint: `残高に +${fmtYen(s.amountYen)} を追加`,
+          };
+        }
+        return {
+          item,
+          restockQty: null,
+          restockYen: null,
+          hint: "金額未取得のため統合不可（新規追加してください）",
+        };
+      }
+      if (s.quantity != null && s.quantity > 0) {
+        return {
+          item,
+          restockQty: s.quantity,
+          restockYen: null,
+          hint: `+${s.quantity} 枚を既存に追加`,
+        };
+      }
+      if (
+        s.amountYen != null &&
+        s.amountYen > 0 &&
+        item.unitYen != null &&
+        item.unitYen > 0
+      ) {
+        const qty = Math.floor(s.amountYen / item.unitYen);
+        if (qty > 0) {
+          return {
+            item,
+            restockQty: qty,
+            restockYen: null,
+            hint: `+${qty} 枚を追加（${fmtYen(s.amountYen)} ÷ @${fmtYen(item.unitYen)}）`,
+          };
+        }
+      }
+      return {
+        item,
+        restockQty: null,
+        restockYen: null,
+        hint: "枚数未取得のため統合不可（新規追加してください）",
+      };
+    });
 }
 
 function historyText(h: UsageEntry): string {
@@ -404,6 +489,12 @@ export default function ToolClient({ scanEnabled = false }: Props) {
   const editDialogRef = useRef<HTMLDialogElement | null>(null);
   const importDialogRef = useRef<HTMLDialogElement | null>(null);
   const usageDialogRef = useRef<HTMLDialogElement | null>(null);
+  const scanDupDialogRef = useRef<HTMLDialogElement | null>(null);
+  const [scanDup, setScanDup] = useState<{
+    scan: ScanResult;
+    model: string | null;
+    matches: DuplicateMatch[];
+  } | null>(null);
 
   const [editMode, setEditMode] = useState<"add" | "edit">("add");
   const [draft, setDraft] = useState<Draft>(toDraft());
@@ -553,6 +644,16 @@ export default function ToolClient({ scanEnabled = false }: Props) {
   }
 
   function openAddFromScan(s: ScanResult, model: string | null) {
+    const matches = findScanDuplicates(items, s);
+    if (matches.length > 0) {
+      setScanDup({ scan: s, model, matches });
+      scanDupDialogRef.current?.showModal();
+      return;
+    }
+    proceedAddFromScan(s, model);
+  }
+
+  function proceedAddFromScan(s: ScanResult, model: string | null) {
     setEditMode("add");
     setDraft(scanResultToDraft(s));
     setDraftError(null);
@@ -560,6 +661,27 @@ export default function ToolClient({ scanEnabled = false }: Props) {
     const conf = (s.confidence * 100).toFixed(0);
     const modelLabel = model ? ` / ${model}` : "";
     setToast({ message: `スキャン結果を反映しました（確信度 ${conf}%${modelLabel}）` });
+  }
+
+  function mergeIntoExisting(match: DuplicateMatch) {
+    const snapshot = items.find((p) => p.id === match.item.id);
+    if (!snapshot) return;
+    const amount =
+      match.restockYen != null ? match.restockYen : match.restockQty ?? 0;
+    if (amount <= 0) return;
+    applyRestock(match.item.id, amount, SCAN_MERGE_NOTE);
+    scanDupDialogRef.current?.close();
+    setScanDup(null);
+    showUndoableToast(`「${match.item.title}」に追加しました`, snapshot);
+  }
+
+  function dismissScanDup(addAsNew: boolean) {
+    const pending = scanDup;
+    scanDupDialogRef.current?.close();
+    setScanDup(null);
+    if (addAsNew && pending) {
+      proceedAddFromScan(pending.scan, pending.model);
+    }
   }
 
   function openEdit(it: BenefitItemV2) {
@@ -1518,6 +1640,89 @@ export default function ToolClient({ scanEnabled = false }: Props) {
         error={usageError}
         onSubmit={submitUsage}
       />
+
+      {/* Scan duplicate dialog */}
+      <dialog ref={scanDupDialogRef} className={styles.dialog}>
+        <form
+          method="dialog"
+          className={styles.dialogInner}
+          onSubmit={(e) => {
+            e.preventDefault();
+            dismissScanDup(false);
+          }}
+        >
+          <div className={styles.dialogHeader}>
+            <h2 className={styles.dialogTitle}>同じ優待が登録済み</h2>
+          </div>
+          <div className={styles.formGrid}>
+            {scanDup && (
+              <>
+                <p className={styles.dupLead}>
+                  <b>{scanDup.scan.company ?? ""}</b> /{" "}
+                  <b>{scanDup.scan.title ?? ""}</b> と一致する優待が既にあります。
+                  どうしますか？
+                </p>
+                <p className={styles.dupScan}>
+                  スキャン結果:
+                  {scanDup.scan.quantity != null
+                    ? ` ${scanDup.scan.quantity} 枚`
+                    : ""}
+                  {scanDup.scan.amountYen != null
+                    ? ` / ${fmtYen(scanDup.scan.amountYen)}`
+                    : ""}
+                  {scanDup.scan.expiresOn
+                    ? ` / 期限 ${fmtJPDate(scanDup.scan.expiresOn)}`
+                    : ""}
+                </p>
+                <ul className={styles.dupList}>
+                  {scanDup.matches.map((m) => {
+                    const canRestock =
+                      (m.restockQty != null && m.restockQty > 0) ||
+                      (m.restockYen != null && m.restockYen > 0);
+                    return (
+                      <li key={m.item.id} className={styles.dupItem}>
+                        <div className={styles.dupItemTitle}>{m.item.title}</div>
+                        <div className={styles.dupItemMeta}>
+                          {remainingText(m.item)}
+                          {m.item.expiresOn
+                            ? ` ・ 期限 ${fmtJPDate(m.item.expiresOn)}`
+                            : ""}
+                        </div>
+                        <div className={styles.dupItemHint}>{m.hint}</div>
+                        {canRestock && (
+                          <button
+                            type="button"
+                            className={styles.primaryBtn}
+                            onClick={() => mergeIntoExisting(m)}
+                          >
+                            これに統合する
+                          </button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
+          </div>
+          <div className={styles.dialogFooter}>
+            <button
+              type="button"
+              className={styles.smallBtn}
+              onClick={() => dismissScanDup(false)}
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              className={styles.smallBtn}
+              onClick={() => dismissScanDup(true)}
+            >
+              別アイテムとして追加
+            </button>
+          </div>
+        </form>
+      </dialog>
 
       {/* toast */}
       {toast && (

--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -198,9 +198,9 @@ export function itemValueYen(it: BenefitItemV2): number {
   return Math.max(0, rem) * (it.unitYen ?? 0);
 }
 
-// 「未使用に戻す」操作で追記されるエントリの識別子（note 文字列マッチ）。
-// 履歴集計でこれを除外することで restock と undo を区別する。
+// 履歴エントリの note に使うラベル。集計の分岐 / 操作の意図記録に使う。
 const RESTORE_NOTE = "未使用に戻す";
+export const SCAN_MERGE_NOTE = "スキャン統合";
 
 function entryYen(it: BenefitItemV2, e: UsageEntry): number {
   return it.trackMode === "amount"


### PR DESCRIPTION
## Summary
カメラ / 画像スキャンで同企業 + 同タイトルの既存アイテムを検出した時、新規追加前に確認ダイアログを挟みます。

### フロー
1. スキャン完了 → 既存アイテムと一致チェック（企業 + タイトル、空白除去で正規化）
2. 一致なし → 従来通り編集ダイアログを開く
3. 一致あり → 候補一覧 + アクション選択ダイアログ
   - **これに統合する**: 既存アイテムに restock（trackMode に応じて自動で量を導出）
   - **別アイテムとして追加**: 従来の編集ダイアログへフォールバック
   - **キャンセル**: 何もしない

### 統合量の導出
- amount モード: スキャンの金額をそのまま restock
- count モード: スキャンの枚数 / または 金額 ÷ 額面で換算
- 情報不足で統合不可な場合は理由をヒント表示し統合ボタンを隠す

### 統合操作の取り消し
内部で `applyRestock` を使うため、既存の Undo Toast 5 秒以内で取り消し可能。

## Why
半期ごとに同銘柄から優待が届く前提のため、毎回スキャンで「同銘柄の既存アイテム」を意識せず追加すると、別レコードが量産されて per-item サマリが見づらくなる。検出 → ユーザー選択で、統合か別管理かを明示的に選べる。

ユースケース棚卸し: P1 (同銘柄サイクル) / P5 (前回データの活用) / β 案として提案済み。

## Test plan
- [ ] 同じ企業 + タイトルでスキャン → ダイアログが出る
- [ ] 企業違い or タイトル違いでは出ない（従来通り編集ダイアログ）
- [ ] 全空白除去で「QUO カード」と「QUOカード」が一致する
- [ ] 候補が複数あるとき、未期限切れ → 期限近い順にソートされる
- [ ] amount モードへの統合（残高加算）が動く
- [ ] count モードへの統合（枚数加算）が動く
- [ ] 統合不可な組み合わせ（情報不足）は理由が見えて統合ボタンが出ない
- [ ] 統合後の Toast「取り消す」で restock 前に戻る
- [ ] 「別アイテムとして追加」で従来の編集ダイアログが開く
- [ ] スキャン結果サマリ（枚数 / 金額 / 期限）がダイアログ上部に見える

🤖 Generated with [Claude Code](https://claude.com/claude-code)