### PR TITLE
fix(yutai-expiry): 額面未設定で累計金額が反映されない件のUI改善

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -906,6 +906,15 @@
   margin-bottom: 6px;
 }
 
+.fieldHint {
+  display: block;
+  font-size: 11px;
+  color: var(--color-warning);
+  margin-top: 6px;
+  margin-bottom: 0;
+  line-height: 1.5;
+}
+
 .field input,
 .field textarea,
 .bigTextarea {

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -158,6 +158,11 @@ function remainingText(it: BenefitItemV2): string {
 }
 
 function itemTotalsText(it: BenefitItemV2): string | null {
+  // 額面未設定の count アイテムは yen 換算不可。乖離理由を明示する。
+  if (it.trackMode === "count" && it.unitYen == null) {
+    const hasActivity = (it.initial ?? 0) > 0 || it.history.length > 0;
+    return hasActivity ? "額面未設定のため累計金額に反映されません" : null;
+  }
   const granted = itemGrantedYen(it);
   const used = itemUsedYen(it);
   if (granted === 0 && used === 0) return null;

--- a/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
+++ b/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
@@ -140,6 +140,11 @@ export default function EditBenefitDialog({
                   placeholder="例：1000"
                   inputMode="numeric"
                 />
+                {!draft.unitYen.trim() && (
+                  <span className={styles.fieldHint}>
+                    未入力だと「もらった」「使った」など金額集計に反映されません
+                  </span>
+                )}
               </label>
             </div>
           ) : (


### PR DESCRIPTION
## Bug
count モードで「1 枚あたり額面」を未入力で保存すると、`unitYen=null` となり `itemGrantedYen` / `itemUsedYen` 等が常に 0 を返す。結果として:
- 追加してもダッシュボード「もらった」「使った」に反映されない
- スキャン経由（quantity だけ抽出されて amountYen=null）でも同じ罠にハマる
- 旧 v1 形式の移行でも unitYen=null になりやすい

## Fix (data model 変更なし)
両側から気づける UI を追加:

### EditBenefitDialog
1 枚あたり額面欄が空のとき、警告 hint を inline 表示:
> 未入力だと「もらった」「使った」など金額集計に反映されません

### per-item 表示
カード / 一覧行の「もらった ¥X ／ 使った ¥X」エリアに、額面未設定の count アイテムは代わりに以下を表示:
> 額面未設定のため累計金額に反映されません

ダッシュボードとカードの乖離理由がその場で見える。

## 見送った案
- (iv) 額面の必須化: 既存データへの影響大、保存できなくなる
- (iii) ダッシュボードバナー: (i)+(ii) で大半カバーできるので段階的に

## Test plan
- [ ] count モードで額面欄を空にすると警告 hint が出る
- [ ] 額面欄に値を入れると警告が消える
- [ ] 額面未設定のアイテムのカード/行に「額面未設定のため…」が表示される
- [ ] 額面設定済みアイテムは従来通り「もらった / 使った」が表示される
- [ ] amount モードでは警告対象外（額面の概念がない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)