### PR TITLE
feat(yutai-expiry): 1枚あたり額面を必須化＋既存データ救済バナー（パス A）

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.module.css
+++ b/app/tools/yutai-expiry/ToolClient.module.css
@@ -173,6 +173,38 @@
   color: var(--color-success);
 }
 
+.unitYenBanner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  margin-top: 12px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(217, 119, 6, 0.3);
+  background: rgba(254, 243, 199, 0.5);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  appearance: none;
+}
+
+.unitYenBanner:hover {
+  background: rgba(254, 243, 199, 0.8);
+}
+
+.unitYenBannerLabel {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-warning);
+}
+
+.unitYenBannerHint {
+  font-size: 11px;
+  color: var(--color-warning);
+  opacity: 0.85;
+}
+
 .rowActions {
   display: flex;
   flex-wrap: wrap;

--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -347,12 +347,20 @@ function validateDraft(d: Draft): { ok: boolean; message?: string } {
     const q = coerceNumber(d.qty);
     if (q == null || q < 0)
       return { ok: false, message: "枚数を0以上の数値で入力してください。" };
+    // qty > 0 のとき 1 枚あたり額面は必須（未設定だと金額集計に反映されないため）
+    if (q > 0 && !d.unitYen.trim()) {
+      return {
+        ok: false,
+        message:
+          "1枚あたり額面を入力してください。額面が不明な場合は『金額モード』に切り替えてください。",
+      };
+    }
     if (d.unitYen.trim()) {
       const u = coerceNumber(d.unitYen);
-      if (u == null || u < 0)
+      if (u == null || u <= 0)
         return {
           ok: false,
-          message: "1枚あたり額面は0以上の数値で入力してください。",
+          message: "1枚あたり額面は 0 より大きい数値で入力してください。",
         };
     }
   } else {
@@ -639,6 +647,20 @@ export default function ToolClient({ scanEnabled = false }: Props) {
   const grantedTotalYen = useMemo(() => {
     return items.reduce((sum, it) => sum + itemGrantedYen(it), 0);
   }, [items]);
+
+  // 額面未設定の count アイテム数（金額集計に反映されない既存データの救済導線）
+  const missingUnitYenCount = useMemo(() => {
+    return items.filter(
+      (it) => it.trackMode === "count" && it.unitYen == null && (it.initial ?? 0) > 0
+    ).length;
+  }, [items]);
+
+  function openFirstMissingUnitYen() {
+    const target = items.find(
+      (it) => it.trackMode === "count" && it.unitYen == null && (it.initial ?? 0) > 0
+    );
+    if (target) openEdit(target);
+  }
 
   // --- actions ---
   function openAdd() {
@@ -984,6 +1006,21 @@ export default function ToolClient({ scanEnabled = false }: Props) {
             <StatTile label="期限未設定" value={noExpiryCount} variant="num" />
           </div>
         </div>
+
+        {missingUnitYenCount > 0 && (
+          <button
+            type="button"
+            className={styles.unitYenBanner}
+            onClick={openFirstMissingUnitYen}
+          >
+            <span className={styles.unitYenBannerLabel}>
+              額面未設定の優待が <b>{missingUnitYenCount}</b> 件あります
+            </span>
+            <span className={styles.unitYenBannerHint}>
+              金額集計に反映されていません ・ タップで修正 →
+            </span>
+          </button>
+        )}
       </section>
 
       <div className={styles.topBar}>

--- a/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
+++ b/app/tools/yutai-expiry/components/EditBenefitDialog.tsx
@@ -131,7 +131,7 @@ export default function EditBenefitDialog({
               </label>
 
               <label className={styles.field}>
-                <span>1枚あたり額面（任意）</span>
+                <span>1枚あたり額面 *</span>
                 <input
                   value={draft.unitYen}
                   onChange={(e) =>
@@ -142,7 +142,7 @@ export default function EditBenefitDialog({
                 />
                 {!draft.unitYen.trim() && (
                   <span className={styles.fieldHint}>
-                    未入力だと「もらった」「使った」など金額集計に反映されません
+                    額面が不明な場合は「金額モード」に切り替えてください
                   </span>
                 )}
               </label>


### PR DESCRIPTION
## Summary
unitYen=null による「金額が反映されない」問題の完全解決:
- count モードで qty > 0 のとき、1 枚あたり額面を validation で必須化
- 既存の unitYen=null レガシーデータには、ヒーロー直下に救済バナーを表示
- バナータップで該当アイテムの編集ダイアログを開く

## Why
パス A (必須化) を採用。理由は[直前の議論](https://github.com/Yuichi-TanakaJP/mini-tools/pull/329)の通り、株主優待の額面はほぼ確実に印字されており、ツールの主目的（金額把握）と整合するため。

## 変更点
- `validateDraft`: count + qty>0 で unitYen 必須、unitYen は 0 より大きい数値のみ
- `EditBenefitDialog`: ラベル「(任意)」→「*」、ヒントを「金額モードに切替」案内へ
- `ToolClient`: `missingUnitYenCount` メモと `openFirstMissingUnitYen` 導線
- 救済バナー UI＋CSS（warning 配色）

## 影響
- 新規追加: 額面なしでは保存できない（明示的なエラー表示）
- スキャン経由: amountYen が抽出できなかった場合も手動入力強制
- 既存 unitYen=null データ: バナーから誘導して順次修正
- 「額面が分からないので登録不可」になるケースは amount モードで代替可能

## Test plan
- [ ] count + qty=10 + 額面空で保存 → エラー
- [ ] count + qty=10 + 額面=1000 で保存 → OK
- [ ] count + qty=0（pending 登録）で保存 → OK（額面なしでも許容）
- [ ] amount モードでは validation に変化なし
- [ ] 既存 unitYen=null アイテム 1 件以上があるとバナー表示
- [ ] バナータップで該当アイテムの編集ダイアログが開く
- [ ] バナーは件数 0 になったら自動で消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)