### PR TITLE
fix(yutai-expiry): 編集で残高/枚数が変わった分を履歴に補正記録

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -30,6 +30,7 @@ import {
   itemUsedYen,
   itemGrantedYen,
   SCAN_MERGE_NOTE,
+  EDIT_ADJUST_NOTE,
   TrackMode,
   UsageEntry,
 } from "./benefits/store";
@@ -744,6 +745,21 @@ export default function ToolClient({ scanEnabled = false }: Props) {
       // ただしモード(枚数/金額)を変えた場合は単位が変わるので initial を新値で取り直す。
       const keepInitial =
         prevItem && prevItem.trackMode === draft.trackMode;
+      // 編集で remaining が変わった場合は履歴に差分を記録して集計の整合を保つ。
+      // 例: 残高 0 → 3000 に編集すると history += {+3000, "編集による補正"} となり
+      // 「もらった」も +3000 される（restock と同等扱い）。
+      const adjustedHistory = (() => {
+        if (!keepInitial || !prevItem || remainingInput == null)
+          return keepInitial ? prevItem!.history : [];
+        const prevRem = prevItem.remaining ?? 0;
+        const delta = remainingInput - prevRem;
+        if (delta === 0) return prevItem.history;
+        const entry: UsageEntry =
+          draft.trackMode === "amount"
+            ? { at: nowIso, deltaYen: delta, note: EDIT_ADJUST_NOTE }
+            : { at: nowIso, deltaQty: delta, note: EDIT_ADJUST_NOTE };
+        return [...prevItem.history, entry];
+      })();
       const built = coerceItem({
         id,
         title: draft.title.trim(),
@@ -753,7 +769,7 @@ export default function ToolClient({ scanEnabled = false }: Props) {
         unitYen,
         initial: keepInitial ? prevItem!.initial : remainingInput,
         remaining: remainingInput,
-        history: keepInitial ? prevItem!.history : [],
+        history: adjustedHistory,
         memo: draft.memo?.trim() ?? "",
         link: draft.link.trim() ? draft.link.trim() : undefined,
         createdAt: prevItem?.createdAt ?? nowIso,

--- a/app/tools/yutai-expiry/benefits/store.ts
+++ b/app/tools/yutai-expiry/benefits/store.ts
@@ -201,6 +201,7 @@ export function itemValueYen(it: BenefitItemV2): number {
 // 履歴エントリの note に使うラベル。集計の分岐 / 操作の意図記録に使う。
 const RESTORE_NOTE = "未使用に戻す";
 export const SCAN_MERGE_NOTE = "スキャン統合";
+export const EDIT_ADJUST_NOTE = "編集による補正";
 
 function entryYen(it: BenefitItemV2, e: UsageEntry): number {
   return it.trackMode === "amount"


### PR DESCRIPTION
## Bug
編集ダイアログで残高 / 枚数を変更しても履歴に反映されず、「もらった」が更新されなかった。

**再現**: ¥3,000 amount アイテム追加 → 全部使う（remaining=0）→ 編集ダイアログで残高 3,000 に戻す → granted=3,000 のまま、used=3,000、remaining=3,000 で 4 タイルの収支整合性が崩れていた。

## Fix
`upsertFromDraft` の edit 経路で `keepInitial=true` かつ `remaining` が変わった場合、差分を `history` エントリ（note=EDIT_ADJUST_NOTE）として自動追加。
- 残量増 → 正デルタ（restock 相当 / granted +N）
- 残量減 → 負デルタ（consume 相当 / used +N）

これで `granted = used + expired + remaining` が常に成立。履歴ペインにも「編集による補正」が見えて操作の audit trail が残る。

## 影響
- 既存の「+追加」「使う」操作の挙動は不変
- 編集で typo を直すケースも「補正履歴 +X」「補正履歴 −X」として記録される
- 履歴の「✕」削除ボタンで補正履歴も取り消し可能

## Test plan
- [ ] amount: ¥3000 → 全部使う → 残高 3000 に編集 → もらった ¥6000、4 タイル整合
- [ ] count: 5 枚 → 全部使う → 6 枚に編集 → もらった ¥6000（×額面）、4 タイル整合
- [ ] 編集で残量を下げると履歴に負デルタ（補正）が記録される
- [ ] 履歴ペインに「編集による補正」が表示される
- [ ] 履歴の「✕」で補正を取り消せる
- [ ] 残量を変えない編集（タイトル/メモのみ）では履歴増えない

🤖 Generated with [Claude Code](https://claude.com/claude-code)