### PR TITLE
feat(my-stocks): JSON エクスポート/インポート（バックアップ）を追加

### DIFF
--- a/app/tools/my-stocks/ToolClient.tsx
+++ b/app/tools/my-stocks/ToolClient.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import TabBar from "@/app/tools/_shared/TabBar";
-import { loadItems, saveItems } from "./storage";
+import { loadItems, newId, saveItems } from "./storage";
+import { mergeItems, parseBackupItems, serializeBackup } from "./backup";
 import { useStockMaster } from "./useStockMaster";
 import type { MyStockItem, MyStocksReference, StockListTab, StockMaster } from "./types";
 
@@ -18,13 +19,6 @@ const TAB_OPTIONS = [TAB_LABELS.holding, TAB_LABELS.watch] as const;
 
 const UNDO_MS = 5000;
 
-function newId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
 function formatEarnings(iso: string): string {
   const m = iso.match(/^\d{4}-(\d{2})-(\d{2})$/);
   if (!m) return iso;
@@ -39,6 +33,7 @@ export default function ToolClient({ reference }: Props) {
   const [pendingUndo, setPendingUndo] = useState<MyStockItem | null>(null);
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
 
   const master = useStockMaster();
 
@@ -114,6 +109,52 @@ export default function ToolClient({ reference }: Props) {
     if (undoTimer.current) clearTimeout(undoTimer.current);
   }
 
+  function exportBackup() {
+    if (items.length === 0) {
+      flashNotice("書き出す銘柄がありません");
+      return;
+    }
+    const blob = new Blob([serializeBackup(items)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const stamp = new Date()
+      .toLocaleDateString("en-CA", { timeZone: "Asia/Tokyo" })
+      .replaceAll("-", "");
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `my-stocks-backup-${stamp}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    flashNotice(`${items.length}件をバックアップしました`);
+  }
+
+  function importBackup(file: File) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const parsed = parseBackupItems(String(reader.result ?? ""));
+      if (!parsed) {
+        flashNotice("バックアップファイルを読み込めませんでした");
+        return;
+      }
+      const { merged, added, skipped } = mergeItems(items, parsed);
+      persist(merged);
+      flashNotice(
+        skipped > 0
+          ? `${added}件を取り込みました（重複${skipped}件はスキップ）`
+          : `${added}件を取り込みました`,
+      );
+    };
+    reader.onerror = () => flashNotice("ファイルの読み込みに失敗しました");
+    reader.readAsText(file);
+  }
+
+  function onImportInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) importBackup(file);
+    e.target.value = ""; // 同じファイルを連続選択できるようにリセット
+  }
+
   return (
     <main style={{ padding: "24px 16px 96px" }}>
       <section style={{ maxWidth: 760, margin: "0 auto", display: "grid", gap: 16 }}>
@@ -178,6 +219,42 @@ export default function ToolClient({ reference }: Props) {
               ))}
             </ul>
           )}
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gap: 8,
+            marginTop: 8,
+            paddingTop: 16,
+            borderTop: "1px solid var(--color-border)",
+          }}
+        >
+          <div style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 700 }}>
+            バックアップ
+          </div>
+          <p style={{ fontSize: 12, color: "var(--color-text-sub)", margin: 0 }}>
+            端末を変えるときや誤って消したときのために、JSON で書き出し・取り込みできます。取り込みは既存に追加され、同じ銘柄は重複しません。
+          </p>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button type="button" onClick={exportBackup} style={toolbarButtonStyle}>
+              エクスポート（書き出し）
+            </button>
+            <button
+              type="button"
+              onClick={() => importInputRef.current?.click()}
+              style={toolbarButtonStyle}
+            >
+              インポート（取り込み）
+            </button>
+            <input
+              ref={importInputRef}
+              type="file"
+              accept="application/json,.json"
+              onChange={onImportInputChange}
+              style={{ display: "none" }}
+            />
+          </div>
         </div>
       </section>
 
@@ -466,4 +543,15 @@ const numberInputStyle: React.CSSProperties = {
   background: "var(--color-bg-input)",
   color: "var(--color-text)",
   fontSize: 13,
+};
+
+const toolbarButtonStyle: React.CSSProperties = {
+  padding: "8px 14px",
+  borderRadius: 8,
+  border: "1.5px solid var(--color-border-strong)",
+  background: "var(--color-bg-card)",
+  color: "var(--color-text-sub)",
+  fontSize: 13,
+  fontWeight: 700,
+  cursor: "pointer",
 };

--- a/app/tools/my-stocks/__tests__/backup.test.ts
+++ b/app/tools/my-stocks/__tests__/backup.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import type { MyStockItem } from "../types";
+import {
+  BACKUP_SCHEMA,
+  mergeItems,
+  parseBackupItems,
+  serializeBackup,
+} from "../backup";
+
+function item(overrides: Partial<MyStockItem> = {}): MyStockItem {
+  return {
+    id: "id-1",
+    code: "7203",
+    name: "トヨタ自動車",
+    market: "プライム（内国株式）",
+    sector: "輸送用機器",
+    tab: "holding",
+    quantity: 100,
+    acquisitionPrice: 2500,
+    memo: "",
+    addedAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe("serializeBackup / parseBackupItems", () => {
+  it("直列化したものを復元できる（round-trip）", () => {
+    const items = [item(), item({ id: "id-2", code: "6758", name: "ソニーG", tab: "watch" })];
+    const restored = parseBackupItems(serializeBackup(items));
+    expect(restored).not.toBeNull();
+    expect(restored).toHaveLength(2);
+    expect(restored?.[0].code).toBe("7203");
+  });
+
+  it("schema を持つバックアップ形式を受け付ける", () => {
+    const text = JSON.stringify({
+      schema: BACKUP_SCHEMA,
+      version: 1,
+      exportedAt: "2026-05-31T00:00:00.000Z",
+      items: [item()],
+    });
+    expect(parseBackupItems(text)).toHaveLength(1);
+  });
+
+  it("items 配列のみの JSON も寛容に受け付ける", () => {
+    expect(parseBackupItems(JSON.stringify([item()]))).toHaveLength(1);
+  });
+
+  it("不正な JSON は null", () => {
+    expect(parseBackupItems("{ not json")).toBeNull();
+  });
+
+  it("schema 不一致のオブジェクトは null", () => {
+    const text = JSON.stringify({ schema: "other", items: [item()] });
+    expect(parseBackupItems(text)).toBeNull();
+  });
+
+  it("不正な要素は正規化で除去される", () => {
+    const text = JSON.stringify([item(), { foo: "bar" }, { tab: "holding" }]);
+    expect(parseBackupItems(text)).toHaveLength(1);
+  });
+});
+
+describe("mergeItems", () => {
+  it("同一タブ・同一コードはスキップして既存を優先する", () => {
+    const current = [item({ id: "cur", memo: "既存メモ" })];
+    const incoming = [item({ id: "inc", memo: "取込メモ" })];
+    const result = mergeItems(current, incoming);
+    expect(result.added).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.merged).toHaveLength(1);
+    expect(result.merged[0].memo).toBe("既存メモ");
+  });
+
+  it("タブが違えば同一コードでも追加する", () => {
+    const current = [item({ id: "cur", tab: "holding" })];
+    const incoming = [item({ id: "inc", tab: "watch" })];
+    const result = mergeItems(current, incoming);
+    expect(result.added).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.merged).toHaveLength(2);
+  });
+
+  it("id が衝突する追加項目は新しい id を振り直す", () => {
+    const current = [item({ id: "dup", code: "7203", tab: "holding" })];
+    const incoming = [item({ id: "dup", code: "6758", tab: "holding" })];
+    const result = mergeItems(current, incoming);
+    expect(result.added).toBe(1);
+    const ids = result.merged.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length); // 全 id 一意
+  });
+});

--- a/app/tools/my-stocks/backup.ts
+++ b/app/tools/my-stocks/backup.ts
@@ -1,0 +1,93 @@
+// app/tools/my-stocks/backup.ts
+import type { MyStockItem } from "./types";
+import { newId, normalizeItems } from "./storage";
+
+export const BACKUP_SCHEMA = "mini-tools/my-stocks";
+export const BACKUP_VERSION = 1;
+
+export type BackupFile = {
+  schema: typeof BACKUP_SCHEMA;
+  version: number;
+  exportedAt: string;
+  items: MyStockItem[];
+};
+
+/** items をバックアップ JSON 文字列に直列化する。 */
+export function serializeBackup(items: MyStockItem[]): string {
+  const payload: BackupFile = {
+    schema: BACKUP_SCHEMA,
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    items,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+/**
+ * バックアップ JSON 文字列を検証して items を取り出す。
+ * - 直接 items 配列のみの JSON も受け付ける（寛容に）
+ * - schema が一致しない / items が無い場合は null
+ * 純粋関数（window 非依存）。
+ */
+export function parseBackupItems(text: string): MyStockItem[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  // 配列がそのまま渡されたケース
+  if (Array.isArray(parsed)) {
+    return normalizeItems(parsed);
+  }
+
+  if (parsed && typeof parsed === "object") {
+    const obj = parsed as Partial<BackupFile>;
+    if (obj.schema === BACKUP_SCHEMA && Array.isArray(obj.items)) {
+      return normalizeItems(obj.items);
+    }
+  }
+
+  return null;
+}
+
+export type MergeResult = {
+  merged: MyStockItem[];
+  added: number;
+  skipped: number;
+};
+
+/**
+ * 既存 items に incoming を非破壊マージする。
+ * - 同一タブ・同一コードは既存を優先してスキップ
+ * - id が衝突する場合は新しい id を振り直す
+ */
+export function mergeItems(current: MyStockItem[], incoming: MyStockItem[]): MergeResult {
+  const seenKeys = new Set(current.map((it) => `${it.tab}:${it.code}`));
+  const usedIds = new Set(current.map((it) => it.id));
+
+  const additions: MyStockItem[] = [];
+  let skipped = 0;
+
+  for (const item of incoming) {
+    const key = `${item.tab}:${item.code}`;
+    if (seenKeys.has(key)) {
+      skipped += 1;
+      continue;
+    }
+    seenKeys.add(key);
+
+    let id = item.id;
+    if (usedIds.has(id)) id = newId();
+    usedIds.add(id);
+
+    additions.push({ ...item, id });
+  }
+
+  return {
+    merged: [...additions, ...current],
+    added: additions.length,
+    skipped,
+  };
+}

--- a/app/tools/my-stocks/storage.ts
+++ b/app/tools/my-stocks/storage.ts
@@ -7,9 +7,47 @@ function isStockTab(value: unknown): value is StockListTab {
   return value === "holding" || value === "watch";
 }
 
+/** 端末・テスト双方で動く ID 生成。 */
+export function newId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * 任意の入力（localStorage / インポートファイル）を MyStockItem[] に正規化する。
+ * 不正な要素は捨て、欠損フィールドは補完する。純粋関数（window 非依存）。
+ */
+export function normalizeItems(parsed: unknown): MyStockItem[] {
+  if (!Array.isArray(parsed)) return [];
+
+  const normalized: MyStockItem[] = [];
+  for (const it of parsed) {
+    if (
+      it &&
+      typeof it === "object" &&
+      typeof (it as MyStockItem).id === "string" &&
+      typeof (it as MyStockItem).code === "string" &&
+      typeof (it as MyStockItem).name === "string" &&
+      isStockTab((it as MyStockItem).tab)
+    ) {
+      const item = it as MyStockItem;
+      normalized.push({
+        ...item,
+        market: typeof item.market === "string" ? item.market : "",
+        sector: typeof item.sector === "string" ? item.sector : null,
+        addedAt: typeof item.addedAt === "number" ? item.addedAt : Date.now(),
+        updatedAt:
+          typeof item.updatedAt === "number" ? item.updatedAt : item.addedAt ?? Date.now(),
+      });
+    }
+  }
+  return normalized;
+}
+
 /**
  * localStorage から銘柄一覧を読む。
- * 壊れたデータや旧形式は読み取り時に正規化し、保存し直す。
  * SSR では window が無いので空配列を返す（hydration ガイドライン準拠）。
  */
 export function loadItems(): MyStockItem[] {
@@ -17,31 +55,7 @@ export function loadItems(): MyStockItem[] {
   try {
     const raw = localStorage.getItem(ITEMS_KEY);
     if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-
-    const normalized: MyStockItem[] = [];
-    for (const it of parsed) {
-      if (
-        it &&
-        typeof it === "object" &&
-        typeof (it as MyStockItem).id === "string" &&
-        typeof (it as MyStockItem).code === "string" &&
-        typeof (it as MyStockItem).name === "string" &&
-        isStockTab((it as MyStockItem).tab)
-      ) {
-        const item = it as MyStockItem;
-        normalized.push({
-          ...item,
-          market: typeof item.market === "string" ? item.market : "",
-          sector: typeof item.sector === "string" ? item.sector : null,
-          addedAt: typeof item.addedAt === "number" ? item.addedAt : Date.now(),
-          updatedAt:
-            typeof item.updatedAt === "number" ? item.updatedAt : item.addedAt ?? Date.now(),
-        });
-      }
-    }
-    return normalized;
+    return normalizeItems(JSON.parse(raw) as unknown);
   } catch {
     return [];
   }

--- a/docs/decision-log/2026-05-31-my-stocks-public-watchlist.md
+++ b/docs/decision-log/2026-05-31-my-stocks-public-watchlist.md
@@ -79,10 +79,28 @@
 - JSON エクスポート/インポート（バックアップ・端末移行）。
 - premium portfolio との将来的なデータ共有/インポート導線。
 
+## 追記（2026-05-31）次フェーズの着手判断
+
+MVP マージ後、残課題の進め方を整理した。
+
+- **Phase 2a（JSON エクスポート/インポート）を先行実装**する。
+  - 自己完結・privacy 懸念なし・外部依存なしのため低リスク。
+  - インポートは**非破壊マージ**（同一タブ・同一コードは既存優先でスキップ、id 衝突は振り直し）。
+  - バックアップ形式は `{ schema: "mini-tools/my-stocks", version, exportedAt, items }`。
+    items 配列のみの JSON も寛容に受け付ける。
+- **Phase 2b（TDNET/EDINET フィード連携）は保留**する。
+  - TDNET/EDINET は API 専用・日次フィードで、開示は件数が多い（7日で数百〜、30日で数千件）。
+  - 「銘柄コードをサーバへ送らない」方針と転送量がトレードオフになるため、
+    着手前に次の方式を決める:
+    - 案A: 広めに取得しクライアントで code filter（現方針踏襲・転送量重い）
+    - 案B: 自社 API ルートへコード集合を送り該当分のみ取得（軽量だがコードがサーバに出る→新 decision-log 必要）
+  - バッジ（code→1値の点引き）はデータ量が小さく案A相当で問題なかったが、
+    フィードは件数が桁違いのため同じ方式だと転送量が効く点が判断ポイント。
+
 ## 関連
 
 - Issue:
-- PR:
+- PR: #346（MVP）
 - 参照 docs:
   - [2026-04-25-premium-portfolio-dashboard.md](./2026-04-25-premium-portfolio-dashboard.md)
   - [2026-03-12-ssr-localstorage-hydration-guidelines.md](./2026-03-12-ssr-localstorage-hydration-guidelines.md)


### PR DESCRIPTION
## 概要

マイ銘柄リスト（`/tools/my-stocks`）に **JSON エクスポート/インポート（バックアップ）** を追加。端末移行・誤削除全損対策。

次フェーズの計画整理で「2a（本PR）を先行・2b（TDNET/EDINETフィード）は保留」と判断した経緯は [decision-log の追記](docs/decision-log/2026-05-31-my-stocks-public-watchlist.md) を参照。

## 変更点

- **エクスポート**: `{ schema: "mini-tools/my-stocks", version, exportedAt, items }` を `my-stocks-backup-YYYYMMDD.json` で書き出し
- **インポート**: ファイル選択 → 検証 → **非破壊マージ**（同一タブ・同一コードは既存優先でスキップ、id 衝突は振り直し）→ 追加/スキップ件数を通知
- `storage.ts` を `normalizeItems` / `newId` に切り出し、読込・取込で共通化
- 純粋関数（serialize / parse / merge）の**ユニットテスト9件**を追加

## privacy

- 書き出し/取り込みはすべて端末内で完結。サーバー送信なし（既存方針を維持）。

## 確認

- `npm run lint` ✅
- `npm run build` ✅（`/tools/my-stocks` 静的生成）
- `npx vitest run app/tools/my-stocks` ✅（9件パス）

## 保留（次フェーズ・要判断）

- 2b: TDNET/EDINET マイ銘柄フィード（案A: クライアント filter / 案B: 自社API）。decision-log に論点記載済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
