### PR TITLE
Fix investor-flow summary fallback

### DIFF
--- a/app/tools/investor-flow/ToolClient.tsx
+++ b/app/tools/investor-flow/ToolClient.tsx
@@ -182,6 +182,27 @@ function getTopMovers(records: InvestorFlowRecord[]) {
     .slice(0, 6);
 }
 
+function getRawNetRanking(records: InvestorFlowRecord[]): InvestorFlowNetRankingItem[] {
+  return records
+    .filter((record) => record.category !== "総計" && record.category !== "委託計")
+    .map((record) => ({
+      category: record.category,
+      buy_yen: record.buy_yen,
+      sell_yen: record.sell_yen,
+      diff_yen: record.diff_yen,
+      direction: record.diff_yen > 0 ? "net_buy" : record.diff_yen < 0 ? "net_sell" : "flat",
+      previous_diff_yen: null,
+      diff_change_yen: null,
+      rank_by_abs_diff: 0,
+    }))
+    .sort((a, b) => Math.abs(b.diff_yen) - Math.abs(a.diff_yen))
+    .map((item, index) => ({ ...item, rank_by_abs_diff: index + 1 }));
+}
+
+function getLargestByDirection(items: InvestorFlowNetRankingItem[], direction: "net_buy" | "net_sell") {
+  return items.find((item) => item.direction === direction) ?? null;
+}
+
 function getTopAnalysisMovers(analysis: InvestorFlowAnalysisPayload) {
   return analysis.net_ranking
     .filter((item) => item.category !== "総計" && item.category !== "委託計")
@@ -194,6 +215,18 @@ function getCompositionShare(
   category: string,
 ) {
   return items.find((item) => item.group === group && item.category === category)?.share_pct ?? null;
+}
+
+function getRawShare(
+  records: InvestorFlowRecord[],
+  denominatorCategory: string,
+  category: string,
+  amountKey: "buy_yen" | "sell_yen",
+) {
+  const denominator = getRecord(records, denominatorCategory)?.[amountKey];
+  const amount = getRecord(records, category)?.[amountKey];
+  if (!denominator || !amount) return null;
+  return (amount / denominator) * 100;
 }
 
 function MetricCard({
@@ -570,6 +603,61 @@ function AnalysisSummaryView({ analysis }: { analysis: InvestorFlowAnalysisPaylo
   );
 }
 
+function RawSummaryView({ records }: { records: InvestorFlowRecord[] }) {
+  const ranking = getRawNetRanking(records);
+  const largestNetBuy = getLargestByDirection(ranking, "net_buy");
+  const largestNetSell = getLargestByDirection(ranking, "net_sell");
+  const overseasBuyShare = getRawShare(records, "委託計", "海外投資家", "buy_yen");
+  const individualBuyShare = getRawShare(records, "委託計", "個人", "buy_yen");
+  const proprietaryBuyShare = getRawShare(records, "総計", "自己計", "buy_yen");
+
+  return (
+    <div style={styles.analysisLayout}>
+      <section style={styles.analysisMetricGrid}>
+        <AnalysisMetricCard
+          title="最大の買い越し"
+          value={largestNetBuy ? formatYen(largestNetBuy.diff_yen) : "—"}
+          sub={largestNetBuy?.category ?? "該当なし"}
+          tone="buy"
+        />
+        <AnalysisMetricCard
+          title="最大の売り越し"
+          value={largestNetSell ? formatYen(largestNetSell.diff_yen) : "—"}
+          sub={largestNetSell?.category ?? "該当なし"}
+          tone="sell"
+        />
+        <AnalysisMetricCard
+          title="海外投資家の買い構成"
+          value={formatPct(overseasBuyShare)}
+          sub="委託計の買いに占める割合"
+          tone="neutral"
+        />
+        <AnalysisMetricCard
+          title="個人の買い構成"
+          value={formatPct(individualBuyShare)}
+          sub={`自己計は総計の ${formatPct(proprietaryBuyShare)}`}
+          tone="neutral"
+        />
+      </section>
+
+      <div style={styles.viewGrid}>
+        <AnalysisMoverList items={ranking.slice(0, 6)} />
+        <section style={styles.signalPanel}>
+          <div style={styles.panelTitle}>反転した主体</div>
+          <div style={styles.panelSub}>前週比較が取得できると表示されます。</div>
+          <div style={styles.emptyMini}>分析サマリーの公開待ちです。</div>
+        </section>
+      </div>
+
+      <section style={styles.signalPanel}>
+        <div style={styles.panelTitle}>継続している流れ</div>
+        <div style={styles.panelSub}>複数週の比較データが取得できると表示されます。</div>
+        <div style={styles.emptyMini}>現在は当週の raw データから分かる範囲を表示しています。</div>
+      </section>
+    </div>
+  );
+}
+
 function SummaryView({
   records,
   analysis,
@@ -581,21 +669,7 @@ function SummaryView({
     return <AnalysisSummaryView analysis={analysis} />;
   }
 
-  return (
-    <div style={styles.viewGrid}>
-      <MoverList records={records} />
-      <section style={styles.compactCompositionGrid}>
-        {COMPOSITION_GROUPS.map((group) => (
-          <CompactCompositionCard
-            key={group.title}
-            title={group.title}
-            denominator={getRecord(records, group.denominator)}
-            records={pickRecords(records, group.categories)}
-          />
-        ))}
-      </section>
-    </div>
-  );
+  return <RawSummaryView records={records} />;
 }
 
 function StructureNode({
@@ -1127,6 +1201,7 @@ const styles: Record<string, CSSProperties> = {
   signalPanel: {
     display: "grid",
     gap: 10,
+    alignSelf: "start",
     padding: 14,
     borderRadius: 14,
     border: "1px solid rgba(15,23,42,0.08)",

--- a/docs/specs/tools/investor-flow.md
+++ b/docs/specs/tools/investor-flow.md
@@ -27,7 +27,8 @@
   - 差引金額ランキング
   - 前週から買い越し/売り越しが反転した主体
   - 同方向が継続している主体
-- 分析 API が取得できない場合は、raw investor-flow payload から従来のサマリーを表示する
+- 分析 API が取得できない場合も、raw investor-flow payload から計算できる範囲で同じサマリー枠を表示する
+- raw のみの場合、反転・継続は比較データ待ちとして表示する
 - 構造タブは `総計 -> 自己計 / 委託計 -> 委託内訳` の関係を表示する
 - 詳細タブは各内訳テーブルを表示する
 
@@ -61,7 +62,7 @@
 | 週切替 | query string を更新し、server component を再評価する |
 | API 未設定 | データ取得先が未接続 |
 | raw payload 取得失敗 | 選択週のデータ取得失敗 card |
-| analysis payload 取得失敗 | 注意表示を出し、raw payload 由来の表示に fallback |
+| analysis payload 取得失敗 | 注意表示を出し、raw payload から計算できるサマリーに fallback |
 
 ## premium / 権限制御
 

--- a/docs/uat/investor-flow.md
+++ b/docs/uat/investor-flow.md
@@ -14,8 +14,8 @@
 |---|---|---|
 | raw manifest | `MARKET_INFO_API_BASE_URL/investor-flow/manifest` | 未接続表示 |
 | raw latest / week | `MARKET_INFO_API_BASE_URL/investor-flow/latest` または `/weeks/{start}/{end}` | 選択週の error card |
-| analysis manifest | `MARKET_INFO_API_BASE_URL/investor-flow/analysis/manifest` | raw 表示に fallback |
-| analysis latest / week | `MARKET_INFO_API_BASE_URL/investor-flow/analysis/latest` または `/analysis/weeks/{start}/{end}` | raw 表示に fallback |
+| analysis manifest | `MARKET_INFO_API_BASE_URL/investor-flow/analysis/manifest` | raw から計算できるサマリーに fallback |
+| analysis latest / week | `MARKET_INFO_API_BASE_URL/investor-flow/analysis/latest` または `/analysis/weeks/{start}/{end}` | raw から計算できるサマリーに fallback |
 
 - repo 同梱 JSON fallback は持たない
 - 週切替は query string 更新で server component を再評価する
@@ -37,7 +37,7 @@
 |---|---|
 | `MARKET_INFO_API_BASE_URL` 未設定 | 「データ取得先が未接続です」表示 |
 | raw manifest は取れるが raw week が失敗 | 選択週の error card |
-| analysis だけ失敗 | 注意表示を出し、生データ由来のサマリーを表示 |
+| analysis だけ失敗 | 注意表示を出し、生データ由来のサマリーを表示。反転・継続は比較データ待ち表示 |
 | query string の週が manifest にない | manifest latest に正規化 |
 
 ## 環境ごとの注意点


### PR DESCRIPTION
## Summary

- Show the analysis-style summary layout even when the investor-flow analysis API is unavailable
- Compute raw-data fallback values for largest net buy, largest net sell, and buy composition shares
- Keep reversal and streak sections visible as comparison-data waiting states
- Update investor-flow specs/UAT docs to describe the raw-computable fallback

## Verification

- `npm run lint -- app/tools/investor-flow docs/specs/tools/investor-flow.md docs/uat/investor-flow.md`
  - Passed; markdown files are ignored by eslint with warnings
- `npm test -- app/tools/investor-flow/__tests__/data-loader.test.ts`
  - Passed; 7 tests
- `npm run build`
  - Passed
- Local Playwright marker check against current prod API state where analysis latest is 404
  - `最大の買い越し`: found
  - `最大の売り越し`: found
  - `反転した主体`: found
  - `継続している流れ`: found
  - old heading `差引が大きい主体`: not found
  - console errors: none
- `codex --profile review-low review --base main`
  - No introduced correctness issues found

## Notes

- The prod analysis endpoint is still not publishing analysis JSON yet. This PR fixes the mini-tools UI fallback for that condition; analysis publishing remains an operational follow-up in market_info / R2 configuration.
