### PR TITLE
feat(yutai-memo): 日興の信用売り残をオンデマンド取得

### DIFF
--- a/app/api/nikko/short-balance/route.ts
+++ b/app/api/nikko/short-balance/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+import { getApiBaseUrl } from "@/lib/market-api";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** 一度に登録できる銘柄コード数の上限。市場情報・日興への負荷を抑える。 */
+const MAX_CODES = 100;
+
+async function isAuthorized(): Promise<boolean> {
+  // 既存の premium セッション認証を gate に使う。
+  // 第三者が日興セッション / market-info の取得キューを濫費するのを防ぐ。
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+  return verifyPremiumSession(session);
+}
+
+/** 4桁中心の日本株コード。英字混じり（例: 130A）も許容する。 */
+function normalizeCodes(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  for (const v of raw) {
+    if (typeof v !== "string") continue;
+    const code = v.trim().toUpperCase();
+    if (/^[0-9][0-9A-Z]{3}$/.test(code)) seen.add(code);
+    if (seen.size >= MAX_CODES) break;
+  }
+  return [...seen];
+}
+
+/**
+ * 優待銘柄メモ帳から「この銘柄の信用売り残高を取得したい」コードを受け取り、
+ * market-info に取得対象として登録する（完全非同期 = 即返す）。
+ * 実際の取得・公開 JSON 更新は market-info PC が手動パスキーで自分のペースで行う。
+ * 反映は次回のページ読込で loadNikkoShortBalance() が拾う。
+ */
+export async function POST(request: Request) {
+  if (!(await isAuthorized())) {
+    // 未ログイン / セッション期限切れ。クライアントが JSON.parse できるよう JSON で返す。
+    // 存在自体を伏せたい意図で 404 を使うが、ボディは構造化エラー。
+    return NextResponse.json(
+      { error: "ログインが必要です。/premium/login からログインしてください。" },
+      { status: 404 },
+    );
+  }
+
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) {
+    return NextResponse.json(
+      { error: "MARKET_INFO_API_BASE_URL is not configured" },
+      { status: 503 },
+    );
+  }
+
+  let body: { codes?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const codes = normalizeCodes(body.codes);
+  if (codes.length === 0) {
+    return NextResponse.json({ error: "codes is required" }, { status: 400 });
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${apiBase}/nikko/short-balance/request`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ codes }),
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: "market-info への登録に失敗しました", detail: String(e) },
+      { status: 502 },
+    );
+  }
+
+  if (!res.ok) {
+    const upstream = res.status;
+    const retryable = upstream === 503 || upstream === 429;
+    return NextResponse.json(
+      { error: "market-info が登録を受け付けませんでした", upstreamStatus: upstream, retryable },
+      { status: retryable ? upstream : 502 },
+    );
+  }
+
+  // 受付完了。完全非同期なので結果は待たず、登録できた件数だけ返す。
+  return NextResponse.json({ accepted: true, requested: codes.length });
+}

--- a/app/tools/yutai-memo/ClientOnly.tsx
+++ b/app/tools/yutai-memo/ClientOnly.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { createClientOnlyTool } from "@/components/createClientOnlyTool";
+import dynamic from "next/dynamic";
+import type { NikkoShortBalanceData } from "./types";
 
-const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
+const ToolClient = dynamic(() => import("./ToolClient"), { ssr: false });
 
-export default ClientOnly;
+export default function ClientOnly({
+  shortBalance,
+}: {
+  shortBalance: NikkoShortBalanceData;
+}) {
+  return <ToolClient shortBalance={shortBalance} />;
+}

--- a/app/tools/yutai-memo/ToolClient.module.css
+++ b/app/tools/yutai-memo/ToolClient.module.css
@@ -381,6 +381,26 @@
   gap: 8px;
 }
 
+/* ===== 信用売り残高（日興） ===== */
+.shortBalanceBar {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.shortBalanceBadge {
+  color: #0f766e;
+  font-size: 12px;
+  font-weight: 600;
+  background: #ccfbf1;
+  padding: 1px 6px;
+  border-radius: 5px;
+  white-space: nowrap;
+  width: fit-content;
+}
+
 /* ===== Month badges ===== */
 .monthPriorityRow {
   display: flex;

--- a/app/tools/yutai-memo/ToolClient.tsx
+++ b/app/tools/yutai-memo/ToolClient.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useMemo, useState } from "react";
 import styles from "./ToolClient.module.css";
-import type { ArchivedMemoItem, CrossType, MemoItem, Tag } from "./types";
+import type {
+  ArchivedMemoItem,
+  CrossType,
+  MemoItem,
+  NikkoShortBalanceData,
+  Tag,
+} from "./types";
 import { CROSS_TYPES, DEFAULT_TAGS } from "./types";
 import {
   loadArchivedItems,
@@ -179,7 +185,13 @@ const CROSS_TYPE_DESCRIPTIONS: Record<CrossType, string> = {
     "1株だけ持ち続けて保有年数を積み、将来の長期優待条件を満たすことを狙います。",
 };
 
-export default function ToolClient() {
+type ShortBalanceRequestState = "idle" | "loading" | "done" | "error";
+
+export default function ToolClient({
+  shortBalance,
+}: {
+  shortBalance: NikkoShortBalanceData;
+}) {
   const [items, setItems] = useState<MemoItem[]>(() => loadItems());
   const [archives, setArchives] = useState<ArchivedMemoItem[]>(() =>
     loadArchivedItems()
@@ -220,6 +232,9 @@ export default function ToolClient() {
     new Set()
   );
   const [strategyHelpOpen, setStrategyHelpOpen] = useState(false);
+  const [shortBalanceRequest, setShortBalanceRequest] =
+    useState<ShortBalanceRequestState>("idle");
+  const [shortBalanceMessage, setShortBalanceMessage] = useState<string | null>(null);
   const [tickerMaster, setTickerMaster] = useState<TickerMasterItem[]>([]);
   const [tickerMasterError, setTickerMasterError] = useState<string | null>(null);
 
@@ -341,6 +356,64 @@ export default function ToolClient() {
       .slice()
       .sort(compare);
   }, [items, q, monthFilter, tagFilter, tagNameById, sortState]);
+
+  // 日興の信用売り残高: code（大文字）→ 株数。公開 JSON を自分の銘柄で filter する。
+  const sellBalanceByCode = useMemo(() => {
+    const m = new Map<string, number | null>();
+    for (const [code, rec] of Object.entries(shortBalance.byCode)) {
+      m.set(code.toUpperCase(), rec?.sellBalance ?? null);
+    }
+    return m;
+  }, [shortBalance]);
+
+  const numberFormat = useMemo(() => new Intl.NumberFormat("ja-JP"), []);
+
+  // 現在の表示（フィルタ後）からコード付きの銘柄コードを集める。
+  const visibleCodes = useMemo(() => {
+    const set = new Set<string>();
+    for (const it of filtered) {
+      const code = it.code?.trim().toUpperCase();
+      if (code) set.add(code);
+    }
+    return [...set];
+  }, [filtered]);
+
+  // 「取得」: 表示中の銘柄コードを market-info に取得対象として登録する（完全非同期）。
+  // 結果は次回ページ読込で反映されるため、ここでは受付できたかだけを伝える。
+  async function requestShortBalances() {
+    if (shortBalanceRequest === "loading") return;
+    if (visibleCodes.length === 0) {
+      setShortBalanceRequest("error");
+      setShortBalanceMessage("コードが登録された銘柄がありません。");
+      return;
+    }
+    setShortBalanceRequest("loading");
+    setShortBalanceMessage(null);
+    try {
+      const res = await fetch("/api/nikko/short-balance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ codes: visibleCodes }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        accepted?: boolean;
+        requested?: number;
+        error?: string;
+      };
+      if (!res.ok || !data.accepted) {
+        setShortBalanceRequest("error");
+        setShortBalanceMessage(data.error ?? "取得の依頼に失敗しました。");
+        return;
+      }
+      setShortBalanceRequest("done");
+      setShortBalanceMessage(
+        `${data.requested ?? visibleCodes.length}件を取得依頼しました。反映までしばらくかかります（再読み込みで確認）。`,
+      );
+    } catch {
+      setShortBalanceRequest("error");
+      setShortBalanceMessage("通信に失敗しました。時間をおいて再度お試しください。");
+    }
+  }
 
   function openNew(seed?: Partial<Draft>) {
     if (typeof window !== "undefined") {
@@ -1029,6 +1102,31 @@ export default function ToolClient() {
             </select>
           </div>
 
+          <div className={styles.shortBalanceBar}>
+            <button
+              className={styles.btn}
+              type="button"
+              onClick={requestShortBalances}
+              disabled={shortBalanceRequest === "loading"}
+              title="表示中の銘柄の日興・信用売り残高を取得依頼します（反映は後ほど）"
+            >
+              {shortBalanceRequest === "loading"
+                ? "取得依頼中…"
+                : `売り残を取得（表示中${visibleCodes.length}件）`}
+            </button>
+            {shortBalance.asOf ? (
+              <span className={styles.small}>売り残基準日: {shortBalance.asOf}</span>
+            ) : null}
+            {shortBalanceMessage ? (
+              <span
+                className={styles.small}
+                style={{ color: shortBalanceRequest === "error" ? "#c0392b" : undefined }}
+              >
+                {shortBalanceMessage}
+              </span>
+            ) : null}
+          </div>
+
           {showTickerSearchHint ? (
             <div className={styles.small}>{tickerSearchHintMessage}</div>
           ) : null}
@@ -1217,6 +1315,18 @@ export default function ToolClient() {
                                 ({normalizeDisplayText(it.code)})
                               </span>
                             ) : null}
+                            {(() => {
+                              if (!it.code) return null;
+                              const code = it.code.trim().toUpperCase();
+                              if (!sellBalanceByCode.has(code)) return null;
+                              const bal = sellBalanceByCode.get(code) ?? null;
+                              return (
+                                <span className={styles.shortBalanceBadge}>
+                                  売り残{" "}
+                                  {bal === null ? "—" : `${numberFormat.format(bal)}株`}
+                                </span>
+                              );
+                            })()}
                           </div>
                         </div>
                         <div className={styles.monthPriorityRow}>

--- a/app/tools/yutai-memo/__tests__/data-loader.test.ts
+++ b/app/tools/yutai-memo/__tests__/data-loader.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NikkoShortBalanceData } from "../types";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from "node:fs/promises";
+import { loadNikkoShortBalance } from "../data-loader";
+
+const mockReadFile = vi.mocked(readFile);
+
+const SAMPLE: NikkoShortBalanceData = {
+  asOf: "2026-06-02",
+  byCode: { "7203": { sellBalance: 1234500 } },
+};
+
+function makeFetchOk(body: unknown): Response {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+function makeFetch500(): Response {
+  return { ok: false, status: 500 } as unknown as Response;
+}
+
+describe("loadNikkoShortBalance", () => {
+  beforeEach(() => {
+    mockReadFile.mockReset();
+    vi.stubGlobal("fetch", vi.fn());
+    process.env.NODE_ENV = "test";
+    delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("API 未設定のとき、ローカルサンプルを返す（fetch しない）", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify(SAMPLE));
+
+    const result = await loadNikkoShortBalance();
+
+    expect(result).toEqual(SAMPLE);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("API 未設定・サンプルも無いとき、空表を返す", async () => {
+    mockReadFile.mockRejectedValue(new Error("not found"));
+
+    const result = await loadNikkoShortBalance();
+
+    expect(result).toEqual({ asOf: null, byCode: {} });
+  });
+
+  it("API 設定あり・正常レスポンスのとき、API の値を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockResolvedValue(makeFetchOk(SAMPLE));
+
+    const result = await loadNikkoShortBalance();
+
+    expect(result).toEqual(SAMPLE);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.com/nikko/short-balance",
+      expect.anything(),
+    );
+  });
+
+  it("API 設定あり・fetch 失敗のとき、サンプルにフォールバックせず空表を返す", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch).mockResolvedValue(makeFetch500());
+
+    const result = await loadNikkoShortBalance();
+
+    expect(result).toEqual({ asOf: null, byCode: {} });
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+});

--- a/app/tools/yutai-memo/data-loader.ts
+++ b/app/tools/yutai-memo/data-loader.ts
@@ -1,0 +1,43 @@
+// app/tools/yutai-memo/data-loader.ts
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import type { NikkoShortBalanceData } from "./types";
+
+const EMPTY: NikkoShortBalanceData = { asOf: null, byCode: {} };
+
+async function loadLocalSample(): Promise<NikkoShortBalanceData | null> {
+  try {
+    const raw = await readFile(
+      path.join(process.cwd(), "app/tools/yutai-memo/data/nikko_short_balance_sample.json"),
+      "utf-8",
+    );
+    return JSON.parse(raw) as NikkoShortBalanceData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 日興の信用売り残高（株数）の公開 JSON を取得する。
+ * market-info は「登録された銘柄コードだけ」を取得して by_code に載せる
+ * （全銘柄取得は行わない）。ユーザーの保有銘柄コードはここでは使わず、
+ * クライアントが自分のコードで filter して表示する。
+ *
+ * API 未設定時はサンプルにフォールバック（開発用）。
+ * API あり・fetch 失敗時はサンプルを返さず空表にする（誤情報防止）。
+ */
+export async function loadNikkoShortBalance(): Promise<NikkoShortBalanceData> {
+  const apiBase = getApiBaseUrl();
+
+  if (!apiBase) {
+    return (canUseLocalMarketDataFallback() ? await loadLocalSample() : null) ?? EMPTY;
+  }
+
+  try {
+    // 反映は「いつか反映される」型なので頻繁な再取得は不要。60 秒キャッシュ。
+    return await fetchJson<NikkoShortBalanceData>(`${apiBase}/nikko/short-balance`, 60);
+  } catch {
+    return EMPTY;
+  }
+}

--- a/app/tools/yutai-memo/data/nikko_short_balance_sample.json
+++ b/app/tools/yutai-memo/data/nikko_short_balance_sample.json
@@ -1,0 +1,8 @@
+{
+  "asOf": "2026-06-02",
+  "byCode": {
+    "7203": { "sellBalance": 1234500 },
+    "8591": { "sellBalance": 56700 },
+    "9433": { "sellBalance": null }
+  }
+}

--- a/app/tools/yutai-memo/page.tsx
+++ b/app/tools/yutai-memo/page.tsx
@@ -1,6 +1,7 @@
 // app/tools/yutai-memo/page.tsx
 import type { Metadata } from "next";
 import ClientOnly from "./ClientOnly";
+import { loadNikkoShortBalance } from "./data-loader";
 
 export const metadata: Metadata = {
   title: "優待銘柄メモ帳 | mini-tools",
@@ -11,10 +12,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Page() {
+export default async function Page() {
+  // 日興の信用売り残高（公開 JSON）をサーバ側で読み、クライアントへ渡す。
+  // クライアントが自分のメモ銘柄コードで filter して表示する。
+  const shortBalance = await loadNikkoShortBalance();
   return (
     <>
-      <ClientOnly />
+      <ClientOnly shortBalance={shortBalance} />
     </>
   );
 }

--- a/app/tools/yutai-memo/types.ts
+++ b/app/tools/yutai-memo/types.ts
@@ -41,6 +41,23 @@ export type MemoItem = {
   updatedAt: string; // ISO
 };
 
+/**
+ * 日興証券の信用売り残高（株数）。クロス取引が今可能かの判断材料。
+ * market-info が「登録された銘柄コードだけ」取得して公開する JSON の shape。
+ * 用途を信用売り残高に限定しているため項目は最小（買い残・前週比などは持たない）。
+ */
+export type NikkoShortBalanceRecord = {
+  /** 信用売り残高（株数）。取得できなければ null。 */
+  sellBalance: number | null;
+};
+
+export type NikkoShortBalanceData = {
+  /** 基準日（YYYY-MM-DD）。取得できなければ null。 */
+  asOf: string | null;
+  /** code → 信用売り残高。market-info に登録済みのコードのみ載る。 */
+  byCode: Record<string, NikkoShortBalanceRecord>;
+};
+
 export type ArchivedMemoItem = {
   id: string;
   memoId: string;

--- a/docs/decision-log/2026-06-03-yutai-memo-short-balance-on-demand.md
+++ b/docs/decision-log/2026-06-03-yutai-memo-short-balance-on-demand.md
@@ -1,0 +1,68 @@
+# 2026-06-03 優待銘柄メモ帳の信用売り残オンデマンド取得
+
+## 背景
+
+- 優待銘柄メモ帳（`app/tools/yutai-memo`）で、その月にウォッチしている銘柄について「今クロス取引が可能か」を判断したい。
+- 判断材料は日興証券（SMBC日興）の **信用売り残高（株数）**。残数が減っていればクロスしづらい、という用途。
+- 銘柄コードはブラウザの localStorage（`MemoItem[]`）にしか無い。
+- 現状の market-info は全銘柄を一括取得する作りで、ウォッチ銘柄だけ知りたい今回の用途には不要なデータ・サーバ負荷が発生する。
+- 日興は手動パスキー認証であり、取得実行は market-info のある PC 上で行う前提。
+
+## 今回決めたこと
+
+### データ
+- 取得項目は **信用売り残高（株数）のみ**。買い残・前週比・貸借倍率などは現時点では持たない。
+- 目的は「残数を見て今クロス取引が可能か」を知ることに限定する。
+
+### 取得フロー（完全非同期・「いつか反映」型）
+1. **登録**: 優待銘柄メモ帳の「取得」ボタン → 対象月の銘柄コードを mini-tools の API route に POST → market-info に「このコードを取得対象に登録」して即返す（クライアントは待たない）。API route は既存の premium セッション認証でゲートする。
+2. **取得**: market-info PC（手動パスキーでログイン済みセッション）が、登録されたコードだけ日興をスクレイピングし、公開 JSON `/nikko/short-balance`（`{ asOf, byCode }`）を更新する。自分のペース（キュー/定期実行）で良い。
+3. **反映**: 次に優待銘柄メモ帳を開く／再読込したとき、data-loader が公開 JSON を読み、クライアントが自分のコードで filter してカード内に売り残＋取得日（asOf）を表示する。
+
+### 想定する型（mini-tools 側）
+```ts
+type NikkoShortBalanceRecord = {
+  sellBalance: number | null; // 信用売り残高（株数）
+};
+type NikkoShortBalanceData = {
+  asOf: string | null;
+  byCode: Record<string, NikkoShortBalanceRecord>;
+};
+```
+
+## 判断理由
+
+- **完全非同期にした理由**: ライブ取得は銘柄数×秒かかり、同期で待たせるとタイムアウト・UX 悪化を招く。利用者が「いつか反映されればよい」と許容したため、ジョブ状態を mini-tools 側で追わない静的 JSON 反映型が最小実装で済む。
+- **静的 JSON 反映型を採った理由**: market-info は既に「事前生成した静的 JSON を配信」する作り。反映ステップ（3）が既存の `loadNikkoCreditData()`（`app/tools/yutai-candidates/data-loader.ts`）と同型でコピーするだけになる。ポーリングやジョブ ID 管理が不要。
+- **採らなかった案**:
+  - 同期＋件数上限案: 実装は単純だが、セッション切れ時のハードエラー UI とタイムアウト対策が必要になり、非同期許容なら不要。
+  - 往復コピペ案（コード書き出し → PC スクリプト → 貼り付けインポート）: 手作業が増え、ボタン一発で完結する今回の要望に合わない。
+- **セッション切れの扱い**: market-info 側で日興セッションが切れていればコードは「保留」のまま、再ログイン後に取得して次回反映。完全非同期のためハードエラー UI が不要になり、同期案より堅牢。
+- **コードをサーバへ送る点**: マイ銘柄リスト（my-stocks）は意図的にコードをサーバへ送らない方針だが、本機能は「選んだ少数コードだけを取得対象に登録する」ことが目的そのものであり、全銘柄取得を避けるための departure として許容する。premium 認証ゲートで第三者の濫用を防ぐ。
+
+## 影響範囲
+
+- mini-tools（新規）:
+  - `app/api/nikko/short-balance/route.ts` — POST codes・premium 認証で market-info に登録。先例: `app/api/yutai-expiry/scan/route.ts`
+  - data-loader に `loadNikkoShortBalance()` ＋ 型 `NikkoShortBalanceData`。先例: `app/tools/yutai-candidates/data-loader.ts` の Nikko 系
+  - `app/tools/yutai-memo/page.tsx` → `ClientOnly` → カードへ reference 配線＋「取得」ボタン。先例: `app/tools/my-stocks/page.tsx` の reference 配線
+- market-info（別リポジトリ・新規）:
+  - 銘柄コードの「取得対象登録」受け口
+  - 登録コードのみ日興をスクレイピング
+  - 公開 JSON `/nikko/short-balance` の配信
+- 既存の全銘柄取得パイプラインには手を入れない。
+
+## 残課題
+
+- market-info 側の動的取得エンドポイント・スクレイパは本リポジトリ外で別途実装する。
+- 取得結果のキャッシュ方針（当日分の再取得抑制など）は実装時に検討。
+- セッション切れを利用者にどこまで可視化するか（保留中バッジ等）は未定。
+- 将来、買い残・前週比などを足すかは需要次第。
+
+## 関連
+
+- Issue:
+- PR:
+- 参照 docs:
+  - `docs/decision-log/2026-05-31-nikko-out-of-stock-shares-based.md`（日興・株数ベースの既存判断）
+  - `docs/decision-log/2026-05-31-my-stocks-public-watchlist.md`（コードをサーバへ送らない方針との対比）


### PR DESCRIPTION
## 概要

優待銘柄メモ帳（yutai-memo）から、**表示中の銘柄コードだけ**を market-info に取得対象として登録し、日興証券の**信用売り残高（株数）**をカードに表示する機能を追加します。「今クロス取引が可能か」を残数で判断するのが目的です。

全銘柄取得ではなく選んだ銘柄だけを対象にすることで、market-info / 日興への負荷を抑えます。

## フロー（完全非同期・「いつか反映」型）

1. **登録**: 「売り残を取得」ボタン → 表示中コードを `POST /api/nikko/short-balance`（premium認証ゲート）→ market-info に登録して即返す
2. **取得**: market-info PC（手動パスキーでログイン済み）が登録コードだけ日興をスクレイプ → 公開JSONを更新（※別リポで実装）
3. **反映**: 次回ページ読込で `loadNikkoShortBalance()` が公開JSONを読み、クライアントが自分のコードで filter してカードに売り残＋基準日を表示

設計判断の詳細は [decision-log](docs/decision-log/2026-06-03-yutai-memo-short-balance-on-demand.md) を参照。

## 変更点（mini-tools 側）

- `types.ts`: `NikkoShortBalanceRecord`（`sellBalance` のみ）/ `NikkoShortBalanceData`
- `data-loader.ts`: `loadNikkoShortBalance()`（API未設定時はサンプルfallback、fetch失敗時は空表）
- `app/api/nikko/short-balance/route.ts`: POST codes → premium認証 → market-info に登録（最大100件・コード正規化）
- `page.tsx` / `ClientOnly.tsx`: async化して reference をクライアントへ配線
- `ToolClient.tsx`: 「売り残を取得（表示中N件）」ボタン＋状態表示、カード内に売り残バッジ
- テスト: data-loader のフォールバック挙動（4ケース）

## market-info 側（別リポで要実装）

mini-tools が前提とする contract:
- `POST ${apiBase}/nikko/short-balance/request` body `{ codes: string[] }` — 取得対象の登録
- `GET ${apiBase}/nikko/short-balance` → `{ asOf, byCode: { "7203": { sellBalance: 1234500 } } }`

## 検証

- ✅ `npm run build` 成功（`/api/nikko/short-balance` 登録、`/tools/yutai-memo` は1分ISR）
- ✅ 型チェック・lint クリーン
- ✅ テスト 4件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)