### PR TITLE
fix(investor-flow): prefer fresh analysis latest

### DIFF
--- a/app/tools/investor-flow/__tests__/data-loader.test.ts
+++ b/app/tools/investor-flow/__tests__/data-loader.test.ts
@@ -204,6 +204,70 @@ describe("investor-flow data-loader", () => {
     );
   });
 
+  it("raw manifest が古い場合は analysis manifest の最新週を選ぶ", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    const freshAnalysisManifest: InvestorFlowAnalysisManifest = {
+      ...ANALYSIS_MANIFEST,
+      latest: {
+        start_date: "2026-05-25",
+        end_date: "2026-05-29",
+        path: "investor_flow_analysis_2026-05-25_to_2026-05-29.json",
+      },
+      weeks: [
+        {
+          start_date: "2026-05-25",
+          end_date: "2026-05-29",
+          path: "investor_flow_analysis_2026-05-25_to_2026-05-29.json",
+        },
+        ...ANALYSIS_MANIFEST.weeks,
+      ],
+    };
+    const freshPayload = { ...PAYLOAD, start_date: "2026-05-25", end_date: "2026-05-29" };
+    const freshAnalysis = { ...ANALYSIS, start_date: "2026-05-25", end_date: "2026-05-29" };
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(makeFetchOk(MANIFEST))
+      .mockResolvedValueOnce(makeFetchOk(freshAnalysisManifest))
+      .mockResolvedValueOnce(makeFetchOk(freshPayload))
+      .mockResolvedValueOnce(makeFetchOk(freshAnalysis));
+
+    const result = await loadInvestorFlowPageData();
+
+    expect(result.selectedWeek?.start_date).toBe("2026-05-25");
+    expect(result.manifest?.latest.start_date).toBe("2026-05-25");
+    expect(result.manifest?.weeks.map((week) => week.start_date)).toEqual([
+      "2026-05-25",
+      "2026-05-18",
+      "2026-05-11",
+    ]);
+    expect(result.payload?.start_date).toBe("2026-05-25");
+    expect(result.analysis?.start_date).toBe("2026-05-25");
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      "https://api.example.com/investor-flow/weeks/2026-05-25/2026-05-29",
+      expect.any(Object),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      4,
+      "https://api.example.com/investor-flow/analysis/latest",
+      expect.any(Object),
+    );
+  });
+
+  it("raw manifest が失敗した場合は analysis manifest だけで接続済みにしない", async () => {
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(makeFetch404())
+      .mockResolvedValueOnce(makeFetchOk(ANALYSIS_MANIFEST));
+
+    const result = await loadInvestorFlowPageData();
+
+    expect(result.manifest).toBeNull();
+    expect(result.selectedWeek).toBeNull();
+    expect(result.payload).toBeNull();
+    expect(result.analysis).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("page data は過去週なら weeks endpoint を使う", async () => {
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch)

--- a/app/tools/investor-flow/data-loader.ts
+++ b/app/tools/investor-flow/data-loader.ts
@@ -8,20 +8,63 @@ import type {
   InvestorFlowWeekRef,
 } from "./types";
 
+const INVESTOR_FLOW_REVALIDATE_SECONDS = 0;
+
+function isAfterWeek(left: InvestorFlowWeekRef | null | undefined, right: InvestorFlowWeekRef | null | undefined) {
+  if (!left) return false;
+  if (!right) return true;
+  if (left.start_date !== right.start_date) return left.start_date > right.start_date;
+  return left.end_date > right.end_date;
+}
+
 function findWeek(
   manifest: InvestorFlowManifest | null,
+  analysisManifest: InvestorFlowAnalysisManifest | null,
   startDate?: string,
   endDate?: string,
 ): InvestorFlowWeekRef | null {
   if (!manifest) return null;
   if (startDate && endDate) {
     return (
-      manifest.weeks.find(
+      manifest?.weeks.find(
         (week) => week.start_date === startDate && week.end_date === endDate,
-      ) ?? manifest.latest
+      ) ??
+      analysisManifest?.weeks.find(
+        (week) => week.start_date === startDate && week.end_date === endDate,
+      ) ??
+      manifest?.latest ??
+      analysisManifest?.latest ??
+      null
     );
   }
-  return manifest.latest;
+  return isAfterWeek(analysisManifest?.latest, manifest?.latest)
+    ? (analysisManifest?.latest ?? null)
+    : (manifest?.latest ?? analysisManifest?.latest ?? null);
+}
+
+function mergeDisplayManifest(
+  manifest: InvestorFlowManifest | null,
+  analysisManifest: InvestorFlowAnalysisManifest | null,
+): InvestorFlowManifest | null {
+  if (!manifest) return null;
+  const latest = isAfterWeek(analysisManifest?.latest, manifest?.latest)
+    ? analysisManifest?.latest
+    : manifest?.latest;
+  if (!latest) return manifest;
+  const weekMap = new Map<string, InvestorFlowWeekRef>();
+  for (const week of [...(analysisManifest?.weeks ?? []), ...(manifest?.weeks ?? [])]) {
+    weekMap.set(`${week.start_date}:${week.end_date}`, week);
+  }
+  const weeks = [...weekMap.values()].sort((left, right) => {
+    if (left.start_date !== right.start_date) return right.start_date.localeCompare(left.start_date);
+    return right.end_date.localeCompare(left.end_date);
+  });
+  return {
+    data_source: manifest?.data_source ?? analysisManifest?.data_source ?? "JPX",
+    latest,
+    weeks,
+    generated_at_jst: manifest?.generated_at_jst ?? analysisManifest?.generated_at_jst ?? "",
+  };
 }
 
 function hasAnalysisWeek(
@@ -49,7 +92,10 @@ export async function loadInvestorFlowManifest(): Promise<InvestorFlowManifest |
   if (!apiBase) return null;
 
   try {
-    return await fetchJson<InvestorFlowManifest>(`${apiBase}/investor-flow/manifest`);
+    return await fetchJson<InvestorFlowManifest>(
+      `${apiBase}/investor-flow/manifest`,
+      INVESTOR_FLOW_REVALIDATE_SECONDS,
+    );
   } catch {
     return null;
   }
@@ -60,7 +106,10 @@ export async function loadInvestorFlowAnalysisManifest(): Promise<InvestorFlowAn
   if (!apiBase) return null;
 
   try {
-    return await fetchJson<InvestorFlowAnalysisManifest>(`${apiBase}/investor-flow/analysis/manifest`);
+    return await fetchJson<InvestorFlowAnalysisManifest>(
+      `${apiBase}/investor-flow/analysis/manifest`,
+      INVESTOR_FLOW_REVALIDATE_SECONDS,
+    );
   } catch {
     return null;
   }
@@ -71,7 +120,10 @@ export async function loadInvestorFlowLatest(): Promise<InvestorFlowPayload | nu
   if (!apiBase) return null;
 
   try {
-    return await fetchJson<InvestorFlowPayload>(`${apiBase}/investor-flow/latest`);
+    return await fetchJson<InvestorFlowPayload>(
+      `${apiBase}/investor-flow/latest`,
+      INVESTOR_FLOW_REVALIDATE_SECONDS,
+    );
   } catch {
     return null;
   }
@@ -82,7 +134,10 @@ export async function loadInvestorFlowAnalysisLatest(): Promise<InvestorFlowAnal
   if (!apiBase) return null;
 
   try {
-    return await fetchJson<InvestorFlowAnalysisPayload>(`${apiBase}/investor-flow/analysis/latest`);
+    return await fetchJson<InvestorFlowAnalysisPayload>(
+      `${apiBase}/investor-flow/analysis/latest`,
+      INVESTOR_FLOW_REVALIDATE_SECONDS,
+    );
   } catch {
     return null;
   }
@@ -98,6 +153,7 @@ export async function loadInvestorFlowWeek(
   try {
     return await fetchJson<InvestorFlowPayload>(
       `${apiBase}/investor-flow/weeks/${startDate}/${endDate}`,
+      INVESTOR_FLOW_REVALIDATE_SECONDS,
     );
   } catch {
     return null;
@@ -114,6 +170,7 @@ export async function loadInvestorFlowAnalysisWeek(
   try {
     return await fetchJson<InvestorFlowAnalysisPayload>(
       `${apiBase}/investor-flow/analysis/weeks/${startDate}/${endDate}`,
+      INVESTOR_FLOW_REVALIDATE_SECONDS,
     );
   } catch {
     return null;
@@ -128,7 +185,8 @@ export async function loadInvestorFlowPageData(
     loadInvestorFlowManifest(),
     loadInvestorFlowAnalysisManifest(),
   ]);
-  const selectedWeek = findWeek(manifest, startDate, endDate);
+  const selectedWeek = findWeek(manifest, analysisManifest, startDate, endDate);
+  const displayManifest = mergeDisplayManifest(manifest, analysisManifest);
   const isLatest =
     selectedWeek &&
     manifest?.latest.start_date === selectedWeek.start_date &&
@@ -153,7 +211,7 @@ export async function loadInvestorFlowPageData(
   const matchedAnalysis = isSameWeek(analysis, selectedWeek) ? analysis : null;
 
   return {
-    manifest,
+    manifest: displayManifest,
     payload,
     analysisManifest,
     analysis: matchedAnalysis,


### PR DESCRIPTION
## Summary

- Prefer the newer analysis manifest latest week when the raw manifest is temporarily stale after publish.
- Merge analysis weeks into the displayed week selector only when the raw manifest exists.
- Disable Next fetch revalidation for investor-flow API calls so publish updates are reflected immediately.

## Verification

- `npm test -- app/tools/investor-flow/__tests__/data-loader.test.ts`
- `npm run lint`
- `npm run build`
- Local production check on `http://127.0.0.1:3004/tools/investor-flow`
  - latest week `2026/05/25 - 2026/05/29` visible
  - previous week `2026/05/18 - 2026/05/22` visible
  - heatmap includes both `05/25` and `05/18`
  - console errors: 0
- `codex review` found no actionable issues after the raw-manifest failure fix.
