### PR TITLE
feat(my-stocks): add stock master list

### DIFF
--- a/app/tools/my-stocks/ToolClient.tsx
+++ b/app/tools/my-stocks/ToolClient.tsx
@@ -17,6 +17,7 @@ type Props = {
   reference: MyStocksReference;
 };
 
+type ViewTab = StockListTab | "master";
 type HoldingViewMode = "list" | "account" | "ratio";
 type AccountGroupKey = "specific" | "nisa" | "other";
 
@@ -24,7 +25,15 @@ const TAB_LABELS: Record<StockListTab, string> = {
   holding: "保有メモ",
   watch: "ウォッチ",
 };
-const TAB_OPTIONS = [TAB_LABELS.holding, TAB_LABELS.watch] as const;
+const VIEW_TAB_LABELS: Record<ViewTab, string> = {
+  ...TAB_LABELS,
+  master: "銘柄一覧",
+};
+const VIEW_TAB_OPTIONS = [
+  VIEW_TAB_LABELS.holding,
+  VIEW_TAB_LABELS.watch,
+  VIEW_TAB_LABELS.master,
+] as const;
 const HOLDING_VIEW_OPTIONS: Array<{ mode: HoldingViewMode; label: string }> = [
   { mode: "list", label: "一覧" },
   { mode: "account", label: "口座別" },
@@ -48,11 +57,18 @@ const ACCOUNT_GROUPS: Array<{ key: AccountGroupKey; label: string; color: string
 
 const STOCK_CHART_COLORS = ["#2563eb", "#16a34a", "#dc2626", "#d97706", "#7c3aed", "#0891b2"];
 const UNDO_MS = 5000;
+const MASTER_PAGE_SIZE = 50;
 
 function formatEarnings(iso: string): string {
   const m = iso.match(/^\d{4}-(\d{2})-(\d{2})$/);
   if (!m) return iso;
   return `${Number(m[1])}/${Number(m[2])}`;
+}
+
+function formatDividend(dividend: MyStocksReference["dividendByCode"][string]): string {
+  const yieldText = `${dividend.yieldPct.toFixed(2)}%`;
+  if (dividend.perShare === null) return yieldText;
+  return `${yieldText} / ${dividend.perShare.toLocaleString("ja-JP")}円`;
 }
 
 function accountMergeKey(item: MyStockItem): string {
@@ -109,9 +125,10 @@ function formatYen(amount: number): string {
 
 export default function ToolClient({ reference }: Props) {
   const [items, setItems] = useState<MyStockItem[]>(() => loadItems());
-  const [tab, setTab] = useState<StockListTab>("holding");
+  const [tab, setTab] = useState<ViewTab>("holding");
   const [holdingViewMode, setHoldingViewMode] = useState<HoldingViewMode>("list");
   const [query, setQuery] = useState("");
+  const [masterPage, setMasterPage] = useState(0);
   const [newHoldingAccountType, setNewHoldingAccountType] = useState<StockAccountType | "">("");
   const [addAccountDrafts, setAddAccountDrafts] = useState<Record<string, StockAccountType | "">>(
     {},
@@ -124,7 +141,11 @@ export default function ToolClient({ reference }: Props) {
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const importInputRef = useRef<HTMLInputElement>(null);
 
-  const master = useStockMaster();
+  const master = useStockMaster(reference.stockMaster);
+
+  useEffect(() => {
+    if (tab === "master") setMasterPage(0);
+  }, [query, tab]);
 
   useEffect(() => {
     return () => {
@@ -145,21 +166,43 @@ export default function ToolClient({ reference }: Props) {
   }
 
   const tabItems = useMemo(
-    () => items.filter((it) => it.tab === tab).sort((a, b) => b.addedAt - a.addedAt),
+    () =>
+      tab === "master"
+        ? []
+        : items.filter((it) => it.tab === tab).sort((a, b) => b.addedAt - a.addedAt),
     [items, tab],
   );
 
   const candidates = useMemo(() => master.search(query, 20), [master, query]);
+  const masterRows = useMemo(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return master.all;
+    const lower = trimmed.toLowerCase();
+    const isCodeLike = /^[0-9a-zA-Z]+$/.test(trimmed);
+    return master.all.filter(
+      (stock) =>
+        (isCodeLike && stock.code.toLowerCase().startsWith(lower)) ||
+        stock.name.toLowerCase().includes(lower),
+    );
+  }, [master, query]);
+  const masterPageCount = Math.max(1, Math.ceil(masterRows.length / MASTER_PAGE_SIZE));
+  const boundedMasterPage = Math.min(masterPage, masterPageCount - 1);
+  const masterPageRows = masterRows.slice(
+    boundedMasterPage * MASTER_PAGE_SIZE,
+    boundedMasterPage * MASTER_PAGE_SIZE + MASTER_PAGE_SIZE,
+  );
 
-  function addStock(stock: StockMaster) {
+  function addStock(stock: StockMaster, targetTab: StockListTab = tab === "master" ? "watch" : tab) {
     const nextAccountOption = ACCOUNT_OPTIONS.find(
       (option) => option.type === newHoldingAccountType,
     );
     const nextKey =
-      tab === "holding" ? `holding:${stock.code}:${newHoldingAccountType}` : `watch:${stock.code}`;
+      targetTab === "holding"
+        ? `holding:${stock.code}:${newHoldingAccountType}`
+        : `watch:${stock.code}`;
     const exists = items.some((it) => accountMergeKey(it) === nextKey);
     if (exists) {
-      flashNotice(`${stock.name} はすでに「${TAB_LABELS[tab]}」にあります`);
+      flashNotice(`${stock.name} はすでに「${TAB_LABELS[targetTab]}」にあります`);
       return;
     }
     const now = Date.now();
@@ -169,19 +212,21 @@ export default function ToolClient({ reference }: Props) {
       name: stock.name,
       market: stock.market,
       sector: stock.sector,
-      tab,
-      accountType: tab === "holding" ? newHoldingAccountType || null : undefined,
+      tab: targetTab,
+      accountType: targetTab === "holding" ? newHoldingAccountType || null : undefined,
       accountLabel:
-        tab === "holding" && newHoldingAccountType ? nextAccountOption?.label ?? null : undefined,
-      quantity: tab === "holding" ? null : undefined,
-      acquisitionPrice: tab === "holding" ? null : undefined,
+        targetTab === "holding" && newHoldingAccountType
+          ? nextAccountOption?.label ?? null
+          : undefined,
+      quantity: targetTab === "holding" ? null : undefined,
+      acquisitionPrice: targetTab === "holding" ? null : undefined,
       memo: "",
       addedAt: now,
       updatedAt: now,
     };
     persist([item, ...items]);
-    setQuery("");
-    flashNotice(`${stock.name} を「${TAB_LABELS[tab]}」に追加しました`);
+    if (tab !== "master") setQuery("");
+    flashNotice(`${stock.name} を「${TAB_LABELS[targetTab]}」に追加しました`);
   }
 
   function updateItem(id: string, patch: Partial<MyStockItem>) {
@@ -339,22 +384,44 @@ export default function ToolClient({ reference }: Props) {
         </header>
 
         <TabBar
-          options={TAB_OPTIONS}
-          value={TAB_LABELS[tab]}
-          onChange={(label) => setTab(label === TAB_LABELS.holding ? "holding" : "watch")}
+          options={VIEW_TAB_OPTIONS}
+          value={VIEW_TAB_LABELS[tab]}
+          onChange={(label) => {
+            if (label === VIEW_TAB_LABELS.holding) setTab("holding");
+            else if (label === VIEW_TAB_LABELS.watch) setTab("watch");
+            else setTab("master");
+          }}
         />
 
-        <AddPanel
-          tab={tab}
-          query={query}
-          onQueryChange={setQuery}
-          holdingAccountType={newHoldingAccountType}
-          onHoldingAccountTypeChange={setNewHoldingAccountType}
-          candidates={candidates}
-          masterReady={master.ready}
-          masterError={master.error}
-          onPick={addStock}
-        />
+        {tab === "master" ? (
+          <MasterListPanel
+            query={query}
+            onQueryChange={setQuery}
+            rows={masterPageRows}
+            totalRows={masterRows.length}
+            page={boundedMasterPage}
+            pageCount={masterPageCount}
+            masterReady={master.ready}
+            masterError={master.error}
+            reference={reference}
+            onPrevPage={() => setMasterPage((page) => Math.max(0, page - 1))}
+            onNextPage={() => setMasterPage((page) => Math.min(masterPageCount - 1, page + 1))}
+            onAddHolding={(stock) => addStock(stock, "holding")}
+            onAddWatch={(stock) => addStock(stock, "watch")}
+          />
+        ) : (
+          <AddPanel
+            tab={tab}
+            query={query}
+            onQueryChange={setQuery}
+            holdingAccountType={newHoldingAccountType}
+            onHoldingAccountTypeChange={setNewHoldingAccountType}
+            candidates={candidates}
+            masterReady={master.ready}
+            masterError={master.error}
+            onPick={(stock) => addStock(stock)}
+          />
+        )}
 
         {notice && (
           <div
@@ -372,6 +439,7 @@ export default function ToolClient({ reference }: Props) {
           </div>
         )}
 
+        {tab !== "master" && (
         <div style={{ display: "grid", gap: 4 }}>
           <div
             style={{
@@ -429,6 +497,7 @@ export default function ToolClient({ reference }: Props) {
             </ul>
           )}
         </div>
+        )}
 
         <div
           style={{
@@ -652,6 +721,7 @@ function AccountSplitView({
         const base = group.items[0];
         const earnings = reference.nextEarningsByCode[base.code];
         const yutaiMonths = reference.yutaiMonthsByCode[base.code];
+        const dividend = reference.dividendByCode[base.code];
 
         return (
         <section
@@ -694,6 +764,11 @@ function AccountSplitView({
                 {yutaiMonths && yutaiMonths.length > 0 && (
                   <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
                     優待 {yutaiMonths.map((m) => `${m}月`).join("・")}
+                  </span>
+                )}
+                {dividend && (
+                  <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
+                    配当 {formatDividend(dividend)}
                   </span>
                 )}
                 <span style={{ fontSize: 11, color: "var(--color-text-muted)", fontWeight: 800 }}>
@@ -1125,6 +1200,200 @@ type AddPanelProps = {
   onPick: (stock: StockMaster) => void;
 };
 
+type MasterListPanelProps = {
+  query: string;
+  onQueryChange: (value: string) => void;
+  rows: StockMaster[];
+  totalRows: number;
+  page: number;
+  pageCount: number;
+  masterReady: boolean;
+  masterError: boolean;
+  reference: MyStocksReference;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+  onAddHolding: (stock: StockMaster) => void;
+  onAddWatch: (stock: StockMaster) => void;
+};
+
+function MasterListPanel({
+  query,
+  onQueryChange,
+  rows,
+  totalRows,
+  page,
+  pageCount,
+  masterReady,
+  masterError,
+  reference,
+  onPrevPage,
+  onNextPage,
+  onAddHolding,
+  onAddWatch,
+}: MasterListPanelProps) {
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="銘柄コード または 銘柄名で検索"
+        aria-label="銘柄一覧を検索"
+        style={{
+          width: "100%",
+          boxSizing: "border-box",
+          padding: "10px 12px",
+          borderRadius: 8,
+          border: "1.5px solid var(--color-border-strong)",
+          background: "var(--color-bg-input)",
+          color: "var(--color-text)",
+          fontSize: 14,
+        }}
+      />
+
+      {masterReady && !masterError && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 10,
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ fontSize: 12, color: "var(--color-text-muted)", fontWeight: 700 }}>
+            {totalRows.toLocaleString("ja-JP")}件 / {page + 1}ページ
+          </span>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              onClick={onPrevPage}
+              disabled={page <= 0}
+              style={pagerButtonStyle(page <= 0)}
+            >
+              前へ
+            </button>
+            <button
+              type="button"
+              onClick={onNextPage}
+              disabled={page >= pageCount - 1}
+              style={pagerButtonStyle(page >= pageCount - 1)}
+            >
+              次へ
+            </button>
+          </div>
+        </div>
+      )}
+
+      {masterError ? (
+        <span style={{ fontSize: 12, color: "var(--color-error)" }}>
+          銘柄データを読み込めませんでした。時間をおいて再度お試しください。
+        </span>
+      ) : !masterReady ? (
+        <p style={{ fontSize: 13, color: "var(--color-text-muted)", padding: "12px 4px" }}>
+          読み込み中…
+        </p>
+      ) : rows.length === 0 ? (
+        <p style={{ fontSize: 13, color: "var(--color-text-muted)", padding: "12px 4px" }}>
+          該当する銘柄がありません
+        </p>
+      ) : (
+        <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 8 }}>
+          {rows.map((stock) => {
+            const earnings = reference.nextEarningsByCode[stock.code];
+            const yutaiMonths = reference.yutaiMonthsByCode[stock.code];
+            const dividend = stock.dividend ?? reference.dividendByCode[stock.code];
+
+            return (
+              <li
+                key={stock.code}
+                style={{
+                  border: "1px solid var(--color-border)",
+                  borderRadius: 8,
+                  background: "var(--color-bg-card)",
+                  padding: "9px 12px",
+                  display: "grid",
+                  gap: 7,
+                }}
+              >
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "minmax(0, 1fr) auto",
+                    gap: 10,
+                    alignItems: "start",
+                  }}
+                >
+                  <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "baseline",
+                        gap: 8,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <span style={{ fontWeight: 900, color: "var(--color-text)", fontSize: 14 }}>
+                        {stock.code}
+                      </span>
+                      <span style={{ color: "var(--color-text)", fontSize: 14 }}>
+                        {stock.name}
+                      </span>
+                      {stock.market && (
+                        <span style={{ color: "var(--color-text-muted)", fontSize: 11 }}>
+                          {stock.market}
+                        </span>
+                      )}
+                    </div>
+                    <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                      {earnings && (
+                        <span style={badgeStyle("var(--color-accent-sub)", "var(--color-accent)")}>
+                          次決算 {formatEarnings(earnings)}
+                        </span>
+                      )}
+                      {yutaiMonths && yutaiMonths.length > 0 && (
+                        <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
+                          優待 {yutaiMonths.map((m) => `${m}月`).join("・")}
+                        </span>
+                      )}
+                      {dividend && (
+                        <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
+                          配当利回り {dividend.yieldPct.toFixed(2)}%
+                        </span>
+                      )}
+                      {dividend?.perShare !== null && dividend?.perShare !== undefined && (
+                        <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
+                          配当額 {dividend.perShare.toLocaleString("ja-JP")}円
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "end" }}>
+                    <button
+                      type="button"
+                      onClick={() => onAddHolding(stock)}
+                      style={smallActionButtonStyle}
+                    >
+                      保有
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onAddWatch(stock)}
+                      style={smallActionButtonStyle}
+                    >
+                      ウォッチ
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function AddPanel({
   tab,
   query,
@@ -1257,6 +1526,7 @@ function StockRow({
 }: StockRowProps) {
   const earnings = reference.nextEarningsByCode[item.code];
   const yutaiMonths = reference.yutaiMonthsByCode[item.code];
+  const dividend = reference.dividendByCode[item.code];
   const holdingAccountLabel = accountLabel(item);
 
   return (
@@ -1311,7 +1581,7 @@ function StockRow({
         </button>
       </div>
 
-      {(earnings || (yutaiMonths && yutaiMonths.length > 0)) && (
+      {(earnings || (yutaiMonths && yutaiMonths.length > 0) || dividend) && (
         <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
           {earnings && (
             <span style={badgeStyle("var(--color-accent-sub)", "var(--color-accent)")}>
@@ -1321,6 +1591,11 @@ function StockRow({
           {yutaiMonths && yutaiMonths.length > 0 && (
             <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
               優待 {yutaiMonths.map((m) => `${m}月`).join("・")}
+            </span>
+          )}
+          {dividend && (
+            <span style={badgeStyle("var(--color-bg-input)", "var(--color-text-sub)")}>
+              配当 {formatDividend(dividend)}
             </span>
           )}
         </div>
@@ -1413,6 +1688,21 @@ function badgeStyle(bg: string, color: string): React.CSSProperties {
   };
 }
 
+function pagerButtonStyle(disabled: boolean): React.CSSProperties {
+  return {
+    minWidth: 58,
+    padding: "6px 10px",
+    borderRadius: 7,
+    border: "1.5px solid var(--color-border-strong)",
+    background: disabled ? "var(--color-bg-input)" : "var(--color-bg-card)",
+    color: disabled ? "var(--color-text-muted)" : "var(--color-text-sub)",
+    fontSize: 12,
+    fontWeight: 800,
+    cursor: disabled ? "default" : "pointer",
+    opacity: disabled ? 0.65 : 1,
+  };
+}
+
 const fieldLabelStyle: React.CSSProperties = {
   display: "grid",
   gap: 3,
@@ -1470,6 +1760,17 @@ const addAccountButtonStyle: React.CSSProperties = {
   borderRadius: 6,
   border: "1px solid var(--color-border-strong)",
   background: "var(--color-bg-input)",
+  color: "var(--color-text-sub)",
+  fontSize: 12,
+  fontWeight: 800,
+  cursor: "pointer",
+};
+
+const smallActionButtonStyle: React.CSSProperties = {
+  padding: "5px 9px",
+  borderRadius: 6,
+  border: "1.5px solid var(--color-border-strong)",
+  background: "var(--color-bg-card)",
   color: "var(--color-text-sub)",
   fontSize: 12,
   fontWeight: 800,

--- a/app/tools/my-stocks/__tests__/data-loader.test.ts
+++ b/app/tools/my-stocks/__tests__/data-loader.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadMyStocksReference } from "../data-loader";
+
+function makeFetchOk(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("my-stocks data-loader", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com/";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.MARKET_INFO_API_BASE_URL;
+  });
+
+  it("stock-master latest から基盤情報 map を作る", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      makeFetchOk([
+        {
+          code: "7203",
+          name: "トヨタＡＢＣ１２３",
+          display_name: "トヨタＡＢＣ１２３",
+          abbrev_name: "トヨタ",
+          market: "プライム",
+          sector: "輸送用機器",
+          earnings_next_date: "2026-06-10",
+          yutai_months: "3,9",
+          dividend_yield_pct: 2.5,
+          dividend_per_share: 117,
+          dividend_as_of: "2026-06-07",
+          as_of_date: "2026-06-08",
+        },
+        {
+          code: "1301",
+          name: "極洋",
+          display_name: "極洋",
+          abbrev_name: "極洋",
+          market: "プライム",
+          sector: "水産・農林業",
+          earnings_next_date: null,
+          yutai_months: null,
+          dividend_yield_pct: null,
+          dividend_per_share: null,
+          dividend_as_of: null,
+          as_of_date: "2026-06-08",
+        },
+      ]),
+    );
+
+    const result = await loadMyStocksReference();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.com/stock-master/latest",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.asOf).toBe("2026-06-08");
+    expect(result.nextEarningsByCode).toEqual({ "7203": "2026-06-10" });
+    expect(result.yutaiMonthsByCode).toEqual({ "7203": [3, 9] });
+    expect(result.dividendByCode).toEqual({
+      "7203": { yieldPct: 2.5, perShare: 117, asOf: "2026-06-07" },
+    });
+    expect(result.stockMaster).toEqual([
+      {
+        code: "7203",
+        name: "トヨタABC123",
+        market: "プライム",
+        sector: "輸送用機器",
+        dividend: { yieldPct: 2.5, perShare: 117, asOf: "2026-06-07" },
+      },
+      {
+        code: "1301",
+        name: "極洋",
+        market: "プライム",
+        sector: "水産・農林業",
+      },
+    ]);
+  });
+});

--- a/app/tools/my-stocks/data-loader.ts
+++ b/app/tools/my-stocks/data-loader.ts
@@ -4,7 +4,23 @@ import {
   loadMonthlyYutaiMonthData,
 } from "@/app/tools/yutai-candidates/data-loader";
 import { loadEarningsCalendarPageData } from "@/app/tools/earnings-calendar/data-loader";
+import { fetchJson, getApiBaseUrl } from "@/lib/market-api";
 import type { MyStocksReference } from "./types";
+
+type StockMasterLatestRecord = {
+  code: string;
+  name: string;
+  display_name: string;
+  abbrev_name: string;
+  market: string;
+  sector: string | null;
+  earnings_next_date: string | null;
+  yutai_months: string | null;
+  dividend_yield_pct: number | null;
+  dividend_per_share: number | null;
+  dividend_as_of: string | null;
+  as_of_date: string;
+};
 
 /** JST の今日（YYYY-MM-DD）を返す。 */
 function getJstTodayIso(): string {
@@ -25,6 +41,9 @@ function getJstTodayIso(): string {
  * バッジは表示されないだけでツール本体は動く。
  */
 export async function loadMyStocksReference(): Promise<MyStocksReference> {
+  const stockMasterReference = await loadStockMasterReference();
+  if (stockMasterReference) return stockMasterReference;
+
   const today = getJstTodayIso();
 
   const [yutaiMonthsByCode, nextEarningsByCode] = await Promise.all([
@@ -36,7 +55,75 @@ export async function loadMyStocksReference(): Promise<MyStocksReference> {
     asOf: today,
     nextEarningsByCode,
     yutaiMonthsByCode,
+    dividendByCode: {},
+    stockMaster: [],
   };
+}
+
+async function loadStockMasterReference(): Promise<MyStocksReference | null> {
+  const apiBase = getApiBaseUrl();
+  if (!apiBase) return null;
+
+  try {
+    const records = await fetchJson<StockMasterLatestRecord[]>(`${apiBase}/stock-master/latest`);
+    const nextEarningsByCode: Record<string, string> = {};
+    const yutaiMonthsByCode: Record<string, number[]> = {};
+    const dividendByCode: MyStocksReference["dividendByCode"] = {};
+    const stockMaster: MyStocksReference["stockMaster"] = [];
+    let asOf: string | null = null;
+
+    for (const record of records) {
+      if (!record.code) continue;
+      asOf ??= record.as_of_date || null;
+      if (record.earnings_next_date) {
+        nextEarningsByCode[record.code] = record.earnings_next_date;
+      }
+      const months = parseYutaiMonths(record.yutai_months);
+      if (months.length > 0) {
+        yutaiMonthsByCode[record.code] = months;
+      }
+      if (typeof record.dividend_yield_pct === "number") {
+        dividendByCode[record.code] = {
+          yieldPct: record.dividend_yield_pct,
+          perShare: typeof record.dividend_per_share === "number" ? record.dividend_per_share : null,
+          asOf: record.dividend_as_of,
+        };
+      }
+      const dividend = dividendByCode[record.code];
+      stockMaster.push({
+        code: record.code,
+        name: normalizeAscii(record.display_name || record.name || record.abbrev_name),
+        market: record.market,
+        sector: record.sector,
+        ...(dividend ? { dividend } : {}),
+      });
+    }
+
+    return {
+      asOf,
+      nextEarningsByCode,
+      yutaiMonthsByCode,
+      dividendByCode,
+      stockMaster,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAscii(value: string): string {
+  return value.replace(/[０-９Ａ-Ｚａ-ｚ]/g, (ch) =>
+    String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
+  );
+}
+
+function parseYutaiMonths(value: string | null): number[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((part) => Number(part.trim()))
+    .filter((month) => Number.isInteger(month) && month >= 1 && month <= 12)
+    .sort((a, b) => a - b);
 }
 
 async function buildYutaiMonthsByCode(): Promise<Record<string, number[]>> {

--- a/app/tools/my-stocks/types.ts
+++ b/app/tools/my-stocks/types.ts
@@ -17,6 +17,11 @@ export type StockMaster = {
   name: string;
   market: string;
   sector: string | null;
+  dividend?: {
+    yieldPct: number;
+    perShare: number | null;
+    asOf: string | null;
+  };
 };
 
 /**
@@ -55,4 +60,15 @@ export type MyStocksReference = {
   nextEarningsByCode: Record<string, string>;
   /** code → 優待権利確定月（1-12、複数あり得る）。 */
   yutaiMonthsByCode: Record<string, number[]>;
+  /** code → 配当利回り・推定年間配当。 */
+  dividendByCode: Record<
+    string,
+    {
+      yieldPct: number;
+      perShare: number | null;
+      asOf: string | null;
+    }
+  >;
+  /** API から取得できた場合の配当等を含む銘柄一覧。未取得時は client local fallback を使う。 */
+  stockMaster: StockMaster[];
 };

--- a/app/tools/my-stocks/useStockMaster.ts
+++ b/app/tools/my-stocks/useStockMaster.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { StockMaster } from "./types";
 
 const MASTER_URL = "/data/jpx_listed_companies.json";
@@ -32,7 +32,7 @@ async function fetchMaster(): Promise<StockMaster[]> {
       if (typeof r.code === "string" && typeof r.name === "string") {
         list.push({
           code: r.code,
-          name: r.name,
+          name: normalizeAscii(r.name),
           market: typeof r.market === "string" ? r.market : "",
           sector: typeof r.sector === "string" ? r.sector : null,
         });
@@ -49,29 +49,37 @@ async function fetchMaster(): Promise<StockMaster[]> {
   }
 }
 
+function normalizeAscii(value: string): string {
+  return value.replace(/[０-９Ａ-Ｚａ-ｚ]/g, (ch) =>
+    String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
+  );
+}
+
 export type StockMasterState = {
   ready: boolean;
   error: boolean;
+  all: StockMaster[];
   /** クエリにマッチする銘柄を最大 limit 件返す。 */
   search: (query: string, limit?: number) => StockMaster[];
 };
 
-export function useStockMaster(): StockMasterState {
-  const [ready, setReady] = useState(cachedMaster !== null);
+export function useStockMaster(initialMaster: StockMaster[] = []): StockMasterState {
+  const hasInitialMaster = initialMaster.length > 0;
+  const [ready, setReady] = useState(hasInitialMaster || cachedMaster !== null);
   const [error, setError] = useState(false);
-  const masterRef = useRef<StockMaster[]>(cachedMaster ?? []);
+  const [all, setAll] = useState<StockMaster[]>(
+    initialMaster.length > 0 ? initialMaster : cachedMaster ?? [],
+  );
 
   useEffect(() => {
-    if (cachedMaster) {
-      // 初期 state が既に ready=true を反映済みなので setState 不要
-      masterRef.current = cachedMaster;
+    if (hasInitialMaster || cachedMaster) {
       return;
     }
     let active = true;
     fetchMaster()
       .then((list) => {
         if (!active) return;
-        masterRef.current = list;
+        setAll(list);
         setReady(true);
       })
       .catch(() => {
@@ -81,7 +89,7 @@ export function useStockMaster(): StockMasterState {
     return () => {
       active = false;
     };
-  }, []);
+  }, [hasInitialMaster]);
 
   const search = useCallback((query: string, limit = 30): StockMaster[] => {
     const q = query.trim();
@@ -89,7 +97,7 @@ export function useStockMaster(): StockMasterState {
     const lower = q.toLowerCase();
     const isCodeLike = /^[0-9a-zA-Z]+$/.test(q);
     const results: StockMaster[] = [];
-    for (const m of masterRef.current) {
+    for (const m of all) {
       const codeHit = isCodeLike && m.code.toLowerCase().startsWith(lower);
       const nameHit = m.name.toLowerCase().includes(lower);
       if (codeHit || nameHit) {
@@ -98,7 +106,7 @@ export function useStockMaster(): StockMasterState {
       }
     }
     return results;
-  }, []);
+  }, [all]);
 
-  return { ready, error, search };
+  return { ready, error, all, search };
 }

--- a/docs/decision-log/2026-06-09-my-stocks-stock-master-reference.md
+++ b/docs/decision-log/2026-06-09-my-stocks-stock-master-reference.md
@@ -1,0 +1,24 @@
+# My Stocks Stock Master Reference
+
+Date: 2026-06-09
+
+## Decision
+
+`my-stocks` の公開基盤情報は `MARKET_INFO_API_BASE_URL` が設定されている場合、`GET /stock-master/latest` を優先して取得する。
+
+API が未設定または取得失敗した場合は、従来どおり優待 month API と決算カレンダー API から code map を合成する fallback を残す。
+
+画面には保存対象の `保有メモ` / `ウォッチ` に加えて、保存形式を変えない表示専用タブ `銘柄一覧` を追加する。`銘柄一覧` は client 側の銘柄マスターを一覧・検索し、各行から保有またはウォッチへ追加できる。件数が多いため、50件単位のページ送りを持つ。
+
+## Reason
+
+`market_info` 側で JPX 銘柄マスター、決算予定、優待、配当利回りを結合した stock master を publish できるようになったため、mini-tools 側で複数 endpoint を読んで同じ基盤情報を再構成するより、latest reference artifact を優先するほうが軽く、表示項目も揃えやすい。
+
+## Impact
+
+- `my-stocks` は次回決算・優待月に加えて配当利回りと推定年間配当を badge 表示できる。
+- `銘柄一覧` では配当利回りと配当額を分けて表示する。
+- `dividend_per_share` は確定配当ではなく `market_info` 側の利回り・株価からの逆算推定値として扱う。
+- `銘柄一覧` タブは表示専用で、localStorage の `tab` 値は `holding` / `watch` のまま維持する。
+- stock-master API が取得できた場合は、その records を配当付きの銘柄一覧として使う。
+- 銘柄名の全角英数字は `market_info` の stock master artifact 側で半角化する。mini-tools は `/data/jpx_listed_companies.json` fallback にも同じ表示変換を適用する。


### PR DESCRIPTION
## 概要

マイ銘柄リストに検索・ページ送り可能な銘柄一覧を追加し、stock master APIの配当情報を表示します。

## 変更内容

- `銘柄一覧` タブを追加
- 50件単位の前へ/次へページ送り
- 配当利回りと配当額を別表示
- API recordsを一覧本体として利用
- 全角英数字を半角化したfallback表示

## 確認

- `npm run lint`: passed
- 対象Vitest: passed
- `npm run build`: passed
- Codex reviewの検索500件上限指摘を修正済み
