### PR TITLE
fix(my-stocks): large stock master cache error

### DIFF
--- a/app/tools/my-stocks/__tests__/data-loader.test.ts
+++ b/app/tools/my-stocks/__tests__/data-loader.test.ts
@@ -59,7 +59,14 @@ describe("my-stocks data-loader", () => {
 
     expect(fetch).toHaveBeenCalledWith(
       "https://api.example.com/stock-master/latest",
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        cache: "no-store",
+      }),
+    );
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ next: expect.anything() }),
     );
     expect(result.asOf).toBe("2026-06-08");
     expect(result.nextEarningsByCode).toEqual({ "7203": "2026-06-10" });

--- a/app/tools/my-stocks/data-loader.ts
+++ b/app/tools/my-stocks/data-loader.ts
@@ -65,7 +65,11 @@ async function loadStockMasterReference(): Promise<MyStocksReference | null> {
   if (!apiBase) return null;
 
   try {
-    const records = await fetchJson<StockMasterLatestRecord[]>(`${apiBase}/stock-master/latest`);
+    const records = await fetchJson<StockMasterLatestRecord[]>(
+      `${apiBase}/stock-master/latest`,
+      300,
+      { cache: "no-store" },
+    );
     const nextEarningsByCode: Record<string, string> = {};
     const yutaiMonthsByCode: Record<string, number[]> = {};
     const dividendByCode: MyStocksReference["dividendByCode"] = {};

--- a/lib/market-api.ts
+++ b/lib/market-api.ts
@@ -22,14 +22,20 @@ export function canUseLocalMarketDataFallback(): boolean {
  * JSON を fetch して型付きで返す。5秒タイムアウト付き。
  * revalidate はデータの更新頻度に合わせて呼び出し側で指定する（デフォルト 300 秒）。
  */
-export async function fetchJson<T>(url: string, revalidate = 300): Promise<T> {
+export async function fetchJson<T>(
+  url: string,
+  revalidate = 300,
+  options: { cache?: RequestCache } = {},
+): Promise<T> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
 
   try {
     const res = await fetch(url, {
       signal: controller.signal,
-      next: { revalidate },
+      ...(options.cache === "no-store"
+        ? { cache: "no-store" as const }
+        : { next: { revalidate } }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## 概要

マイ銘柄リストで表示されていた Next.js Data Cache 上限超過エラーを解消します。

## 変更内容

- `fetchJson` に任意の `cache` 指定を追加
- 約 2.62 MB の `/stock-master/latest` 取得だけ `cache: "no-store"` に変更
- 対象 fetch に `next.revalidate` が付かないことをテストで固定

## 確認項目

- `npm test -- --run app/tools/my-stocks/__tests__`
- `npm run lint`
- `npm run build`
- `/tools/my-stocks` が HTTP 200 を返すこと
- RSCレスポンスから `items over 2MB` と source map 警告が消えること

## 関連 Issue

なし
