### PR TITLE
fix(share): 共有URLのハイドレーション不整合を解消

### DIFF
--- a/components/ShareButtons.tsx
+++ b/components/ShareButtons.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { track } from "@/lib/analytics";
 import { QRCodeCanvas } from "qrcode.react";
 import { createPortal } from "react-dom";
+import { resolveShareUrl } from "./share-url";
 import styles from "./ShareButtons.module.css";
+
+// origin はブラウザ依存値。useSyncExternalStore で
+// サーバー / ハイドレーション初回は null、マウント後に現在 origin を返す。
+// （関数参照を安定させるためモジュールスコープに置く）
+const subscribeOrigin = () => () => {};
+const getOriginSnapshot = () => window.location.origin;
+const getOriginServerSnapshot = (): string | null => null;
 
 type ShareMethod = "x" | "facebook" | "email" | "copy" | "premium" | "qr";
 
@@ -22,33 +30,6 @@ type Props = {
 
 const DEFAULT_METHODS: ShareMethod[] = ["x", "facebook", "email", "copy"];
 
-/**
- * pathname + searchParams から共有用の絶対 URL を生成する。
- * NEXT_PUBLIC_SITE_URL があればそれを base にし、なければ window.location.origin にフォールバックする。
- * url prop が渡された場合はそれをそのまま使う。
- */
-function resolveShareUrl(
-  urlProp: string | undefined,
-  pathname: string,
-  searchParams: URLSearchParams | null
-): string {
-  if (urlProp) return urlProp;
-
-  const qs = searchParams?.toString();
-  const pathWithQuery = `${pathname}${qs ? `?${qs}` : ""}`;
-  const base =
-    process.env.NEXT_PUBLIC_SITE_URL?.trim().replace(/\/+$/, "") ||
-    (typeof window !== "undefined" ? window.location.origin : "");
-
-  try {
-    return new URL(pathWithQuery, base).href;
-  } catch {
-    // base が取得できない SSR 初期レンダリング時は相対パスにフォールバック。
-    // クライアント再レンダリング時には window.location.origin が base に入るため絶対 URL になる。
-    return pathWithQuery;
-  }
-}
-
 export default function ShareButtons({
   text,
   url,
@@ -64,9 +45,17 @@ export default function ShareButtons({
 
   const [qrOpen, setQrOpen] = useState(false);
 
+  // SSR とクライアント初回描画は origin=null で一致させ、マウント後に
+  // 現在 origin へ昇格させる（ハイドレーションミスマッチを防ぐ）。
+  const origin = useSyncExternalStore(
+    subscribeOrigin,
+    getOriginSnapshot,
+    getOriginServerSnapshot
+  );
+
   const shareUrl = useMemo(
-    () => resolveShareUrl(url, pathname, searchParams),
-    [url, pathname, searchParams]
+    () => resolveShareUrl(url, pathname, searchParams, origin),
+    [url, pathname, searchParams, origin]
   );
 
   const shareLinks = useMemo(() => {

--- a/components/__tests__/share-url.test.ts
+++ b/components/__tests__/share-url.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveShareUrl } from "../share-url";
+
+const SITE_URL = "https://mini-tools.example.com";
+
+describe("resolveShareUrl", () => {
+  let originalSiteUrl: string | undefined;
+
+  beforeEach(() => {
+    originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  afterEach(() => {
+    if (originalSiteUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl;
+    }
+  });
+
+  describe("env 未設定", () => {
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+    });
+
+    it("マウント前 (origin=null) は相対パスを返す（SSR と初回 CSR を一致させる）", () => {
+      expect(resolveShareUrl(undefined, "/tools/my-stocks", null, null)).toBe(
+        "/tools/my-stocks",
+      );
+    });
+
+    it("query 付きの相対パスを保持する", () => {
+      const sp = new URLSearchParams({ tab: "ratio", code: "7203" });
+      expect(resolveShareUrl(undefined, "/tools/my-stocks", sp, null)).toBe(
+        "/tools/my-stocks?tab=ratio&code=7203",
+      );
+    });
+
+    it("マウント後 (origin 注入) は現在 origin を base に絶対 URL を返す", () => {
+      expect(
+        resolveShareUrl(undefined, "/tools/my-stocks", null, "http://localhost:3000"),
+      ).toBe("http://localhost:3000/tools/my-stocks");
+    });
+  });
+
+  describe("env 設定済み", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
+    });
+
+    it("マウント前でも env を base に絶対 URL を返す", () => {
+      expect(resolveShareUrl(undefined, "/tools/my-stocks", null, null)).toBe(
+        `${SITE_URL}/tools/my-stocks`,
+      );
+    });
+
+    it("origin より env を優先する", () => {
+      expect(
+        resolveShareUrl(undefined, "/tools/my-stocks", null, "http://localhost:3000"),
+      ).toBe(`${SITE_URL}/tools/my-stocks`);
+    });
+
+    it("末尾スラッシュは正規化する", () => {
+      process.env.NEXT_PUBLIC_SITE_URL = `${SITE_URL}///`;
+      expect(resolveShareUrl(undefined, "/tools/x", null, null)).toBe(
+        `${SITE_URL}/tools/x`,
+      );
+    });
+  });
+
+  describe("url prop 指定", () => {
+    it("絶対 URL の url prop はそのまま使う", () => {
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+      expect(
+        resolveShareUrl("https://example.com/share/abc", "/tools/x", null, null),
+      ).toBe("https://example.com/share/abc");
+    });
+
+    it("相対 url prop は base で絶対化する（env 優先）", () => {
+      process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
+      expect(resolveShareUrl("/p/123", "/tools/x", null, null)).toBe(
+        `${SITE_URL}/p/123`,
+      );
+    });
+
+    it("相対 url prop は base 未解決なら相対のまま返す", () => {
+      delete process.env.NEXT_PUBLIC_SITE_URL;
+      expect(resolveShareUrl("/p/123", "/tools/x", null, null)).toBe("/p/123");
+    });
+
+    it("url prop は pathname より優先される", () => {
+      process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
+      expect(resolveShareUrl("/override", "/tools/x", null, "http://localhost:3000")).toBe(
+        `${SITE_URL}/override`,
+      );
+    });
+  });
+});

--- a/components/share-url.ts
+++ b/components/share-url.ts
@@ -1,0 +1,46 @@
+// 共有 URL 生成ロジック。
+// SSR とクライアント初回描画を一致させるため、ブラウザ依存値 (origin) は
+// レンダー中に直接読まず、呼び出し側がマウント後に注入する。
+// 仕様: docs/specs/cross-cutting/share-url-spec.md
+
+/**
+ * 共有用 URL を生成する。
+ *
+ * 解決順:
+ * 1. 対象 (url prop があればそれ、無ければ pathname + query) が
+ *    すでに絶対 URL ならそのまま返す。
+ * 2. 相対なら base で絶対化する。base は
+ *    `NEXT_PUBLIC_SITE_URL` → `origin`（マウント後に注入）の順。
+ * 3. base が未解決（env 未設定 かつ マウント前 / SSR）の場合のみ相対のまま返す。
+ *
+ * origin をレンダー中に読まないことで、SSR とクライアント初回描画の出力が
+ * 一致し、ハイドレーションミスマッチを防ぐ。
+ */
+export function resolveShareUrl(
+  urlProp: string | undefined,
+  pathname: string,
+  searchParams: URLSearchParams | null,
+  origin: string | null,
+): string {
+  const qs = searchParams?.toString();
+  const pathWithQuery = `${pathname}${qs ? `?${qs}` : ""}`;
+  const target = urlProp ?? pathWithQuery;
+
+  // すでに絶対 URL（scheme 付き）ならそのまま使う。
+  try {
+    return new URL(target).href;
+  } catch {
+    // 相対 URL の場合は下で base を使って絶対化する。
+  }
+
+  const base =
+    process.env.NEXT_PUBLIC_SITE_URL?.trim().replace(/\/+$/, "") || origin || "";
+
+  try {
+    return new URL(target, base).href;
+  } catch {
+    // base が空（env 未設定 かつ マウント前）のときだけ相対のまま返す。
+    // マウント後に origin が注入されると再レンダリングで絶対 URL へ昇格する。
+    return target;
+  }
+}

--- a/docs/decision-log/2026-06-14-sharebuttons-hydration-origin.md
+++ b/docs/decision-log/2026-06-14-sharebuttons-hydration-origin.md
@@ -1,0 +1,24 @@
+# ShareButtons の共有 URL ハイドレーション対応
+
+Date: 2026-06-14
+
+## Decision
+
+`ShareButtons` の共有 URL 生成を、SSR とクライアント初回描画で必ず一致させる。
+
+- URL 生成ロジック `resolveShareUrl` を `components/share-url.ts` に純関数として切り出し、単体テスト可能にする。
+- `resolveShareUrl(urlProp, pathname, searchParams, origin)` は base を `NEXT_PUBLIC_SITE_URL` → `origin` の順で解決する。`origin` は引数で受け取り、関数内で `window` を参照しない。
+- `ShareButtons` は `useSyncExternalStore` で origin を取得する（server snapshot = `null`、client snapshot = `window.location.origin`）。これによりサーバー / ハイドレーション初回は `null`、マウント後に現在 origin へ昇格する。
+- url prop が相対 URL の場合も base で絶対化する（絶対 URL ならそのまま）。
+
+## Reason
+
+旧実装は `resolveShareUrl` がレンダー中に `typeof window` を見て分岐していた。`NEXT_PUBLIC_SITE_URL` 未設定時、サーバーは相対パス・クライアントは `window.location.origin` 基準の絶対 URL を返し、共有リンクの `href` がハイドレーションで不一致になっていた（`.env` で同変数を空/削除した際に顕在化。`.env` 変更がバグを作ったのではなく、既存の潜在バグが表面化した）。
+
+リポジトリ方針「SSR とクライアント初回描画を一致させ、ブラウザ依存値はマウント後に注入する」に合わせ、origin をレンダー中に読まない構成へ変更した。`useSyncExternalStore` は React 公式の SSR セーフなブラウザ値取得手段で、`useEffect` 内同期 setState を禁じる lint ルール（react-hooks/set-state-in-effect）にも抵触しない。
+
+## Impact
+
+- `NEXT_PUBLIC_SITE_URL` 未設定（ローカル開発）でも共有リンクのハイドレーション警告が出ない。env 設定時は従来どおり最初から絶対 URL。
+- `resolveShareUrl` に env 未設定 / 設定済み / url prop 指定（絶対・相対）のケースを `components/__tests__/share-url.test.ts` で網羅。
+- 仕様は [share-url-spec.md](../specs/cross-cutting/share-url-spec.md) に base 解決順・url prop の扱いを追記。

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-06-14 ShareButtons 共有URLのハイドレーション対応（origin はマウント後注入）](./decision-log/2026-06-14-sharebuttons-hydration-origin.md)
 - [2026-06-14 マイ銘柄リスト 比率グラフの種別切り替え（帯/円/四角ヒートマップ）](./decision-log/2026-06-14-my-stocks-ratio-chart-types.md)
 - [2026-06-14 開示レーダーの日付別JSONとブラウザHTTPキャッシュ](./decision-log/2026-06-14-disclosure-radar-http-cache.md)
 - [2026-06-14 全ツール切り替え用ハンバーガー＋ドロワー](./decision-log/2026-06-14-global-nav-drawer.md)

--- a/docs/specs/cross-cutting/share-url-spec.md
+++ b/docs/specs/cross-cutting/share-url-spec.md
@@ -10,8 +10,27 @@
 
 ### 実装上の前提
 
-- `NEXT_PUBLIC_SITE_URL` が定義されている場合は、共有 URL の基準として優先的に使用する
+- `NEXT_PUBLIC_SITE_URL` が定義されている場合は、共有 URL の基準（base）として優先的に使用する
 - ローカル開発環境（localhost）であっても、QR 共有では正規サイト URL を生成する
-- URL 生成ロジックは 1 箇所に集約し、分岐はオプションで表現する（将来拡張用）
+- URL 生成ロジックは 1 箇所（`components/share-url.ts` の `resolveShareUrl`）に集約し、分岐はオプションで表現する（将来拡張用）
 
-この方針により、開発環境と本番環境の差異による共有トラブルを防いでいます。
+### base の解決順とハイドレーション
+
+共有 URL の base は次の順で解決する:
+
+1. `NEXT_PUBLIC_SITE_URL`（設定時は SSR・クライアントとも常にこれを使用）
+2. **env 未設定時はマウント後に現在の `origin`（`window.location.origin`）を使用する**
+
+`origin` はブラウザ依存値のため、**レンダー中には読まない**。`ShareButtons` はマウント後に `useEffect` で `origin` を state へ注入し、再レンダリングで絶対 URL へ昇格させる。これにより **SSR とクライアント初回描画の出力が一致**し、ハイドレーションミスマッチを防ぐ。
+
+- env 未設定 かつ マウント前（SSR / 初回 CSR）: 相対 URL（例 `/tools/x`）を返す
+- env 未設定 かつ マウント後: `origin` を base にした絶対 URL を返す
+- env 設定済み: マウント前後を問わず env を base にした絶対 URL を返す
+
+### url prop の扱い
+
+- `url` prop は対象 URL の明示指定として扱う
+- `url` prop が**絶対 URL** の場合はそのまま使用する
+- `url` prop が**相対 URL** の場合は、`pathname` と同じく base で絶対化する（base 未解決時のみ相対のまま）
+
+この方針により、開発環境と本番環境の差異による共有トラブルと、ハイドレーション不整合を防いでいます。


### PR DESCRIPTION
## 背景

`ShareButtons` の X/Facebook 共有リンク `href` で、SSR とクライアント初回描画の URL が食い違いハイドレーションミスマッチが発生していた。

原因は旧 `resolveShareUrl` がレンダー中に `typeof window` を見て分岐していたこと。`NEXT_PUBLIC_SITE_URL` 未設定時、サーバーは相対パス・クライアントは `window.location.origin` 基準の絶対URLを返していた（`.env` で同変数を空/削除した際に顕在化。.env 変更がバグを作ったのではなく既存の潜在バグが表面化）。

## 対応（恒久対応）

リポジトリ方針「SSR とクライアント初回描画を一致させ、ブラウザ依存値はマウント後に注入する」に沿って修正。

- `resolveShareUrl` を [components/share-url.ts](components/share-url.ts) に**純関数**として切り出し（`origin` を引数で受け取り、関数内で `window` を参照しない）。
- `ShareButtons` は `useSyncExternalStore` で origin を取得（server snapshot=`null`、client=`window.location.origin`）。SSR/初回CSRは null=相対、マウント後に絶対URLへ昇格。
  - `useEffect` 内同期 setState を禁じる lint ルール（react-hooks/set-state-in-effect）にも抵触しない公式の SSR セーフ手段。
- base 解決順を明確化: `NEXT_PUBLIC_SITE_URL` → `origin`。
- `url` prop は**絶対ならそのまま**、**相対なら base で絶対化**（仕様を明文化）。

## テスト・ドキュメント

- [components/__tests__/share-url.test.ts](components/__tests__/share-url.test.ts): env未設定 / 設定済み / url prop（絶対・相対）を網羅（10 ケース）。とくに「env未設定 + origin=null → 相対」と「origin注入 → 絶対」で、SSR と初回CSRが同一出力になる不変条件を固定。
- [share-url-spec.md](docs/specs/cross-cutting/share-url-spec.md): base 解決順・ハイドレーション方針・url prop の扱いを追記。
- decision-log 追加。

## 確認

- `npm run lint`（CIゲート）: パス
- `npm run build`（CIゲート）: 成功
- `npx vitest run components/__tests__/share-url.test.ts`: 10 passed
- ⚠️ ライブのブラウザ確認は、別の `next dev` が起動中（`.next/dev/lock`）かつ `.env.local` 存在のため、稼働中セッションを奪わない判断で未実施。手順は下記。

### ローカルでのハイドレーション確認手順（env未設定）
1. 起動中の dev サーバーを停止
2. `NEXT_PUBLIC_SITE_URL` を未設定にして `npm run dev`
3. 任意のツールページを開き、DevTools コンソールに hydration mismatch 警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)