### PR TITLE
fix(admin): 投資主体別の鮮度を公開日時基準にする

### DIFF
--- a/app/admin/__tests__/freshness.test.ts
+++ b/app/admin/__tests__/freshness.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { classifyFreshnessDate, getAgeDaysFromDate } from "../freshness";
+
+describe("admin freshness", () => {
+  it("accepts slash-separated generated_at_jst values", () => {
+    expect(getAgeDaysFromDate("2026/06/11 16:30:05", "2026-06-15")).toBe(4);
+    expect(classifyFreshnessDate("2026/06/11 16:30:05", "2026-06-15")).toBe("recent");
+  });
+
+  it("still classifies an old weekly start date as stale", () => {
+    expect(classifyFreshnessDate("2026-06-01", "2026-06-15")).toBe("stale");
+  });
+});

--- a/app/admin/freshness.ts
+++ b/app/admin/freshness.ts
@@ -1,0 +1,30 @@
+export type Freshness = "fresh" | "recent" | "stale" | "failed" | "none";
+
+/** JST (Asia/Tokyo) 基準で YYYY-MM-DD を返す */
+export function jstDateString(date: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+export function getAgeDaysFromDate(value: string, todayJst: string = jstDateString()): number | null {
+  const datePrefix = value.slice(0, 10).replaceAll("/", "-");
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(datePrefix)) return null;
+  const t1 = Date.parse(`${datePrefix}T00:00:00Z`);
+  const t2 = Date.parse(`${todayJst}T00:00:00Z`);
+  if (Number.isNaN(t1) || Number.isNaN(t2)) return null;
+  return Math.max(0, Math.round((t2 - t1) / 86_400_000));
+}
+
+export function classifyFreshnessDate(value: string | null | undefined, todayJst?: string): Freshness {
+  if (value === undefined) return "none";
+  if (value === null) return "failed";
+  const ageDays = getAgeDaysFromDate(value, todayJst);
+  if (ageDays === null) return "recent";
+  if (ageDays <= 2) return "fresh";
+  if (ageDays <= 7) return "recent";
+  return "stale";
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,6 +5,12 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 import { fetchJson, getApiBaseUrl } from "@/lib/market-api";
+import {
+  classifyFreshnessDate,
+  getAgeDaysFromDate,
+  jstDateString,
+  type Freshness,
+} from "./freshness";
 
 export const metadata: Metadata = {
   title: "Admin Dashboard | mini-tools",
@@ -40,12 +46,11 @@ type ToolRow = {
   schedule: Schedule;
   note?: string;
   latest?: string | null;
+  freshnessDate?: string | null;
   fetchedAt?: string;
   /** manifest が dates[]/weeks[] を持つ場合の実履歴 (YYYY-MM-DD)。空配列 = 履歴なし */
   history?: string[];
 };
-
-type Freshness = "fresh" | "recent" | "stale" | "failed" | "none";
 
 // ============== Data Fetch Helpers ==============
 
@@ -53,20 +58,25 @@ async function fetchManifestLatest(
   endpoint: string,
   pick: (json: unknown) => string | null,
   pickHistory?: (json: unknown) => string[],
-  options: { cache?: RequestCache } = {},
-): Promise<{ latest: string | null; fetchedAt: string; history: string[] }> {
+  options: { cache?: RequestCache; pickFreshnessDate?: (json: unknown) => string | null } = {},
+): Promise<{ latest: string | null; freshnessDate: string | null; fetchedAt: string; history: string[] }> {
   const apiBase = getApiBaseUrl();
   const fetchedAt = new Date().toISOString();
-  if (!apiBase) return { latest: null, fetchedAt, history: [] };
+  if (!apiBase) return { latest: null, freshnessDate: null, fetchedAt, history: [] };
   try {
     // 管理画面なので fresh 性より通信量を優先: 10 分 (600s) キャッシュ。
     // 1 ユーザー (= ほぼ自分のみ) が連続でタブを切替えても、各 manifest は 10 分に 1 回しか実 API を叩かない。
     // 例外: 2MB を超えるレスポンス (例: /stock-master/latest) は Data Cache に載らず
     // 「Failed to set Next.js data cache」を毎回吐くため、呼び出し側で cache:"no-store" を指定する。
-    const json = await fetchJson<unknown>(`${apiBase}${endpoint}`, 600, options);
-    return { latest: pick(json), fetchedAt, history: pickHistory ? pickHistory(json) : [] };
+    const json = await fetchJson<unknown>(`${apiBase}${endpoint}`, 600, { cache: options.cache });
+    return {
+      latest: pick(json),
+      freshnessDate: options.pickFreshnessDate?.(json) ?? null,
+      fetchedAt,
+      history: pickHistory ? pickHistory(json) : [],
+    };
   } catch {
-    return { latest: null, fetchedAt, history: [] };
+    return { latest: null, freshnessDate: null, fetchedAt, history: [] };
   }
 }
 
@@ -176,7 +186,12 @@ async function loadRows(): Promise<ToolRow[]> {
     fetchManifestLatest("/yutai/manifest", (j) => pickString(j, "generated_at")),
     fetchManifestLatest("/market-rankings/market-cap/manifest", (j) => pickString(j, "generatedAt") ?? pickString(j, "latest")),
     fetchManifestLatest("/market-rankings/dividend-yield/manifest", (j) => pickString(j, "generatedAt") ?? pickString(j, "latest")),
-    fetchManifestLatest("/investor-flow/manifest", pickInvestorFlowLatestStart, pickInvestorFlowWeeks),
+    fetchManifestLatest(
+      "/investor-flow/manifest",
+      pickInvestorFlowLatestStart,
+      pickInvestorFlowWeeks,
+      { pickFreshnessDate: (j) => pickString(j, "generated_at_jst") },
+    ),
   ]);
   const [nikkoCredit, sbiCredit, tdnet, jpxClosed, disclosureEvents, stockMaster] = await Promise.all([
     fetchManifestLatest("/nikko/credit", (j) => pickString(j, "date") ?? pickString(j, "generated_at")),
@@ -194,7 +209,7 @@ async function loadRows(): Promise<ToolRow[]> {
     { category: "stocks", name: "米国株ランキング", href: "/tools/us-stock-ranking", source: "/us-ranking/manifest", rule: "生成は --with-us-ranking。publish 運用は要確認。", schedule: SCHED_AD_HOC, latest: usRanking.latest, fetchedAt: usRanking.fetchedAt, history: usRanking.history },
     { category: "stocks", name: "市場ランキング (時価総額)", href: "/tools/market-rankings", source: "/market-rankings/market-cap/manifest", rule: SCHED_MONTHLY.description, schedule: SCHED_MONTHLY, latest: marketCap.latest, fetchedAt: marketCap.fetchedAt },
     { category: "stocks", name: "市場ランキング (配当利回り)", href: "/tools/market-rankings", source: "/market-rankings/dividend-yield/manifest", rule: SCHED_MONTHLY.description, schedule: SCHED_MONTHLY, latest: dividendYield.latest, fetchedAt: dividendYield.fetchedAt },
-    { category: "stocks", name: "投資主体別売買動向", href: "/tools/investor-flow", source: "/investor-flow/manifest", rule: SCHED_WEEKLY.description, schedule: SCHED_WEEKLY, latest: investorFlow.latest, fetchedAt: investorFlow.fetchedAt, history: investorFlow.history },
+    { category: "stocks", name: "投資主体別売買動向", href: "/tools/investor-flow", source: "/investor-flow/manifest", rule: SCHED_WEEKLY.description, schedule: SCHED_WEEKLY, latest: investorFlow.latest, freshnessDate: investorFlow.freshnessDate, fetchedAt: investorFlow.fetchedAt, history: investorFlow.history },
 
     { category: "calendars", name: "決算カレンダー (国内)", href: "/tools/earnings-calendar", source: "/earnings-calendar/domestic/manifest", rule: SCHED_WEEKLY.description, schedule: SCHED_WEEKLY, latest: earningsDom.latest, fetchedAt: earningsDom.fetchedAt },
     { category: "calendars", name: "決算カレンダー (海外)", href: "/tools/earnings-calendar", source: "/earnings-calendar/overseas/manifest", rule: SCHED_WEEKLY.description, schedule: SCHED_WEEKLY, latest: earningsOv.latest, fetchedAt: earningsOv.fetchedAt },
@@ -241,33 +256,13 @@ const FRESHNESS_META: Record<Freshness, { label: string; bg: string; fg: string;
 };
 
 function classifyFreshness(row: ToolRow): Freshness {
-  if (row.latest === undefined) return "none";
-  if (row.latest === null) return "failed";
-  const ageDays = getAgeDays(row);
-  if (ageDays === null) return "recent";
-  if (ageDays <= 2) return "fresh";
-  if (ageDays <= 7) return "recent";
-  return "stale";
-}
-
-/** JST (Asia/Tokyo) 基準で YYYY-MM-DD を返す */
-function jstDateString(date: Date = new Date()): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Asia/Tokyo",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(date);
+  return classifyFreshnessDate(row.freshnessDate ?? row.latest);
 }
 
 function getAgeDays(row: ToolRow): number | null {
-  if (!row.latest) return null;
-  const latestDate = row.latest.slice(0, 10);
-  const todayJst = jstDateString();
-  const t1 = Date.parse(`${latestDate}T00:00:00Z`);
-  const t2 = Date.parse(`${todayJst}T00:00:00Z`);
-  if (Number.isNaN(t1) || Number.isNaN(t2)) return null;
-  return Math.max(0, Math.round((t2 - t1) / 86_400_000));
+  const freshnessDate = row.freshnessDate ?? row.latest;
+  if (!freshnessDate) return null;
+  return getAgeDaysFromDate(freshnessDate);
 }
 
 function formatAge(days: number | null): string {
@@ -451,8 +446,15 @@ function SlaView({ rows }: { rows: ToolRow[] }) {
                 <div>
                   <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, fontSize: 11 }}>
                     <span style={{ color: "#94a3b8" }}>
-                      Last: <span style={{ color: "#f1f5f9", fontWeight: 700, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{formatLatest(row.latest)}</span>
-                      <span style={{ color: "#64748b", marginLeft: 6 }}>({formatAge(age)} ago)</span>
+                      {row.freshnessDate ? "Latest week: " : "Last: "}
+                      <span style={{ color: "#f1f5f9", fontWeight: 700, fontFamily: "ui-monospace, SFMono-Regular, monospace" }}>{formatLatest(row.latest)}</span>
+                      {row.freshnessDate ? (
+                        <span style={{ color: "#64748b", marginLeft: 8 }}>
+                          Published: {formatLatest(row.freshnessDate)} ({formatAge(age)} ago)
+                        </span>
+                      ) : (
+                        <span style={{ color: "#64748b", marginLeft: 6 }}>({formatAge(age)} ago)</span>
+                      )}
                     </span>
                     {sla.status === "no-sla" ? (
                       <span style={{ color: "#64748b", fontSize: 10, fontWeight: 800 }}>NO SLA</span>

--- a/docs/decision-log/2026-06-15-investor-flow-dashboard-freshness.md
+++ b/docs/decision-log/2026-06-15-investor-flow-dashboard-freshness.md
@@ -1,0 +1,24 @@
+# 2026-06-15 投資主体別売買動向のダッシュボード鮮度基準
+
+## 背景
+
+投資主体別売買動向は対象週の翌週にJPXから公表される。管理ダッシュボードが
+`latest.start_date` から経過日数を計算すると、正常に公開された直後でも `STALE` になる。
+
+## 決定
+
+- 投資主体別売買動向の freshness / SLA は manifest の `generated_at_jst` を基準にする。
+- 最終更新週と履歴の表示には、引き続き `latest.start_date` と `weeks[].start_date` を使う。
+- SLA 一覧では対象週と公開日時をそれぞれ `Latest week` / `Published` として表示する。
+- 他データソースの鮮度基準は変更しない。
+
+## 理由
+
+対象期間と公開日時は異なる意味を持つ。運用監視では公開処理が最後に成功した日時を使う方が、
+実際の更新障害とJPXの通常の公表待ちを区別できる。
+
+## 影響範囲
+
+- `app/admin/page.tsx`
+- `app/admin/freshness.ts`
+- `docs/specs/tools/admin-dashboard.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 - [2026-06-13 開示イベントレーダーとモバイル下部ナビ](./decision-log/2026-06-13-disclosure-radar-and-mobile-nav.md)
 - [2026-05-31 日興一般「在庫0」判定を available_shares 基準に変更](./decision-log/2026-05-31-nikko-out-of-stock-shares-based.md)
 - [2026-06-01 投資主体別売買動向の分析API優先表示](./decision-log/2026-06-01-investor-flow-analysis-api-view.md)
+- [2026-06-15 投資主体別売買動向のダッシュボード鮮度基準](./decision-log/2026-06-15-investor-flow-dashboard-freshness.md)
 - [2026-05-30 日興信用バッジの記号化と「売可だが在庫0」追加](./decision-log/2026-05-30-nikko-general-out-of-stock-badge.md)
 - [2026-05-30 ルーター遷移の押下フィードバック共通化（useRouterTransition + pendingKey）](./decision-log/2026-05-30-router-transition-pending-feedback.md)
 - [2026-05-28 yutai-candidates の「パス」アクションとカードレイアウト見直し](./decision-log/2026-05-28-yutai-candidates-pass-action.md)

--- a/docs/specs/tools/admin-dashboard.md
+++ b/docs/specs/tools/admin-dashboard.md
@@ -108,6 +108,12 @@ latest が null (取得失敗)        → "breach"
 
 age は `(today_JST - row.latest)` を YYYY-MM-DD ベースで日数換算する。判定基準は **JST (Asia/Tokyo)** で固定 (週末・祝日オフセットなし)。UTC 基準で計算すると 00:00-08:59 JST の間に age が 1 日少なく出てしまうため、`Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Tokyo" })` で今日の JST 日付を取得して差分を取る。
 
+投資主体別売買動向は、対象週の `latest.start_date` ではなく manifest の
+`generated_at_jst` を freshness / SLA の基準日に使う。JPX の週次データは対象週の翌週に
+公表されるため、対象週の開始日を基準にすると正常公開直後でも `STALE` になるため。
+画面に表示する最終更新週と履歴は従来どおり `latest.start_date` / `weeks[].start_date` を使う。
+SLA 一覧では対象週を `Latest week`、鮮度計算に使った公開日時を `Published` として分けて表示する。
+
 ### Freshness 分類 (heatmap / pill 用)
 
 | ラベル | 条件 |


### PR DESCRIPTION
## 概要

Premium管理ダッシュボードで投資主体別売買動向が、正常更新直後にも `STALE` になる問題を修正します。

## 変更内容

- 投資主体別売買動向の freshness / SLA を `latest.start_date` ではなく manifest の `generated_at_jst` で判定
- 対象週と公開日時を `Latest week` / `Published` として分けて表示
- slash区切りの日時を扱う鮮度計算ヘルパーと回帰テストを追加
- 管理ダッシュボード仕様と判断理由を docs に記録

## 確認項目

- `npm test -- app/admin/__tests__/freshness.test.ts`
- `npm run lint`
- `npm run build`
- `codex review --uncommitted`
  - 公開日時から計算した経過日数を対象週の横に表示する点を指摘され、表示を分離して対応済み
