### PR TITLE
fix(disclosure-radar): guard against empty reference date

### DIFF
--- a/app/tools/disclosure-radar/logic.ts
+++ b/app/tools/disclosure-radar/logic.ts
@@ -49,6 +49,7 @@ export function filterDisclosureEvents(
   unreadOnly: boolean,
   readEventIds: Set<string>,
 ): DisclosureEventItem[] {
+  if (!referenceDate) return [];
   const normalizedQuery = query.trim().toLowerCase();
   const cutoff = addDays(referenceDate, -(rangeDays - 1));
 


### PR DESCRIPTION
## 概要

`disclosure-radar` のデータ未取得時に発生する `RangeError: Invalid time value` クラッシュを修正します。

## 原因

`ToolClient.tsx` の `filterItems` は `referenceDate` に `data?.latestDate ?? ""` / `data?.referenceDate ?? ""`（データ未取得時は空文字）を渡します。`filterDisclosureEvents` → `addDays("", ...)` → `new Date("T00:00:00Z")` が Invalid Date となり、`toISOString()` が `RangeError` を投げてクラッシュしていました。

## 修正

`filterDisclosureEvents` の先頭で `referenceDate` が空なら早期 return（`[]`）するガードを追加。空の基準日では範囲内アイテムが存在しないため、挙動を変えずにクラッシュのみ防ぎます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)