### PR TITLE
fix(yutai-expiry): 「今月失効」タイルを「今月期限」に改称

### DIFF
--- a/app/tools/yutai-expiry/ToolClient.tsx
+++ b/app/tools/yutai-expiry/ToolClient.tsx
@@ -1078,7 +1078,7 @@ export default function ToolClient({ scanEnabled = false }: Props) {
               value={fmtYen(expiredTotalYen)}
               hint="累計（アーカイブ済みも含む）"
             />
-            <StatTile label="今月失効" value={fmtYen(expiringThisMonthYen)} />
+            <StatTile label="今月期限" value={fmtYen(expiringThisMonthYen)} />
           </div>
 
           <div className={styles.statDashDivider} />


### PR DESCRIPTION
## 概要

累計行の「今月失効」タイルのラベルを「今月期限」に変更。今月期限を迎える優待の額面合計を指す表記に合わせた。

## 変更

- `app/tools/yutai-expiry/ToolClient.tsx`: `StatTile` の label を `今月失効` → `今月期限`（集計値 `expiringThisMonthYen` は変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)