### PR TITLE
fix(yutai-candidates): ピックボタンのはみ出しを解消

### DIFF
--- a/app/tools/yutai-candidates/ToolClient.tsx
+++ b/app/tools/yutai-candidates/ToolClient.tsx
@@ -562,7 +562,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
                           aria-pressed={picked}
                           style={picked ? styles.pickButtonActive : styles.pickButton}
                         >
-                          {picked ? "★ ピック済み" : "☆ ピック"}
+                          {picked ? "★ ピック" : "☆ ピック"}
                         </button>
                         <button
                           type="button"


### PR DESCRIPTION
## 概要

優待カレンダーでピックすると「★ ピック済み」になり、`cardFooter` の 1fr 列（`whiteSpace: nowrap`）で文字が枠からはみ出していた。

## 変更

- ピック後のラベルを「★ ピック済み」→「★ ピック」に短縮（`app/tools/yutai-candidates/ToolClient.tsx`）
- ピック前「☆ ピック」と同じ文字幅になり、状態は **塗りつぶし星(★) ＋ 琥珀色背景**（`pickButtonActive`）で表現
- スタイルは変更なし。フィルタの「状態: ピック済み」ドロップダウンは据え置き

🤖 Generated with [Claude Code](https://claude.com/claude-code)