### PR TITLE
feat(home): premium 限定で TODO アプリのカードを追加

### DIFF
--- a/app/ToolGridClient.tsx
+++ b/app/ToolGridClient.tsx
@@ -13,6 +13,7 @@ type ToolItem = {
   icon: string;
   disabled?: boolean;
   statusLabel?: string;
+  external?: boolean;
 };
 
 type Props = {
@@ -226,27 +227,47 @@ export default function ToolGridClient({ tools }: Props) {
               />
             </div>
           ) : (
-            <Link
-              key={t.href}
-              href={t.href}
-              onClick={(event) => onOpen(event, t.href)}
-              onPointerDown={(event) => startLongPress(event, t.disabled)}
-              onPointerMove={cancelLongPressOnMove}
-              onPointerUp={clearLongPressTimer}
-              onPointerCancel={clearLongPressTimer}
-              onPointerLeave={clearLongPressTimer}
-              onContextMenu={(event) => {
-                if (isEditing || suppressNextClickRef.current) event.preventDefault();
-              }}
-              className="tool-card tool-card--link"
-            >
-              <div className="tool-card__icon">{t.icon}</div>
-              <div className="tool-card__body">
-                <div className="tool-card__title">{t.title}</div>
-                <div className="tool-card__desc">{t.detail}</div>
-              </div>
-              <div className="tool-card__arrow" aria-hidden>→</div>
-            </Link>
+            (() => {
+              const sharedProps = {
+                onClick: (event: MouseEvent) => onOpen(event, t.href),
+                onPointerDown: (event: PointerEvent) => startLongPress(event, t.disabled),
+                onPointerMove: cancelLongPressOnMove,
+                onPointerUp: clearLongPressTimer,
+                onPointerCancel: clearLongPressTimer,
+                onPointerLeave: clearLongPressTimer,
+                onContextMenu: (event: MouseEvent) => {
+                  if (isEditing || suppressNextClickRef.current) event.preventDefault();
+                },
+                className: "tool-card tool-card--link",
+              };
+              const inner = (
+                <>
+                  <div className="tool-card__icon">{t.icon}</div>
+                  <div className="tool-card__body">
+                    <div className="tool-card__title">{t.title}</div>
+                    <div className="tool-card__desc">{t.detail}</div>
+                  </div>
+                  <div className="tool-card__arrow" aria-hidden>
+                    {t.external ? "↗" : "→"}
+                  </div>
+                </>
+              );
+              return t.external ? (
+                <a
+                  key={t.href}
+                  href={t.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  {...sharedProps}
+                >
+                  {inner}
+                </a>
+              ) : (
+                <Link key={t.href} href={t.href} {...sharedProps}>
+                  {inner}
+                </Link>
+              );
+            })()
           )
         )}
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,10 @@
 // app/page.tsx
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import ShareButtons from "@/components/ShareButtonsSuspended";
 import ToolGridClient from "./ToolGridClient";
-import { TOOLS } from "@/lib/tools-catalog";
+import { PREMIUM_EXTERNAL_TOOLS, TOOLS } from "@/lib/tools-catalog";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 
 export const metadata: Metadata = {
   title: "mini-tools | 個人投資家向けミニツール集",
@@ -13,7 +15,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HomePage() {
+export default async function HomePage() {
+  // premium ログイン済みのときだけ、ホームに外部ツール（TODO アプリ）カードを足す。
+  // サーバー側 cookie で判定するので、未ログインのクライアントには HTML 自体に出さない。
+  const cookieStore = await cookies();
+  const isPremium = verifyPremiumSession(cookieStore.get(PREMIUM_COOKIE_NAME)?.value);
+  const tools = isPremium ? [...TOOLS, ...PREMIUM_EXTERNAL_TOOLS] : TOOLS;
+
   return (
     <>
       <main style={{ maxWidth: 1040, margin: "0 auto", padding: "0 16px 64px" }}>
@@ -110,11 +118,11 @@ export default function HomePage() {
               fontSize: 11,
               fontWeight: 800,
             }}>
-              {TOOLS.length}
+              {tools.length}
             </span>
           </div>
 
-          <ToolGridClient tools={TOOLS} />
+          <ToolGridClient tools={tools} />
         </section>
 
         {/* フッター */}

--- a/lib/tools-catalog.ts
+++ b/lib/tools-catalog.ts
@@ -13,6 +13,8 @@ export type ToolItem = {
   category: ToolCategory;
   disabled?: boolean;
   statusLabel?: string;
+  // 外部サイトへのリンク。true のときは別タブで開く（内部 routing は使わない）。
+  external?: boolean;
 };
 
 export const CATEGORY_LABELS: Record<ToolCategory, string> = {
@@ -177,6 +179,21 @@ export const TOOLS: ToolItem[] = [
     href: "/tools/charcount",
     icon: "🔤",
     category: "input",
+  },
+];
+
+// premium ログイン済みのときだけホームに表示する外部ツール。
+// 共有カタログ TOOLS には含めない（ナビのドロワーには出さず、ホーム限定にするため）。
+// DB はこのアプリと別管理なので、ここからは外部 URL へ飛ばすだけでデータは混ざらない。
+export const PREMIUM_EXTERNAL_TOOLS: ToolItem[] = [
+  {
+    title: "TODO アプリ",
+    short: "やることリスト（要ログイン）",
+    detail: "別アプリの TODO リストを開きます。premium ログイン中のみ表示。データはこのアプリとは別管理です。",
+    href: "https://todo-app-ten-rose-62.vercel.app/",
+    icon: "✅",
+    category: "input",
+    external: true,
   },
 ];
 


### PR DESCRIPTION
## 概要

ホームのツールグリッドに、外部の TODO アプリ（`https://todo-app-ten-rose-62.vercel.app/`）へ飛ぶカードを1枚追加する。**premium ログイン中のみ表示**する。

todo アプリ側 DB はこのアプリと別管理なので、ここからは外部 URL へ飛ばすだけ。データは混ざらない。

## 仕様

- **premium 限定表示**: `app/page.tsx` をサーバー側で `verifyPremiumSession` 判定（既存の `app/tools/yutai-expiry/page.tsx` と同じパターン）。未ログインのクライアントには HTML 自体にカード/URL を出さない。
- **ホーム限定**: 共有カタログ `lib/tools-catalog.ts` の `TOOLS` には含めず、別配列 `PREMIUM_EXTERNAL_TOOLS` として定義。ナビのドロワーには出さない。
- **外部リンク**: `ToolGridClient` に `external` フラグを追加し、`<a target="_blank" rel="noopener noreferrer">` で別タブ表示（矢印は ↗）。内部 routing の `<Link>` は使わない。

## 変更ファイル

- `lib/tools-catalog.ts`: `ToolItem.external` 追加、`PREMIUM_EXTERNAL_TOOLS` 追加
- `app/page.tsx`: premium 判定して TODO カードを出し分け、件数バッジも連動
- `app/ToolGridClient.tsx`: `external` のとき別タブの `<a>` で描画

## 補足

- ホーム `/` は cookie を読むため dynamic レンダリングになる（既存の premium ページと同様）。
- 確認: `npx tsc --noEmit`（変更ファイルにエラーなし）/ `eslint`（クリーン）/ `npm run build`（成功）。

## 動作確認

- [ ] premium 未ログイン: ホームに TODO カードが出ない
- [ ] premium ログイン後: TODO カードが表示され、別タブで todo アプリが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)