### PR TITLE
feat(data-transfer): データ引っ越し（JSONエクスポート/インポート・Phase 0）

### DIFF
--- a/app/tools/data-transfer/ClientOnly.tsx
+++ b/app/tools/data-transfer/ClientOnly.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { createClientOnlyTool } from "@/components/createClientOnlyTool";
+
+const ClientOnly = createClientOnlyTool(() => import("./ToolClient"));
+
+export default ClientOnly;

--- a/app/tools/data-transfer/ToolClient.tsx
+++ b/app/tools/data-transfer/ToolClient.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { track } from "@/lib/analytics";
+import {
+  applyBackup,
+  buildBackup,
+  parseBackup,
+  serializeBackup,
+  type ApplyMode,
+  type BackupFile,
+} from "@/lib/local-data-transfer";
+
+const cardStyle: React.CSSProperties = {
+  background: "var(--color-bg-card)",
+  borderRadius: 18,
+  border: "1px solid var(--color-border)",
+  boxShadow: "0 8px 24px rgba(15,23,42,0.05)",
+  padding: "18px 18px 16px",
+};
+
+const primaryButton: React.CSSProperties = {
+  padding: "11px 16px",
+  border: "none",
+  borderRadius: 12,
+  background: "var(--color-accent)",
+  color: "#fff",
+  fontSize: 14,
+  fontWeight: 700,
+  cursor: "pointer",
+  textAlign: "center",
+};
+
+const subButton: React.CSSProperties = {
+  padding: "11px 16px",
+  border: "1px solid var(--color-border-strong)",
+  borderRadius: 12,
+  background: "var(--color-bg-input)",
+  color: "var(--color-text-sub)",
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: "pointer",
+  textAlign: "center",
+};
+
+function formatDateForFilename(d: Date): string {
+  const y = d.getFullYear();
+  const m = `${d.getMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export default function ToolClient() {
+  // ssr:false の dynamic import で読み込まれるため、初期化はクライアントでのみ走る。
+  const [currentCount, setCurrentCount] = useState<number | null>(() => buildBackup().itemCount);
+  const [pending, setPending] = useState<BackupFile | null>(null);
+  const [importMode, setImportMode] = useState<ApplyMode>("merge");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = () => {
+    track("action_clicked", { action: "data_export" });
+    try {
+      const json = serializeBackup();
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `mini-tools-backup-${formatDateForFilename(new Date())}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      setError("エクスポートに失敗しました。");
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMessage(null);
+    setError(null);
+    setPending(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === "string" ? reader.result : "";
+      const result = parseBackup(text);
+      if (result.ok && result.backup) {
+        setPending(result.backup);
+      } else {
+        setError(result.error ?? "読み込みに失敗しました。");
+      }
+    };
+    reader.onerror = () => setError("ファイルの読み込みに失敗しました。");
+    reader.readAsText(file);
+  };
+
+  const handleImport = () => {
+    if (!pending) return;
+    if (importMode === "replace") {
+      const ok = window.confirm(
+        "「置き換え」を選んでいます。このバックアップに無いキーは削除され、端末内データが丸ごと差し替わります。よろしいですか？",
+      );
+      if (!ok) return;
+    }
+    track("action_clicked", { action: "data_import", mode: importMode });
+    const res = applyBackup(pending, importMode);
+    setPending(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    setCurrentCount(buildBackup().itemCount);
+    setMessage(
+      `取り込みました（${res.applied} 件を書き込み${res.removed > 0 ? ` / ${res.removed} 件を削除` : ""}）。` +
+        "反映のため、各ツールのページを開き直してください。",
+    );
+  };
+
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "16px 16px 48px" }}>
+      <div style={{ marginBottom: 24 }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "4px 10px",
+            borderRadius: 999,
+            background: "var(--color-accent-sub)",
+            color: "var(--color-accent)",
+            fontSize: 11,
+            fontWeight: 800,
+            marginBottom: 10,
+          }}
+        >
+          🔄 データ引っ越し
+        </div>
+        <h1 style={{ fontSize: 26, fontWeight: 800, margin: "0 0 6px", letterSpacing: -0.4 }}>
+          端末内データをバックアップ / 復元
+        </h1>
+        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--color-text-sub)" }}>
+          各ツールが端末内（ブラウザ）に保存しているデータを JSON でまとめて書き出し・読み込みします。
+          機種変更やブラウザ移行のときに使えます。サーバーへの送信はありません。
+        </p>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        {/* エクスポート */}
+        <section style={cardStyle}>
+          <h2 style={{ fontSize: 16, fontWeight: 800, margin: "0 0 6px" }}>① 書き出す（この端末から）</h2>
+          <p style={{ margin: "0 0 14px", fontSize: 13, color: "var(--color-text-muted)", lineHeight: 1.6 }}>
+            現在この端末に保存されている全データを 1 つの JSON ファイルにダウンロードします。
+            {currentCount !== null && (
+              <>
+                {" "}
+                （対象: <strong>{currentCount}</strong> 項目）
+              </>
+            )}
+          </p>
+          <button onClick={handleExport} style={primaryButton} disabled={currentCount === 0}>
+            JSON をダウンロード
+          </button>
+        </section>
+
+        {/* インポート */}
+        <section style={cardStyle}>
+          <h2 style={{ fontSize: 16, fontWeight: 800, margin: "0 0 6px" }}>② 読み込む（別端末・復元）</h2>
+          <p style={{ margin: "0 0 14px", fontSize: 13, color: "var(--color-text-muted)", lineHeight: 1.6 }}>
+            書き出した JSON ファイルを選ぶと内容を確認できます。取り込み方法を選んで反映してください。
+          </p>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            onChange={handleFileChange}
+            style={{ fontSize: 13, marginBottom: 14, color: "var(--color-text-sub)" }}
+          />
+
+          {pending && (
+            <div
+              style={{
+                background: "var(--color-bg-input)",
+                border: "1px solid var(--color-border)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                marginBottom: 14,
+                fontSize: 13,
+                color: "var(--color-text-sub)",
+                lineHeight: 1.7,
+              }}
+            >
+              <div>
+                読み込んだファイル: <strong>{pending.itemCount}</strong> 項目
+              </div>
+              {pending.exportedAt && (
+                <div style={{ color: "var(--color-text-muted)" }}>
+                  書き出し日時: {new Date(pending.exportedAt).toLocaleString()}
+                </div>
+              )}
+
+              <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 12 }}>
+                <label style={{ display: "flex", gap: 8, alignItems: "flex-start", cursor: "pointer" }}>
+                  <input
+                    type="radio"
+                    name="import-mode"
+                    checked={importMode === "merge"}
+                    onChange={() => setImportMode("merge")}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span>
+                    <strong>追加・上書き（おすすめ）</strong>
+                    <br />
+                    ファイル内のキーを書き込みます。この端末にしかないデータは残ります。
+                  </span>
+                </label>
+                <label style={{ display: "flex", gap: 8, alignItems: "flex-start", cursor: "pointer" }}>
+                  <input
+                    type="radio"
+                    name="import-mode"
+                    checked={importMode === "replace"}
+                    onChange={() => setImportMode("replace")}
+                    style={{ marginTop: 3 }}
+                  />
+                  <span>
+                    <strong>置き換え</strong>
+                    <br />
+                    ファイルに無いキーを削除し、端末内データを丸ごと差し替えます。
+                  </span>
+                </label>
+              </div>
+
+              <button onClick={handleImport} style={{ ...primaryButton, marginTop: 14, width: "100%" }}>
+                取り込む
+              </button>
+            </div>
+          )}
+
+          {error && (
+            <div style={{ fontSize: 13, color: "var(--color-danger, #dc2626)", marginTop: 4 }}>{error}</div>
+          )}
+          {message && (
+            <div style={{ fontSize: 13, color: "var(--color-accent)", marginTop: 4, lineHeight: 1.6 }}>
+              {message}
+            </div>
+          )}
+        </section>
+
+        {/* 注記 */}
+        <p style={{ fontSize: 11, color: "var(--color-text-muted)", lineHeight: 1.7, margin: 0 }}>
+          ※ これは手動のバックアップ機能です（自動同期ではありません）。データはこの端末にのみ保存され、
+          書き出した JSON ファイルの管理はご自身で行ってください。
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/tools/data-transfer/ToolClient.tsx
+++ b/app/tools/data-transfer/ToolClient.tsx
@@ -157,9 +157,27 @@ export default function ToolClient() {
               </>
             )}
           </p>
-          <button onClick={handleExport} style={primaryButton} disabled={currentCount === 0}>
-            JSON をダウンロード
-          </button>
+          {currentCount === 0 ? (
+            <div
+              style={{
+                background: "var(--color-bg-input)",
+                border: "1px solid var(--color-border)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                fontSize: 13,
+                color: "var(--color-text-muted)",
+                lineHeight: 1.7,
+              }}
+            >
+              この端末（ブラウザ）には保存データがまだありません。先に各ツールでデータを入力してから書き出してください。
+              <br />
+              保存先はブラウザ・端末ごとに分かれているため、別の端末／ブラウザ（やシークレットウィンドウ）で入力したデータはここには表示されません。
+            </div>
+          ) : (
+            <button onClick={handleExport} style={primaryButton}>
+              JSON をダウンロード
+            </button>
+          )}
         </section>
 
         {/* インポート */}

--- a/app/tools/data-transfer/page.tsx
+++ b/app/tools/data-transfer/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import ClientOnly from "./ClientOnly";
+
+export const metadata: Metadata = {
+  title: "データ引っ越し | mini-tools",
+  description:
+    "各ツールの端末内データ（LocalStorage）を JSON ファイルに書き出し・読み込み。機種変更やブラウザ移行時のバックアップに使えます。サーバーへの送信はありません。",
+  alternates: {
+    canonical: "/tools/data-transfer",
+  },
+};
+
+export default function Page() {
+  return <ClientOnly />;
+}

--- a/lib/__tests__/local-data-transfer.test.ts
+++ b/lib/__tests__/local-data-transfer.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  BACKUP_SCHEMA,
+  parseBackup,
+  serializeBackup,
+  type BackupFile,
+} from "../local-data-transfer";
+
+function makeBackup(data: Record<string, string>): BackupFile {
+  return {
+    schema: BACKUP_SCHEMA,
+    version: 1,
+    exportedAt: "2026-06-21T00:00:00.000Z",
+    origin: "https://example.test",
+    itemCount: Object.keys(data).length,
+    data,
+  };
+}
+
+describe("local-data-transfer", () => {
+  it("serialize と parse で往復できる", () => {
+    const backup = makeBackup({
+      yutai_memo_items_v1: '[{"id":"a"}]',
+      mini_tools_total_lines_v1: "1200\n300",
+    });
+    const json = serializeBackup(backup);
+    const result = parseBackup(json);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.backup.data).toEqual(backup.data);
+      expect(result.backup.itemCount).toBe(2);
+    }
+  });
+
+  it("schema が違う JSON は拒否する", () => {
+    const result = parseBackup(JSON.stringify({ schema: "something-else", data: {} }));
+    expect(result.ok).toBe(false);
+  });
+
+  it("JSON でない文字列は拒否する", () => {
+    const result = parseBackup("not json {");
+    expect(result.ok).toBe(false);
+  });
+
+  it("data が無い場合は拒否する", () => {
+    const result = parseBackup(JSON.stringify({ schema: BACKUP_SCHEMA, version: 1 }));
+    expect(result.ok).toBe(false);
+  });
+
+  it("data 内の非文字列値は無視する", () => {
+    const result = parseBackup(
+      JSON.stringify({
+        schema: BACKUP_SCHEMA,
+        version: 1,
+        data: { good: "ok", bad: 123, also_bad: null },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.backup.data).toEqual({ good: "ok" });
+    }
+  });
+});

--- a/lib/local-data-transfer.ts
+++ b/lib/local-data-transfer.ts
@@ -1,0 +1,139 @@
+// lib/local-data-transfer.ts
+// 端末内 LocalStorage の全データを JSON にエクスポート / インポートする。
+// Phase 0: ログイン・サーバー不要の「機種変更の救済」用。将来のサーバー同期(Phase 1)とは独立。
+// 各ツールが個別のキー（*_v1 など）を使うため、特定キーの一覧を持たず localStorage 全体を対象にする。
+// これにより、ツールが増えてもこのファイルを更新せずに取りこぼしなくバックアップできる。
+
+export const BACKUP_SCHEMA = "mini-tools-localstorage-backup";
+export const BACKUP_VERSION = 1;
+
+export type BackupFile = {
+  schema: string;
+  version: number;
+  /** エクスポート時刻（ISO 文字列） */
+  exportedAt: string;
+  /** エクスポート元のオリジン（参考情報） */
+  origin?: string;
+  /** data に含まれるキー数 */
+  itemCount: number;
+  /** localStorage のキー → 値（文字列）。値は各ツールが入れた JSON 文字列そのまま */
+  data: Record<string, string>;
+};
+
+/** 現在の localStorage を全件読み出す。利用不可環境では空オブジェクト。 */
+export function collectLocalStorage(): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (typeof window === "undefined") return out;
+  try {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key == null) continue;
+      const value = window.localStorage.getItem(key);
+      if (value == null) continue;
+      out[key] = value;
+    }
+  } catch {
+    // localStorage が使えない環境では空のまま返す
+  }
+  return out;
+}
+
+/** 現在の localStorage からバックアップオブジェクトを作る。 */
+export function buildBackup(): BackupFile {
+  const data = collectLocalStorage();
+  return {
+    schema: BACKUP_SCHEMA,
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    origin: typeof window !== "undefined" ? window.location.origin : undefined,
+    itemCount: Object.keys(data).length,
+    data,
+  };
+}
+
+/** バックアップを保存用 JSON 文字列にする。 */
+export function serializeBackup(backup: BackupFile = buildBackup()): string {
+  return JSON.stringify(backup, null, 2);
+}
+
+// プロジェクトは strict:false（strictNullChecks 無効）のため判別可能ユニオンの絞り込みが効かない。
+// 絞り込みに依存しないよう、成否を 1 つの型で表す。
+export type ParseResult = {
+  ok: boolean;
+  backup?: BackupFile;
+  error?: string;
+};
+
+/** JSON 文字列をバックアップとして検証して読み込む。 */
+export function parseBackup(text: string): ParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "JSON として読み込めませんでした。" };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { ok: false, error: "バックアップ形式ではありません。" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.schema !== BACKUP_SCHEMA) {
+    return { ok: false, error: "mini-tools のバックアップファイルではありません。" };
+  }
+  if (typeof obj.data !== "object" || obj.data === null) {
+    return { ok: false, error: "データ本体（data）が見つかりません。" };
+  }
+  const data: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj.data as Record<string, unknown>)) {
+    // 値は文字列のみ受け入れる（localStorage の値は常に文字列のため）
+    if (typeof v === "string") data[k] = v;
+  }
+  return {
+    ok: true,
+    backup: {
+      schema: BACKUP_SCHEMA,
+      version: typeof obj.version === "number" ? obj.version : 1,
+      exportedAt: typeof obj.exportedAt === "string" ? obj.exportedAt : "",
+      origin: typeof obj.origin === "string" ? obj.origin : undefined,
+      itemCount: Object.keys(data).length,
+      data,
+    },
+  };
+}
+
+export type ApplyMode = "merge" | "replace";
+
+export type ApplyResult = { applied: number; removed: number };
+
+/**
+ * バックアップを localStorage へ書き戻す。
+ * - merge: バックアップのキーを上書き・追記する（既存の他キーは残す）
+ * - replace: バックアップに無い既存キーを削除してから書き込む（端末を丸ごと差し替え）
+ */
+export function applyBackup(backup: BackupFile, mode: ApplyMode = "merge"): ApplyResult {
+  let applied = 0;
+  let removed = 0;
+  if (typeof window === "undefined") return { applied, removed };
+  try {
+    if (mode === "replace") {
+      const keep = new Set(Object.keys(backup.data));
+      const existing: string[] = [];
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (key != null) existing.push(key);
+      }
+      for (const key of existing) {
+        if (!keep.has(key)) {
+          window.localStorage.removeItem(key);
+          removed++;
+        }
+      }
+    }
+    for (const [key, value] of Object.entries(backup.data)) {
+      window.localStorage.setItem(key, value);
+      applied++;
+    }
+  } catch {
+    // 個別の書き込み失敗は無視し、できた分だけ反映する
+  }
+  return { applied, removed };
+}

--- a/lib/tools-catalog.ts
+++ b/lib/tools-catalog.ts
@@ -180,6 +180,14 @@ export const TOOLS: ToolItem[] = [
     icon: "🔤",
     category: "input",
   },
+  {
+    title: "データ引っ越し",
+    short: "端末内データをJSONで保存/復元",
+    detail: "各ツールの端末内データ（LocalStorage）をJSONファイルに書き出し・読み込み。機種変更やブラウザ移行時のバックアップに。サーバー送信なし。",
+    href: "/tools/data-transfer",
+    icon: "🔄",
+    category: "input",
+  },
 ];
 
 // premium ログイン済みのときだけホームに表示する外部ツール。


### PR DESCRIPTION
## 概要

クロスデバイス同期の **Phase 0**。ログイン・DB なしで「機種変更の痛み」だけを先に解消する、端末内データの手動バックアップ／復元ツールを追加する。

- 各ツールが端末内（LocalStorage）に保存するデータを、まとめて 1 つの JSON に**エクスポート**
- 別端末・同端末で JSON を読み込んで**インポート（復元）**
- サーバー送信なし。将来のサーバー同期（Phase 1）とは独立

decision-log「ローカルデータの任意ログイン同期方針」(#378) の段階案に沿った最初の一歩。

## 実装

- `lib/local-data-transfer.ts`
  - LocalStorage **全キー**を対象にする（特定キー一覧を持たないので、ツールが増えても取りこぼさない）
  - `buildBackup` / `serializeBackup` / `parseBackup`（schema 検証）/ `applyBackup`
- `app/tools/data-transfer/`（ClientOnly ページ）
  - ① 書き出す: 現在の項目数を表示して JSON ダウンロード（`mini-tools-backup-YYYY-MM-DD.json`）
  - ② 読み込む: ファイル選択 → 内容プレビュー → **追加・上書き**（推奨）／**置き換え**（確認ダイアログあり）
- `lib/tools-catalog.ts`: input カテゴリに「🔄 データ引っ越し」を登録（ホーム・ドロワーに表示）
- `lib/__tests__/local-data-transfer.test.ts`: parse/serialize の単体テスト（5 ケース）

## 確認

- `vitest`（新規 5 件パス）
- `tsc --noEmit`（新規ファイルにエラーなし）
- `eslint`（クリーン）
- `npm run build`（成功）

注: プロジェクトは `strict:false` のため判別可能ユニオンの絞り込みが効かない。`ParseResult` は単一型（`ok` + 任意 `backup`/`error`）にしている。

## 動作確認（レビュー観点）

- [ ] 既存ツールで保存 → 書き出し → 別ブラウザで読み込み → データが復元される
- [ ] 「置き換え」で確認ダイアログが出る
- [ ] 取り込み後に各ツールを開き直すと反映されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)