### PR TITLE
feat(sync): Phase 1 土台（Supabase でクロスデバイス同期）

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,6 +13,14 @@ MARKET_INFO_API_BASE_URL=
 # 共有リンク / QR 用の公開URL（任意）
 NEXT_PUBLIC_SITE_URL=
 
+# クロスデバイス同期（Phase 1・任意）
+# Supabase プロジェクトの URL と anon public キー。
+# 未設定時は同期機能（/api/sync）は無効（503）になり、各ツールは従来どおり端末内完結で動く。
+# 設定手順: docs/plans/phase1-cross-device-sync-plan.md の「provision 手順」
+# 値は commit しないこと（.env.local のみに記載）。
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
 # premium 仮ログイン用（任意）
 # 未設定時は /premium/login でエラー表示になります
 # 開発用の仮値例: PREMIUM_ACCESS_PASSWORD=nogunogu

--- a/app/api/sync/route.ts
+++ b/app/api/sync/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import { isSyncConfigured } from "@/lib/supabase/config";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// クロスデバイス同期 API（Phase 1）。
+// 設計: docs/plans/phase1-cross-device-sync-plan.md
+// - 未設定（Supabase env なし）なら 503
+// - 未ログインなら 401
+// - データは RLS により自分の行だけが対象（user_id = auth.uid()）
+
+type SyncItem = { key: string; value: unknown; updatedAt: string };
+
+type ToolDataRow = { key: string; value: unknown; updated_at: string };
+
+function rowToItem(row: ToolDataRow): SyncItem {
+  return { key: row.key, value: row.value, updatedAt: row.updated_at };
+}
+
+// GET /api/sync : 自分の全データを返す（復元用）
+export async function GET() {
+  if (!isSyncConfigured()) {
+    return NextResponse.json({ error: "sync is not configured" }, { status: 503 });
+  }
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("tool_data")
+    .select("key, value, updated_at")
+    .eq("user_id", user.id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const items = (data ?? []).map(rowToItem);
+  return NextResponse.json({ items });
+}
+
+// POST /api/sync : items を upsert（保存用）。updatedAt の新しい方を採用（last-write-wins）
+export async function POST(request: Request) {
+  if (!isSyncConfigured()) {
+    return NextResponse.json({ error: "sync is not configured" }, { status: 503 });
+  }
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: { items?: SyncItem[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const incoming = Array.isArray(body.items) ? body.items : [];
+  const valid = incoming.filter(
+    (it) => it && typeof it.key === "string" && typeof it.updatedAt === "string",
+  );
+
+  // 既存の updatedAt を引いて、より新しいものだけ upsert する。
+  const keys = valid.map((it) => it.key);
+  const existing = new Map<string, string>();
+  if (keys.length > 0) {
+    const { data: rows, error } = await supabase
+      .from("tool_data")
+      .select("key, updated_at")
+      .eq("user_id", user.id)
+      .in("key", keys);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    for (const row of rows ?? []) {
+      existing.set(row.key, row.updated_at);
+    }
+  }
+
+  const toUpsert = valid
+    .filter((it) => {
+      const prev = existing.get(it.key);
+      return !prev || new Date(it.updatedAt).getTime() > new Date(prev).getTime();
+    })
+    .map((it) => ({
+      user_id: user.id,
+      key: it.key,
+      value: it.value,
+      updated_at: it.updatedAt,
+    }));
+
+  if (toUpsert.length > 0) {
+    const { error } = await supabase
+      .from("tool_data")
+      .upsert(toUpsert, { onConflict: "user_id,key" });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // マージ後の確定値（全件）を返す。クライアントはこれで LocalStorage を更新する。
+  const { data: after, error: afterError } = await supabase
+    .from("tool_data")
+    .select("key, value, updated_at")
+    .eq("user_id", user.id);
+  if (afterError) {
+    return NextResponse.json({ error: afterError.message }, { status: 500 });
+  }
+
+  const items = (after ?? []).map(rowToItem);
+  return NextResponse.json({ items });
+}

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -11,6 +11,7 @@
 | [プロジェクト継続・撤退判断基準](./project-continuation-criteria.md) | 継続、撤退、凍結の判断基準 |
 | [株価ランキング外部データ移行計画](./stock-ranking-external-data-migration-plan.md) | stock-ranking の外部データ公開移行計画 |
 | [yutai-expiry カメラ画像認識計画](./yutai-expiry-image-capture-plan.md) | 優待券をカメラ撮影し Gemini で自動入力する段階実装計画 |
+| [Phase 1 クロスデバイス同期 実装計画](./phase1-cross-device-sync-plan.md) | 任意ログイン + Supabase でツールデータをデバイス間同期する段階実装計画 |
 
 ## 更新ルール
 

--- a/docs/plans/phase1-cross-device-sync-plan.md
+++ b/docs/plans/phase1-cross-device-sync-plan.md
@@ -1,0 +1,120 @@
+# Phase 1: クロスデバイス同期 実装計画（Supabase）
+
+「ローカルデータの任意ログイン同期方針」（[decision-log 2026-06-21](../decision-log/2026-06-21-localstorage-optional-login-sync-policy.md)）の **Phase 1**。
+未ログインは従来どおり端末内完結。ログイン時だけ、ツールデータをサーバー（DB）に保存し、別端末で復元できるようにする。
+
+- 関連: [Phase 0（JSON エクスポート/インポート）](../../lib/local-data-transfer.ts) は実装済み（PR #380）。
+- アーキ図: `OneDrive/dev-docs/mini-tools-architecture.html` セクション 5。
+
+## 結論（採用スタック）
+
+- **Supabase（Auth + PostgreSQL + RLS）** を採用する。
+- 理由:
+  - 本番で個人データを預かるため、**認証は自作せずマネージドに寄せる**（パスワードハッシュ・セッション・リセット・漏洩対策の自作リスクを回避）。
+  - **RLS（Row Level Security）** で「自分の行だけ読み書き」を DB 側で強制でき、権限の肝を最小コードで担保できる。
+  - mini-tools と同じ Next.js での Supabase 実装例（`dev/data-gallery`）があり、配線を流用できる。
+  - 無料枠で足りる。
+- 採らなかった案:
+  - **Neon + 自前認証**: ログイン自作は学習価値が高いが、本番で認証を自作するセキュリティ責任が重い。
+  - **Supabase DB + 自前セッション**: 認証の安全性が自作品質に依存するため本番では非推奨。
+
+## 設計の柱
+
+- **ローカルファースト**: LocalStorage を手元の正＝キャッシュとして維持。未ログインなら一切サーバー送信なし。
+- **オプトイン**: ログインは任意。未ログインでも全機能が動く。
+- **競合解決**: `updatedAt` の last-write-wins（新しい方を採用）。
+- **権限**: RLS により `user_id = auth.uid()` の行だけ読み書き可。
+- **段階**: まず **優待メモ帳（`yutai_memo_items_v1`）1 本**を縦に通す。汎用 key-value 構造にし、後続ツールは行を足すだけ。
+
+## データモデル
+
+汎用の「ユーザー × LocalStorage キー × 値」テーブル 1 つにする。
+ツールごとにテーブルを増やさず、既存の保存キー（`*_v1`）をそのまま預かる。
+
+```
+table: tool_data
+- user_id     uuid        not null   references auth.users(id) on delete cascade
+- key         text        not null   -- 例: "yutai_memo_items_v1"
+- value       jsonb       not null   -- 各ツールが保存している JSON（文字列ではなく parse 済み）
+- updated_at  timestamptz not null default now()
+- primary key (user_id, key)
+```
+
+- 1 ユーザー × 1 キー = 1 行（upsert）。
+- `value` は JSON。LocalStorage 上は文字列だが、送信時に parse して jsonb で持つ（検索・将来の集計に有利）。
+- RLS: SELECT / INSERT / UPDATE / DELETE すべて `user_id = auth.uid()` を条件にする。
+
+スキーマ・ポリシーの実体は [`supabase/schema.sql`](../../supabase/schema.sql)。Supabase の SQL Editor で実行する。
+
+## API 契約（Route Handler）
+
+サーバー（Next.js）に同期 API を置く。Supabase のセッション Cookie から `user` を取得し、未ログインは 401。
+
+| メソッド | パス | 役割 | 入力 | 出力 |
+|---|---|---|---|---|
+| GET | `/api/sync` | 自分の全データを取得（復元用） | （なし） | `{ items: { key, value, updatedAt }[] }` |
+| POST | `/api/sync` | 1 つ以上のキーを upsert（保存用） | `{ items: { key, value, updatedAt }[] }` | `{ items: { key, value, updatedAt }[] }`（マージ後） |
+
+- POST は `updatedAt` を比較し、**サーバー側が新しければ採用しない**（last-write-wins）。応答で確定値を返す。
+- 環境変数が未設定なら 503（機能無効）。未ログインは 401。
+
+## クライアント同期層
+
+- `lib/sync/` に、対象キーの登録と push/pull を置く。
+- 優待メモ帳の保存（`yutai_memo_items_v1`）を契機に、ログイン中ならデバウンスして POST。
+- 起動時・ログイン直後に GET して、`updatedAt` が新しい方で LocalStorage を更新。
+- 初回ログイン時は、ローカルにあるデータをサーバーへ吸い上げる（空のサーバーで上書き消去しない）。
+
+## 認証フロー
+
+- Supabase Auth（メール＋パスワード、もしくはマジックリンク。初手はメール＋パスワードを想定。後で確定）。
+- `@supabase/ssr` でサーバー / クライアント両方のセッションを Cookie 経由で共有。
+- ログイン/サインアップ UI を `/account`（仮）に置く。premium ログイン（共有 PW）とは別物。
+
+## 環境変数
+
+`.env.local`（と Vercel）に設定。`.env.local.example` にキー名のみ追記済み。**値は commit しない。**
+
+| 変数 | 公開範囲 | 用途 |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | 公開 | Supabase プロジェクト URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | 公開（ブラウザ可） | RLS 前提の anon キー |
+
+- service_role キーは**当面使わない**（RLS + ユーザーセッションで完結するため）。管理操作が必要になったら別途サーバー専用で追加する。
+
+## provision 手順（ユーザー作業）
+
+私（Claude）はアカウントを作れないため、以下はご自身で行う。
+
+1. Supabase で新規プロジェクトを作成（リージョンは ap-northeast 系を推奨）。
+2. SQL Editor で [`supabase/schema.sql`](../../supabase/schema.sql) を実行（`tool_data` テーブル + RLS）。
+3. Authentication → 設定でメール認証を有効化（確認メールの要否を選ぶ）。
+4. Project Settings → API から `URL` と `anon public` キーを取得。
+5. ローカル `.env.local` と Vercel の環境変数に `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` を設定。
+6. 設定できたら連絡 → こちらで認証 UI と優待メモ帳の同期を実機検証しながら仕上げる。
+
+## ロールアウト
+
+1. **本 PR（foundation）**: 計画・スキーマ・依存・Supabase 配線・env 雛形・`/api/sync` 骨組み（未設定時 503）。既存ページからは未参照でビルドに影響なし。
+2. **次 PR**: 認証 UI + 優待メモ帳の同期（provision 後、実機検証込み）。
+3. **その後**: 対象ツールを順次拡大。Phase 2 で自動同期・競合の精緻化。
+
+## リスクと可逆性
+
+- 未ログイン時の挙動は不変なので、既存ユーザーへの影響はゼロ。
+- 環境変数未設定なら同期機能は完全に無効（503）＝安全側に倒れる。
+- データは既存 LocalStorage 形式のまま預かるので、撤退時もローカルは無傷。
+- pause 懸念（Supabase 無料枠）: 実利用が始まれば起きにくい。最悪も復帰可能。
+
+## 残課題
+
+- 認証方式（メール＋パスワード / マジックリンク / OAuth）の最終決定。
+- 退会・データ削除（GDPR 的）導線。
+- 競合解決を要素単位に精緻化するか（当面はキー丸ごと last-write-wins）。
+- 同期トリガの頻度・デバウンス・オフライン再送。
+
+## 関連
+
+- decision-log: [2026-06-21 ローカルデータの任意ログイン同期方針](../decision-log/2026-06-21-localstorage-optional-login-sync-policy.md)
+- 参考実装: `dev/data-gallery`（Supabase × Next.js）
+- Phase 0 実装: `lib/local-data-transfer.ts`, `app/tools/data-transfer/`

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+// lib/supabase/client.ts
+// ブラウザ用 Supabase クライアント（anon キー）。Client Component から使う。
+import { createBrowserClient } from "@supabase/ssr";
+import { getSupabaseEnv } from "./config";
+
+export function createSupabaseBrowserClient() {
+  const { url, anonKey } = getSupabaseEnv();
+  if (!url || !anonKey) {
+    throw new Error("Supabase env が未設定です（NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY）。");
+  }
+  return createBrowserClient(url, anonKey);
+}

--- a/lib/supabase/config.ts
+++ b/lib/supabase/config.ts
@@ -1,0 +1,14 @@
+// lib/supabase/config.ts
+// Supabase の公開 env を読む。未設定なら同期機能を無効（503）にするための判定に使う。
+
+export function getSupabaseEnv() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() || "";
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() || "";
+  return { url, anonKey };
+}
+
+/** クロスデバイス同期（Supabase）が設定済みか。未設定なら同期は無効。 */
+export function isSyncConfigured(): boolean {
+  const { url, anonKey } = getSupabaseEnv();
+  return Boolean(url && anonKey);
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,33 @@
+// lib/supabase/server.ts
+// サーバー用 Supabase クライアント。Cookie 経由でセッションを共有する（@supabase/ssr）。
+// Route Handler / Server Component から使う。
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import { getSupabaseEnv } from "./config";
+
+export async function createSupabaseServerClient() {
+  const { url, anonKey } = getSupabaseEnv();
+  if (!url || !anonKey) {
+    throw new Error("Supabase env が未設定です（NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY）。");
+  }
+
+  const cookieStore = await cookies();
+
+  return createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Component から呼ばれた場合は cookie をセットできない。
+          // セッション更新は Route Handler / middleware 側で行うため無視してよい。
+        }
+      },
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "mini-tools",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.12.0",
+        "@supabase/supabase-js": "^2.108.2",
         "next": "^16.0.10",
         "next-pwa": "^5.6.0",
         "qrcode.react": "^4.2.0",
@@ -2867,6 +2869,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.2.tgz",
+      "integrity": "sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.2.tgz",
+      "integrity": "sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.2.tgz",
+      "integrity": "sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.2.tgz",
+      "integrity": "sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.0.tgz",
+      "integrity": "sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.108.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.2.tgz",
+      "integrity": "sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.108.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
+      "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.108.2",
+        "@supabase/functions-js": "2.108.2",
+        "@supabase/postgrest-js": "2.108.2",
+        "@supabase/realtime-js": "2.108.2",
+        "@supabase/storage-js": "2.108.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -4650,6 +4748,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.47.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
@@ -6219,6 +6330,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/idb": {
       "version": "7.1.1",
@@ -8086,7 +8206,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:ui": "playwright test --config=playwright.ui-smoke.config.ts"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.12.0",
+    "@supabase/supabase-js": "^2.108.2",
     "next": "^16.0.10",
     "next-pwa": "^5.6.0",
     "qrcode.react": "^4.2.0",

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,39 @@
+-- mini-tools クロスデバイス同期（Phase 1）用スキーマ
+-- Supabase の SQL Editor で実行する。
+-- 設計: docs/plans/phase1-cross-device-sync-plan.md
+
+-- ユーザー × LocalStorage キー × 値 の汎用テーブル。
+-- ツールごとにテーブルを増やさず、既存の保存キー（*_v1）をそのまま預かる。
+create table if not exists public.tool_data (
+  user_id    uuid        not null references auth.users (id) on delete cascade,
+  key        text        not null,
+  value      jsonb       not null,
+  updated_at timestamptz not null default now(),
+  primary key (user_id, key)
+);
+
+-- 自分の行だけ読み書きできるよう RLS を有効化する。
+alter table public.tool_data enable row level security;
+
+-- 既存ポリシーがあれば作り直す（再実行を安全にする）。
+drop policy if exists "tool_data select own" on public.tool_data;
+drop policy if exists "tool_data insert own" on public.tool_data;
+drop policy if exists "tool_data update own" on public.tool_data;
+drop policy if exists "tool_data delete own" on public.tool_data;
+
+create policy "tool_data select own"
+  on public.tool_data for select
+  using (auth.uid() = user_id);
+
+create policy "tool_data insert own"
+  on public.tool_data for insert
+  with check (auth.uid() = user_id);
+
+create policy "tool_data update own"
+  on public.tool_data for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "tool_data delete own"
+  on public.tool_data for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## 概要

任意ログイン + DB でツールデータをデバイス間同期する **Phase 1 の土台**。
**未ログイン・未設定なら従来どおり端末内完結**で動き、既存挙動には一切影響しない（新コードは既存ページから未参照、env 未設定なら同期 API は 503）。

採用スタックは **Supabase（Auth + Postgres + RLS）**。本番で個人データを預かるため認証は自作せず、RLS で「自分の行だけ」を DB 側で強制する。詳細は設計書を参照。

## 含むもの

- `docs/plans/phase1-cross-device-sync-plan.md` … 採用理由・スキーマ・API契約・同期方式・**provision 手順**
- `supabase/schema.sql` … `tool_data(user_id, key, value jsonb, updated_at)` + RLS 4ポリシー
- `lib/supabase/{config,client,server}.ts` … env ガード付き配線（`@supabase/ssr`）
- `app/api/sync/route.ts` … `GET`(復元) / `POST`(保存・**last-write-wins**)。未設定 503 / 未ログイン 401
- `.env.local.example` … `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`（値は非 commit）
- deps: `@supabase/supabase-js`, `@supabase/ssr`

## 含まないもの（次 PR）

- 認証 UI（ログイン/サインアップ）
- 優待メモ帳の同期連携（push/pull・初回吸い上げ）
- → どちらも Supabase プロジェクト provision 後に実機検証しながら実装

## あなたの作業（provision）

設計書の「provision 手順」参照。要点: Supabase プロジェクト作成 → `supabase/schema.sql` 実行 → メール認証有効化 → `URL`/`anon` キーを `.env.local` と Vercel に設定。**鍵は PR に貼らず各自の `.env` に。**

## 確認

- `tsc --noEmit`（新規ファイルにエラーなし）/ `eslint`（クリーン）/ `npm run build`（成功、`/api/sync` 生成）
- env 未設定の現状ビルドで既存挙動不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)