### PR TITLE
feat(sync): 認証UI＋クロスデバイス同期（Phase 1）

### DIFF
--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+import { isSyncConfigured } from "@/lib/supabase/config";
+import { pullAll, pushAll } from "@/lib/sync/client";
+import { track } from "@/lib/analytics";
+
+const card: React.CSSProperties = {
+  background: "var(--color-bg-card)",
+  borderRadius: 18,
+  border: "1px solid var(--color-border)",
+  boxShadow: "0 8px 24px rgba(15,23,42,0.05)",
+  padding: "18px 18px 16px",
+};
+const primaryBtn: React.CSSProperties = {
+  padding: "11px 16px",
+  border: "none",
+  borderRadius: 12,
+  background: "var(--color-accent)",
+  color: "#fff",
+  fontSize: 14,
+  fontWeight: 700,
+  cursor: "pointer",
+};
+const subBtn: React.CSSProperties = {
+  padding: "11px 16px",
+  border: "1px solid var(--color-border-strong)",
+  borderRadius: 12,
+  background: "var(--color-bg-input)",
+  color: "var(--color-text-sub)",
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: "pointer",
+};
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  border: "1px solid var(--color-border-strong)",
+  borderRadius: 10,
+  background: "var(--color-bg-input)",
+  color: "var(--color-text)",
+  fontSize: 14,
+  boxSizing: "border-box",
+};
+
+export default function AccountClient() {
+  const configured = isSyncConfigured();
+  const [supabase] = useState<SupabaseClient | null>(() =>
+    configured ? createSupabaseBrowserClient() : null,
+  );
+
+  const [ready, setReady] = useState(false);
+  const [email, setEmail] = useState<string | null>(null);
+  const [inputEmail, setInputEmail] = useState("");
+  const [inputPassword, setInputPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase) {
+      setReady(true);
+      return;
+    }
+    let active = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!active) return;
+      setEmail(data.user?.email ?? null);
+      setReady(true);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setEmail(session?.user?.email ?? null);
+    });
+    return () => {
+      active = false;
+      sub.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  // ログイン直後の同期: まずサーバーから復元（新しい方）、次にローカルを送信。
+  // 復元で変化があればページを再読み込みして各ツールに反映する。
+  async function syncOnLogin() {
+    const pulled = await pullAll();
+    await pushAll();
+    if (pulled.ok && pulled.changed.length > 0) {
+      window.location.reload();
+    }
+  }
+
+  async function handleLogin() {
+    if (!supabase) return;
+    setBusy(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email: inputEmail.trim(),
+        password: inputPassword,
+      });
+      if (error) {
+        setError(error.message);
+        return;
+      }
+      track("action_clicked", { action: "auth_login" });
+      setInputPassword("");
+      await syncOnLogin();
+      setMessage("ログインしました。データを同期しました。");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSignup() {
+    if (!supabase) return;
+    setBusy(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const { data, error } = await supabase.auth.signUp({
+        email: inputEmail.trim(),
+        password: inputPassword,
+      });
+      if (error) {
+        setError(error.message);
+        return;
+      }
+      track("action_clicked", { action: "auth_signup" });
+      setInputPassword("");
+      if (data.session) {
+        // メール確認 OFF の場合はそのままログイン状態になる。
+        await syncOnLogin();
+        setMessage("登録してログインしました。データを同期しました。");
+      } else {
+        setMessage("確認メールを送信しました。メール内のリンクで認証してください。");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleLogout() {
+    if (!supabase) return;
+    await supabase.auth.signOut();
+    setEmail(null);
+    setMessage("ログアウトしました（端末内のデータはそのまま残ります）。");
+  }
+
+  async function handleUpload() {
+    setBusy(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await pushAll();
+      if (res.ok) setMessage("このデバイスのデータをサーバーへ保存しました。");
+      else setError(res.error ?? "アップロードに失敗しました。");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRestore() {
+    setBusy(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await pullAll();
+      if (!res.ok) {
+        setError(res.error ?? "復元に失敗しました。");
+        return;
+      }
+      if (res.changed.length > 0) {
+        setMessage("サーバーから復元しました。ページを再読み込みします…");
+        setTimeout(() => window.location.reload(), 800);
+      } else {
+        setMessage("サーバー側に新しいデータはありませんでした。");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main style={{ maxWidth: 560, margin: "0 auto", padding: "16px 16px 48px" }}>
+      <div style={{ marginBottom: 24 }}>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "4px 10px",
+            borderRadius: 999,
+            background: "var(--color-accent-sub)",
+            color: "var(--color-accent)",
+            fontSize: 11,
+            fontWeight: 800,
+            marginBottom: 10,
+          }}
+        >
+          🔐 アカウント・同期
+        </div>
+        <h1 style={{ fontSize: 26, fontWeight: 800, margin: "0 0 6px", letterSpacing: -0.4 }}>
+          ログインして端末間で同期
+        </h1>
+        <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--color-text-sub)" }}>
+          任意機能です。ログインすると対応ツール（まずは優待メモ帳）のデータを端末間で同期できます。
+          未ログインなら従来どおり端末内のみで動きます。
+        </p>
+      </div>
+
+      {!configured ? (
+        <div style={card}>
+          <p style={{ margin: 0, fontSize: 14, color: "var(--color-text-sub)" }}>
+            同期機能は現在この環境では無効です（サーバー未設定）。従来どおり各ツールは端末内で利用できます。
+          </p>
+        </div>
+      ) : !ready ? (
+        <div style={card}>
+          <p style={{ margin: 0, fontSize: 14, color: "var(--color-text-muted)" }}>読み込み中…</p>
+        </div>
+      ) : email ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={card}>
+            <div style={{ fontSize: 13, color: "var(--color-text-muted)", marginBottom: 4 }}>
+              ログイン中
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 700, marginBottom: 14 }}>{email}</div>
+            <button onClick={handleLogout} style={subBtn} disabled={busy}>
+              ログアウト
+            </button>
+          </div>
+
+          <div style={card}>
+            <h2 style={{ fontSize: 16, fontWeight: 800, margin: "0 0 6px" }}>同期</h2>
+            <p
+              style={{
+                margin: "0 0 14px",
+                fontSize: 13,
+                color: "var(--color-text-muted)",
+                lineHeight: 1.6,
+              }}
+            >
+              ログイン時に自動で同期されます。手動で実行することもできます。
+            </p>
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <button onClick={handleUpload} style={primaryBtn} disabled={busy}>
+                このデバイスを保存（アップロード）
+              </button>
+              <button onClick={handleRestore} style={subBtn} disabled={busy}>
+                サーバーから復元
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div style={card}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <label style={{ fontSize: 13, fontWeight: 700 }}>
+              メールアドレス
+              <input
+                type="email"
+                value={inputEmail}
+                onChange={(e) => setInputEmail(e.target.value)}
+                autoComplete="email"
+                style={{ ...inputStyle, marginTop: 6 }}
+              />
+            </label>
+            <label style={{ fontSize: 13, fontWeight: 700 }}>
+              パスワード
+              <input
+                type="password"
+                value={inputPassword}
+                onChange={(e) => setInputPassword(e.target.value)}
+                autoComplete="current-password"
+                style={{ ...inputStyle, marginTop: 6 }}
+              />
+            </label>
+            <div style={{ display: "flex", gap: 10, marginTop: 4 }}>
+              <button onClick={handleLogin} style={primaryBtn} disabled={busy || !inputEmail || !inputPassword}>
+                ログイン
+              </button>
+              <button onClick={handleSignup} style={subBtn} disabled={busy || !inputEmail || !inputPassword}>
+                新規登録
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <p style={{ fontSize: 13, color: "var(--color-danger, #dc2626)", marginTop: 14 }}>{error}</p>
+      )}
+      {message && (
+        <p style={{ fontSize: 13, color: "var(--color-accent)", marginTop: 14, lineHeight: 1.6 }}>
+          {message}
+        </p>
+      )}
+
+      <p style={{ fontSize: 11, color: "var(--color-text-muted)", lineHeight: 1.7, marginTop: 24 }}>
+        ※ 同期は任意です。ログインしたデータはサーバー（Supabase）に保存され、あなたのアカウントだけが読み書きできます。
+        未ログインなら一切サーバーへ送信されません。
+      </p>
+    </main>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import AccountClient from "./AccountClient";
+
+export const metadata: Metadata = {
+  title: "アカウント・同期 | mini-tools",
+  description:
+    "メールでログインすると、対応ツールのデータを端末間で同期できます（任意）。未ログインなら従来どおり端末内のみで動きます。",
+  alternates: {
+    canonical: "/account",
+  },
+};
+
+export default function Page() {
+  return <AccountClient />;
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,0 +1,35 @@
+// lib/supabase/middleware.ts
+// Supabase セッション Cookie をリフレッシュする（@supabase/ssr の定番パターン）。
+// middleware.ts から呼ぶ。env 未設定なら何もしない。
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { getSupabaseEnv } from "./config";
+
+export async function updateSession(request: NextRequest) {
+  let response = NextResponse.next({ request });
+
+  const { url, anonKey } = getSupabaseEnv();
+  if (!url || !anonKey) return response;
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  // セッションの有効期限が近ければここでリフレッシュされ、Cookie が更新される。
+  await supabase.auth.getUser();
+
+  return response;
+}

--- a/lib/sync/client.ts
+++ b/lib/sync/client.ts
@@ -1,0 +1,134 @@
+// lib/sync/client.ts
+// クライアント側の同期ロジック。/api/sync と LocalStorage の橋渡し。
+// 設計: docs/plans/phase1-cross-device-sync-plan.md
+// - キー単位 last-write-wins（updatedAt の新しい方を採用）
+// - LocalStorage は手元の正＝キャッシュ。サーバーはバックアップ兼デバイス間共有。
+import { SYNCED_KEYS } from "./registry";
+
+const META_KEY = "mini_tools_sync_meta_v1";
+const EPOCH = "1970-01-01T00:00:00.000Z";
+
+type SyncItem = { key: string; value: unknown; updatedAt: string };
+type Meta = Record<string, { updatedAt: string }>;
+
+function readMeta(): Meta {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(META_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Meta) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMeta(meta: Meta) {
+  try {
+    window.localStorage.setItem(META_KEY, JSON.stringify(meta));
+  } catch {
+    // ignore
+  }
+}
+
+function setMetaUpdatedAt(key: string, updatedAt: string) {
+  const meta = readMeta();
+  meta[key] = { updatedAt };
+  writeMeta(meta);
+}
+
+/** ツールがローカル保存した直後に呼ぶ。次回 push でサーバーへ反映される。 */
+export function markChanged(key: string) {
+  setMetaUpdatedAt(key, new Date().toISOString());
+}
+
+// 比較用のローカル updatedAt。
+// - meta があればそれ
+// - meta が無く、ローカルに値があれば「今」（＝初回ログイン時にローカルを優先＝サーバーへ吸い上げ）
+// - meta が無く、値も無ければ epoch（＝サーバーがあれば復元される）
+function effectiveLocalUpdatedAt(key: string, meta: Meta): string {
+  if (meta[key]?.updatedAt) return meta[key].updatedAt;
+  try {
+    return window.localStorage.getItem(key) != null ? new Date().toISOString() : EPOCH;
+  } catch {
+    return EPOCH;
+  }
+}
+
+function collectLocalItems(): SyncItem[] {
+  const meta = readMeta();
+  const items: SyncItem[] = [];
+  for (const key of SYNCED_KEYS) {
+    let raw: string | null = null;
+    try {
+      raw = window.localStorage.getItem(key);
+    } catch {
+      raw = null;
+    }
+    if (raw == null) continue;
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      // JSON でない値はそのまま文字列として送る
+      value = raw;
+    }
+    items.push({ key, value, updatedAt: effectiveLocalUpdatedAt(key, meta) });
+  }
+  return items;
+}
+
+/** サーバーへローカルの同期対象キーを送る（より新しい方をサーバーが採用）。 */
+export async function pushAll(): Promise<{ ok: boolean; error?: string }> {
+  const items = collectLocalItems();
+  try {
+    const res = await fetch("/api/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, error: body.error ?? `HTTP ${res.status}` };
+    }
+    const data = (await res.json()) as { items?: SyncItem[] };
+    // サーバー確定の updatedAt で meta を更新しておく。
+    for (const it of data.items ?? []) {
+      setMetaUpdatedAt(it.key, it.updatedAt);
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+/** サーバーから取得し、より新しいものだけ LocalStorage に反映する。変わったキー名を返す。 */
+export async function pullAll(): Promise<{ ok: boolean; changed: string[]; error?: string }> {
+  try {
+    const res = await fetch("/api/sync", { method: "GET" });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, changed: [], error: body.error ?? `HTTP ${res.status}` };
+    }
+    const data = (await res.json()) as { items?: SyncItem[] };
+    const meta = readMeta();
+    const changed: string[] = [];
+    for (const it of data.items ?? []) {
+      const localAt = effectiveLocalUpdatedAt(it.key, meta);
+      if (new Date(it.updatedAt).getTime() > new Date(localAt).getTime()) {
+        try {
+          const serialized =
+            typeof it.value === "string" ? it.value : JSON.stringify(it.value);
+          window.localStorage.setItem(it.key, serialized);
+          setMetaUpdatedAt(it.key, it.updatedAt);
+          changed.push(it.key);
+        } catch {
+          // ignore individual failures
+        }
+      }
+    }
+    return { ok: true, changed };
+  } catch (e) {
+    return { ok: false, changed: [], error: String(e) };
+  }
+}

--- a/lib/sync/registry.ts
+++ b/lib/sync/registry.ts
@@ -1,0 +1,10 @@
+// lib/sync/registry.ts
+// クロスデバイス同期の対象とする LocalStorage キー。
+// ここに足すだけで同期対象を増やせる（サーバーは汎用 key-value なのでスキーマ変更不要）。
+export const SYNCED_KEYS = [
+  "yutai_memo_items_v1",
+  "yutai_memo_tags_v1",
+  "yutai_memo_archives_v1",
+] as const;
+
+export type SyncedKey = (typeof SYNCED_KEYS)[number];

--- a/lib/tools-catalog.ts
+++ b/lib/tools-catalog.ts
@@ -188,6 +188,14 @@ export const TOOLS: ToolItem[] = [
     icon: "🔄",
     category: "input",
   },
+  {
+    title: "アカウント・同期",
+    short: "ログインして端末間でデータ同期",
+    detail: "メールでログインすると、対応ツール（まずは優待メモ帳）のデータを端末間で同期できます。任意機能で、未ログインなら従来どおり端末内のみ。",
+    href: "/account",
+    icon: "🔐",
+    category: "input",
+  },
 ];
 
 // premium ログイン済みのときだけホームに表示する外部ツール。

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,15 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { isSyncConfigured } from "@/lib/supabase/config";
+import { updateSession } from "@/lib/supabase/middleware";
+
+// Next.js 16 の proxy 規約（旧 middleware）。
+// 同期に関わるパスだけ Supabase セッションをリフレッシュする。
+// 未設定なら何もしない（既存挙動に影響なし）。
+export async function proxy(request: NextRequest) {
+  if (!isSyncConfigured()) return NextResponse.next();
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: ["/account/:path*", "/api/sync"],
+};


### PR DESCRIPTION
## 概要

任意ログイン（Supabase Auth）と、対応キーの **push/pull 同期**を実装。土台 PR #381 の上に、実際にデバイス間でデータが揃う最初の縦スライス。

**未設定 / 未ログインなら従来どおり端末内完結**（既存挙動に影響なし）。

## 含むもの

- **認証 UI** `/account`（ログイン / 新規登録 / ログアウト、メール＋パスワード）
- **同期レイヤー** `lib/sync/`
  - `registry.ts`: 同期対象キー（優待メモ: `items` / `tags` / `archives`）
  - `client.ts`: `pullAll` / `pushAll`。**キー単位 last-write-wins**。初回ログインはローカル優先で吸い上げ（空サーバーで上書きしない）
- **セッション維持** `proxy.ts` + `lib/supabase/middleware.ts`（Next 16 proxy 規約。`/account`・`/api/sync` のみ、未設定は no-op）
- ログイン時に**自動で pull→push**、復元で変化があれば再読込
- `tools-catalog`: 「🔐 アカウント・同期」カード追加

## 次PR（このPRでは未対応）

- 優待メモ編集時の**自動 push**（デバウンス）— 今は `/account` の手動「アップロード」or 再ログインで送信
- 開いたままのツールへの**即時反映**（今は復元時に再読込）
- 同期対象ツールの拡大

## 確認

- `tsc --noEmit` / `eslint` / `npm run build` すべて通過（`/account`・`/api/sync`・Proxy 生成、deprecation 警告なし）

## 動作確認（要・実機／provision 済み環境）

1. `/account` で新規登録 → ログイン（Confirm email OFF 推奨）
2. 端末A: 優待メモ帳でデータ入力 → `/account` で「アップロード」
3. 端末B（別ブラウザ）: 同じアカウントでログイン → 自動 pull → 優待メモ帳にデータが復元
4. 未ログイン時は従来どおり端末内のみで動く / `/api/sync` は未ログインで 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)