### PR TITLE
refactor(yutai): ピック/パス保存と信用バッジ判定を _shared へ抽出

### DIFF
--- a/app/tools/_shared/__tests__/yutai-credit.test.ts
+++ b/app/tools/_shared/__tests__/yutai-credit.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { NikkoCreditRecord, SbiCreditRecord } from "@/app/tools/yutai-candidates/types";
+import {
+  canNikkoGeneralCrossNow,
+  getNikkoCreditBadges,
+  hasNikkoLendingCaution,
+  hasNikkoSellStop,
+  isHandledBySbiShort,
+  isNikkoGeneralOutOfStock,
+  shouldWatchNikkoGeneral,
+} from "../yutai-credit";
+
+function nikkoRecord(overrides: Partial<NikkoCreditRecord> = {}): NikkoCreditRecord {
+  return {
+    institutional_buy: false,
+    institutional_short: false,
+    general_buy: false,
+    general_short: false,
+    available_shares: null,
+    has_exchange_regulation: false,
+    has_internal_regulation: false,
+    regulation_sources: [],
+    regulation_details: [],
+    ...overrides,
+  };
+}
+
+function sbiRecord(overrides: Partial<SbiCreditRecord> = {}): SbiCreditRecord {
+  return {
+    position_status: "available",
+    unit_upper_limit: "",
+    is_hyper: false,
+    is_daily: false,
+    is_short: false,
+    is_long: false,
+    ...overrides,
+  };
+}
+
+describe("日興 一般信用の判定", () => {
+  it("売建規制（取引停止）の明細があれば hasNikkoSellStop", () => {
+    const credit = nikkoRecord({
+      regulation_details: ["exchange|日証金（東証）|新規売建規制 取引停止|2022/07/06"],
+    });
+    expect(hasNikkoSellStop(credit)).toBe(true);
+    expect(hasNikkoSellStop(nikkoRecord())).toBe(false);
+    expect(hasNikkoSellStop(undefined)).toBe(false);
+  });
+
+  it("貸株注意喚起の明細があれば hasNikkoLendingCaution", () => {
+    expect(hasNikkoLendingCaution(nikkoRecord({ regulation_details: ["internal|貸株注意喚起|2026/01/01"] }))).toBe(true);
+    expect(hasNikkoLendingCaution(nikkoRecord())).toBe(false);
+  });
+
+  it("general_short かつ在庫ありかつ売建停止なしなら今クロス可", () => {
+    expect(canNikkoGeneralCrossNow(nikkoRecord({ general_short: true, available_shares: 100 }))).toBe(true);
+    expect(canNikkoGeneralCrossNow(nikkoRecord({ general_short: true, available_shares: 0 }))).toBe(false);
+    expect(canNikkoGeneralCrossNow(nikkoRecord({ general_short: false, available_shares: 100 }))).toBe(false);
+    expect(
+      canNikkoGeneralCrossNow(nikkoRecord({
+        general_short: true,
+        available_shares: 100,
+        regulation_details: ["internal|新規売建規制 取引停止|2011/12/05"],
+      })),
+    ).toBe(false);
+  });
+
+  it("available_shares=0 かつ売建停止なしは在庫切れ扱い（general_short は不問）", () => {
+    expect(isNikkoGeneralOutOfStock(nikkoRecord({ general_short: false, available_shares: 0 }))).toBe(true);
+    expect(isNikkoGeneralOutOfStock(nikkoRecord({ available_shares: null }))).toBe(false);
+    expect(
+      isNikkoGeneralOutOfStock(nikkoRecord({
+        available_shares: 0,
+        regulation_details: ["internal|新規売建規制 取引停止|2011/12/05"],
+      })),
+    ).toBe(false);
+  });
+
+  it("shouldWatchNikkoGeneral は停止中・クロス可・在庫あり非売建を監視対象にする", () => {
+    expect(shouldWatchNikkoGeneral(nikkoRecord({ regulation_details: ["internal|新規売建規制 取引停止|2011/12/05"] }))).toBe(true);
+    expect(shouldWatchNikkoGeneral(nikkoRecord({ general_short: true, available_shares: 100 }))).toBe(true);
+    expect(shouldWatchNikkoGeneral(nikkoRecord({ general_short: false, available_shares: 100 }))).toBe(true);
+    expect(shouldWatchNikkoGeneral(nikkoRecord())).toBe(false);
+    expect(shouldWatchNikkoGeneral(undefined)).toBe(false);
+  });
+});
+
+describe("getNikkoCreditBadges", () => {
+  it("売建停止は一般停止バッジのみ（他の一般系より優先）", () => {
+    const badges = getNikkoCreditBadges(nikkoRecord({
+      general_short: true,
+      available_shares: 100,
+      regulation_details: ["internal|新規売建規制 取引停止|2011/12/05"],
+    }));
+    expect(badges.map((badge) => badge.kind)).toEqual(["generalStop"]);
+    expect(badges[0].label).toBe("一般停止");
+  });
+
+  it("クロス可＋貸株注意喚起は一般注意", () => {
+    const badges = getNikkoCreditBadges(nikkoRecord({
+      general_short: true,
+      available_shares: 100,
+      regulation_details: ["internal|貸株注意喚起|2026/01/01"],
+    }));
+    expect(badges.map((badge) => badge.kind)).toEqual(["generalCaution"]);
+  });
+
+  it("クロス可は一般可、制度売可なら制度可を併記", () => {
+    const badges = getNikkoCreditBadges(nikkoRecord({
+      general_short: true,
+      available_shares: 100,
+      institutional_short: true,
+    }));
+    expect(badges.map((badge) => badge.kind)).toEqual(["generalOk", "institutional"]);
+    expect(badges.map((badge) => badge.label)).toEqual(["一般可", "制度可"]);
+  });
+
+  it("在庫0は一般×、非対象（null）はバッジなし", () => {
+    expect(getNikkoCreditBadges(nikkoRecord({ available_shares: 0 })).map((badge) => badge.kind)).toEqual([
+      "generalOutOfStock",
+    ]);
+    expect(getNikkoCreditBadges(nikkoRecord({ available_shares: null }))).toEqual([]);
+    expect(getNikkoCreditBadges(undefined)).toEqual([]);
+  });
+});
+
+describe("SBI 短期対象の判定", () => {
+  it("is_short のみで判定し、在庫状態（position_status）は見ない", () => {
+    expect(isHandledBySbiShort(sbiRecord({ is_short: true, position_status: "unavailable" }))).toBe(true);
+    expect(isHandledBySbiShort(sbiRecord({ is_short: false, position_status: "available" }))).toBe(false);
+    expect(isHandledBySbiShort(undefined)).toBe(false);
+  });
+});

--- a/app/tools/_shared/__tests__/yutai-selection.test.ts
+++ b/app/tools/_shared/__tests__/yutai-selection.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { MemoItem } from "@/app/tools/yutai-memo/types";
+import { getAddedKeysFromMemoItems, getCardMemoKey, loadCardMemos, loadCodeSet } from "../yutai-selection";
+
+function memoItem(overrides: Partial<MemoItem> = {}): MemoItem {
+  return {
+    id: "id-1",
+    name: "テスト銘柄",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    months: [3],
+    tagIds: [],
+    crossType: "長期優遇なし",
+    acquired: false,
+    priority: 2,
+    memo: "",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("getCardMemoKey", () => {
+  it("code:month 形式のキーを返す", () => {
+    expect(getCardMemoKey({ code: "9861", month: 8 })).toBe("9861:8");
+  });
+});
+
+describe("getAddedKeysFromMemoItems", () => {
+  it("各メモの権利月ごとにキーを作る", () => {
+    const keys = getAddedKeysFromMemoItems([
+      memoItem({ id: "a", code: "9861", months: [2, 8] }),
+      memoItem({ id: "b", code: undefined, months: [3] }),
+    ]);
+    expect(keys).toEqual(new Set(["9861:2", "9861:8", ":3"]));
+  });
+
+  it("months が欠けた旧データでも落ちない", () => {
+    const legacy = memoItem({ id: "c", code: "1234" });
+    delete (legacy as { months?: number[] }).months;
+    expect(getAddedKeysFromMemoItems([legacy])).toEqual(new Set());
+  });
+});
+
+describe("SSR ガード", () => {
+  it("window がない環境では空値を返す", () => {
+    expect(loadCodeSet("monthly_yutai_picks_v1")).toEqual(new Set());
+    expect(loadCardMemos()).toEqual({});
+  });
+});

--- a/app/tools/_shared/yutai-credit.ts
+++ b/app/tools/_shared/yutai-credit.ts
@@ -1,0 +1,74 @@
+// 日興 / SBI 信用データの判定ロジック。
+// 判定ルールの正本は docs/specs/cross-cutting/market-tools-data-fetch-paths.md の
+// 「yutai-candidates の日興信用 badge 判定」を参照。
+// yutai-candidates と yutai-dashboard で共用するため UI（styles）には依存しない。
+import type { NikkoCreditRecord, SbiCreditRecord } from "@/app/tools/yutai-candidates/types";
+
+export function hasNikkoSellStop(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit?.regulation_details?.some((detail) => (
+    detail.includes("新規売建規制") && detail.includes("取引停止")
+  )));
+}
+
+export function hasNikkoLendingCaution(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit?.regulation_details?.some((detail) => detail.includes("貸株注意喚起")));
+}
+
+export function canNikkoGeneralCrossNow(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit?.general_short && (credit.available_shares ?? 0) > 0 && !hasNikkoSellStop(credit));
+}
+
+// 一般信用売建の対象だが在庫が尽きている（＝今はクロス約定できない）状態。
+// available_shares が明示的に 0 = 在庫枠を管理している銘柄で残数 0。
+// general_short は在庫連動で false に倒れるため条件に含めない（在庫0なら false でも対象扱い）。
+// available_shares が null（在庫データを持たない非対象）は対象外で、従来どおり表示しない。
+export function isNikkoGeneralOutOfStock(credit: NikkoCreditRecord | undefined) {
+  return Boolean(credit && credit.available_shares === 0 && !hasNikkoSellStop(credit));
+}
+
+export function shouldWatchNikkoGeneral(credit: NikkoCreditRecord | undefined) {
+  if (!credit) return false;
+  return hasNikkoSellStop(credit) || canNikkoGeneralCrossNow(credit) || (
+    !credit.general_short &&
+    (credit.available_shares ?? 0) > 0 &&
+    !hasNikkoSellStop(credit)
+  );
+}
+
+// SBI は「15営業日短期売りの扱い有無」だけを見る。在庫状態（position_status）は使わない。
+// 判断理由: docs/decision-log/2026-04-05-yutai-candidates-sbi-short-handling.md
+export function isHandledBySbiShort(record: SbiCreditRecord | undefined) {
+  return Boolean(record?.is_short);
+}
+
+export type NikkoCreditBadgeKind =
+  | "generalStop"
+  | "generalCaution"
+  | "generalOk"
+  | "generalOutOfStock"
+  | "institutional";
+
+export type NikkoCreditBadge = {
+  kind: NikkoCreditBadgeKind;
+  label: string;
+  title: string;
+};
+
+// バッジの表示文言と優先順位の正本。UI 側は kind をスタイルに割り当てて描画する。
+export function getNikkoCreditBadges(credit: NikkoCreditRecord | undefined): NikkoCreditBadge[] {
+  if (!credit) return [];
+  const badges: NikkoCreditBadge[] = [];
+  if (hasNikkoSellStop(credit)) {
+    badges.push({ kind: "generalStop", label: "一般停止", title: "一般信用 売建規制（取引停止）" });
+  } else if (canNikkoGeneralCrossNow(credit) && hasNikkoLendingCaution(credit)) {
+    badges.push({ kind: "generalCaution", label: "一般注意", title: "一般信用 売建可（貸株注意喚起）" });
+  } else if (canNikkoGeneralCrossNow(credit)) {
+    badges.push({ kind: "generalOk", label: "一般可", title: "一般信用 売建可（在庫あり）" });
+  } else if (isNikkoGeneralOutOfStock(credit)) {
+    badges.push({ kind: "generalOutOfStock", label: "一般×", title: "一般信用売建の対象だが在庫0（今クロス不可）" });
+  }
+  if (credit.institutional_short) {
+    badges.push({ kind: "institutional", label: "制度可", title: "制度信用 売建可" });
+  }
+  return badges;
+}

--- a/app/tools/_shared/yutai-selection.ts
+++ b/app/tools/_shared/yutai-selection.ts
@@ -1,0 +1,82 @@
+// 月次優待候補のピック / パス / カードメモの LocalStorage 読み書き。
+// yutai-candidates と yutai-dashboard は同じキーを共有し、選択状態を両画面で整合させる。
+// 位置づけ: docs/decision-log/2026-07-05-yutai-dashboard-positioning.md
+import { markChanged } from "@/lib/sync/client";
+import type { MemoItem } from "@/app/tools/yutai-memo/types";
+import type { MonthlyYutaiCandidate } from "@/app/tools/yutai-candidates/types";
+
+export const MONTHLY_YUTAI_PICKED_KEY = "monthly_yutai_picks_v1";
+export const MONTHLY_YUTAI_PASSED_KEY = "monthly_yutai_passes_v1";
+export const MONTHLY_YUTAI_CARD_MEMOS_KEY = "monthly_yutai_card_memos_v1";
+
+export type CalendarCardMemo = {
+  longTermRequired: boolean;
+  longTermBenefit: boolean;
+  preparationMonthsBefore?: number;
+  updatedAt: string;
+};
+
+export function loadCodeSet(storageKey: string) {
+  if (typeof window === "undefined") return new Set<string>();
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return new Set<string>();
+    const parsed = JSON.parse(raw) as string[];
+    return new Set(Array.isArray(parsed) ? parsed.filter((value) => typeof value === "string") : []);
+  } catch {
+    return new Set<string>();
+  }
+}
+
+export function saveCodeSet(storageKey: string, codes: Set<string>, options: { markChanged?: boolean } = {}) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(storageKey, JSON.stringify([...codes]));
+  if (options.markChanged ?? true) markChanged(storageKey);
+}
+
+export function getCardMemoKey(item: Pick<MonthlyYutaiCandidate, "code" | "month">) {
+  return `${item.code}:${item.month}`;
+}
+
+export function loadCardMemos(): Record<string, CalendarCardMemo> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(MONTHLY_YUTAI_CARD_MEMOS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, Partial<CalendarCardMemo>>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter(([key, value]) => typeof key === "string" && value && typeof value === "object")
+        .map(([key, value]) => [
+          key,
+          {
+            longTermRequired: Boolean(value.longTermRequired),
+            longTermBenefit: Boolean(value.longTermBenefit),
+            preparationMonthsBefore:
+              typeof value.preparationMonthsBefore === "number" &&
+              Number.isInteger(value.preparationMonthsBefore) &&
+              value.preparationMonthsBefore >= 0 &&
+              value.preparationMonthsBefore <= 11
+                ? value.preparationMonthsBefore
+                : undefined,
+            updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : "",
+          },
+        ]),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function saveCardMemos(memos: Record<string, CalendarCardMemo>) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(MONTHLY_YUTAI_CARD_MEMOS_KEY, JSON.stringify(memos));
+  markChanged(MONTHLY_YUTAI_CARD_MEMOS_KEY);
+}
+
+export function getAddedKeysFromMemoItems(items: MemoItem[]) {
+  return new Set(
+    items.flatMap((item) => (item.months ?? []).map((month) => `${item.code ?? ""}:${month}`)),
+  );
+}

--- a/app/tools/yutai-candidates/ToolClient.tsx
+++ b/app/tools/yutai-candidates/ToolClient.tsx
@@ -7,12 +7,25 @@ import { loadItems, saveItems } from "@/app/tools/yutai-memo/storage";
 import { CROSS_TYPES, type CrossType, type MemoItem } from "@/app/tools/yutai-memo/types";
 import { isPreparationMonth } from "@/app/tools/yutai-memo/date-utils";
 import { useRouterTransition } from "@/app/tools/_shared/use-router-transition";
-import { markChanged } from "@/lib/sync/client";
+import {
+  canNikkoGeneralCrossNow,
+  getNikkoCreditBadges,
+  isHandledBySbiShort,
+  shouldWatchNikkoGeneral,
+  type NikkoCreditBadgeKind,
+} from "@/app/tools/_shared/yutai-credit";
+import {
+  MONTHLY_YUTAI_PICKED_KEY as PICKED_KEY,
+  MONTHLY_YUTAI_PASSED_KEY as PASSED_KEY,
+  getAddedKeysFromMemoItems,
+  getCardMemoKey,
+  loadCardMemos,
+  loadCodeSet,
+  saveCardMemos,
+  saveCodeSet,
+  type CalendarCardMemo,
+} from "@/app/tools/_shared/yutai-selection";
 import type { MonthlyYutaiCandidate, MonthlyYutaiPageData } from "./types";
-
-const PICKED_KEY = "monthly_yutai_picks_v1";
-const PASSED_KEY = "monthly_yutai_passes_v1";
-const CARD_MEMOS_KEY = "monthly_yutai_card_memos_v1";
 
 type StatusFilter = "all" | "picked" | "passed" | "added" | "unselected";
 type LinkFilter = "all" | "with" | "without";
@@ -36,13 +49,6 @@ type EditingMemoContext = {
   companyName: string;
   month: number;
 };
-type CalendarCardMemo = {
-  longTermRequired: boolean;
-  longTermBenefit: boolean;
-  preparationMonthsBefore?: number;
-  updatedAt: string;
-};
-
 function normalizeText(value: string) {
   return value.normalize("NFKC").toLowerCase();
 }
@@ -72,103 +78,13 @@ function formatKenriLastDate(value: string | null) {
   }).format(new Date(time))}`;
 }
 
-function loadCodeSet(storageKey: string) {
-  if (typeof window === "undefined") return new Set<string>();
-  try {
-    const raw = window.localStorage.getItem(storageKey);
-    if (!raw) return new Set<string>();
-    const parsed = JSON.parse(raw) as string[];
-    return new Set(Array.isArray(parsed) ? parsed.filter((value) => typeof value === "string") : []);
-  } catch {
-    return new Set<string>();
-  }
-}
-
-function saveCodeSet(storageKey: string, codes: Set<string>, options: { markChanged?: boolean } = {}) {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(storageKey, JSON.stringify([...codes]));
-  if (options.markChanged ?? true) markChanged(storageKey);
-}
-
-function getCardMemoKey(item: Pick<MonthlyYutaiCandidate, "code" | "month">) {
-  return `${item.code}:${item.month}`;
-}
-
-function loadCardMemos(): Record<string, CalendarCardMemo> {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = window.localStorage.getItem(CARD_MEMOS_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as Record<string, Partial<CalendarCardMemo>>;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    return Object.fromEntries(
-      Object.entries(parsed)
-        .filter(([key, value]) => typeof key === "string" && value && typeof value === "object")
-        .map(([key, value]) => [
-          key,
-          {
-            longTermRequired: Boolean(value.longTermRequired),
-            longTermBenefit: Boolean(value.longTermBenefit),
-            preparationMonthsBefore:
-              typeof value.preparationMonthsBefore === "number" &&
-              Number.isInteger(value.preparationMonthsBefore) &&
-              value.preparationMonthsBefore >= 0 &&
-              value.preparationMonthsBefore <= 11
-                ? value.preparationMonthsBefore
-                : undefined,
-            updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : "",
-          },
-        ]),
-    );
-  } catch {
-    return {};
-  }
-}
-
-function saveCardMemos(memos: Record<string, CalendarCardMemo>) {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(CARD_MEMOS_KEY, JSON.stringify(memos));
-  markChanged(CARD_MEMOS_KEY);
-}
-
-function getAddedKeysFromMemoItems(items: MemoItem[]) {
-  return new Set(
-    items.flatMap((item) => (item.months ?? []).map((month) => `${item.code ?? ""}:${month}`)),
-  );
-}
-
-type NikkoCreditRecord = NonNullable<MonthlyYutaiPageData["nikkoCredit"]>["by_code"][string];
-
-function hasNikkoSellStop(credit: NikkoCreditRecord | undefined) {
-  return Boolean(credit?.regulation_details?.some((detail) => (
-    detail.includes("新規売建規制") && detail.includes("取引停止")
-  )));
-}
-
-function hasNikkoLendingCaution(credit: NikkoCreditRecord | undefined) {
-  return Boolean(credit?.regulation_details?.some((detail) => detail.includes("貸株注意喚起")));
-}
-
-function canNikkoGeneralCrossNow(credit: NikkoCreditRecord | undefined) {
-  return Boolean(credit?.general_short && (credit.available_shares ?? 0) > 0 && !hasNikkoSellStop(credit));
-}
-
-// 一般信用売建の対象だが在庫が尽きている（＝今はクロス約定できない）状態。
-// available_shares が明示的に 0 = 在庫枠を管理している銘柄で残数 0。
-// general_short は在庫連動で false に倒れるため条件に含めない（在庫0なら false でも対象扱い）。
-// available_shares が null（在庫データを持たない非対象）は対象外で、従来どおり表示しない。
-function isNikkoGeneralOutOfStock(credit: NikkoCreditRecord | undefined) {
-  return Boolean(credit && credit.available_shares === 0 && !hasNikkoSellStop(credit));
-}
-
-function shouldWatchNikkoGeneral(credit: NikkoCreditRecord | undefined) {
-  if (!credit) return false;
-  return hasNikkoSellStop(credit) || canNikkoGeneralCrossNow(credit) || (
-    !credit.general_short &&
-    (credit.available_shares ?? 0) > 0 &&
-    !hasNikkoSellStop(credit)
-  );
-}
+const creditChipStyleByKind: Record<NikkoCreditBadgeKind, string> = {
+  generalStop: "creditChipGeneralRegulation",
+  generalCaution: "creditChipGeneralCaution",
+  generalOk: "creditChipGeneral",
+  generalOutOfStock: "creditChipNoCross",
+  institutional: "creditChipInstitutional",
+};
 
 function renderCreditBadges(
   nikkoCredit: import("./types").NikkoCreditData | null,
@@ -176,22 +92,13 @@ function renderCreditBadges(
   styles: Record<string, React.CSSProperties>,
 ): React.ReactNode {
   if (!nikkoCredit) return null;
-  const credit = nikkoCredit.by_code[code];
-  if (!credit) return null;
-  const badges: React.ReactNode[] = [];
-  if (hasNikkoSellStop(credit)) {
-    badges.push(<span key="gen-regulated" style={styles.creditChipGeneralRegulation} title="一般信用 売建規制（取引停止）">一般停止</span>);
-  } else if (canNikkoGeneralCrossNow(credit) && hasNikkoLendingCaution(credit)) {
-    badges.push(<span key="gen-caution" style={styles.creditChipGeneralCaution} title="一般信用 売建可（貸株注意喚起）">一般注意</span>);
-  } else if (canNikkoGeneralCrossNow(credit)) {
-    badges.push(<span key="gen" style={styles.creditChipGeneral} title="一般信用 売建可（在庫あり）">一般可</span>);
-  } else if (isNikkoGeneralOutOfStock(credit)) {
-    badges.push(<span key="gen-oos" style={styles.creditChipNoCross} title="一般信用売建の対象だが在庫0（今クロス不可）">一般×</span>);
-  }
-  if (credit.institutional_short) {
-    badges.push(<span key="inst" style={styles.creditChipInstitutional} title="制度信用 売建可">制度可</span>);
-  }
-  return badges;
+  const badges = getNikkoCreditBadges(nikkoCredit.by_code[code]);
+  if (badges.length === 0) return null;
+  return badges.map((badge) => (
+    <span key={badge.kind} style={styles[creditChipStyleByKind[badge.kind]]} title={badge.title}>
+      {badge.label}
+    </span>
+  ));
 }
 
 function renderSbiCreditBadge(
@@ -203,12 +110,6 @@ function renderSbiCreditBadge(
   const record = sbiCredit.by_code[code];
   if (!isHandledBySbiShort(record)) return null;
   return <span style={styles.sbiCreditChipAvailable}>SBI売可</span>;
-}
-
-function isHandledBySbiShort(
-  record: import("./types").SbiCreditData["by_code"][string] | undefined,
-) {
-  return Boolean(record?.is_short);
 }
 
 function hasOfficialLink(item: MonthlyYutaiCandidate) {


### PR DESCRIPTION
## 概要

優待統合ダッシュボード（[docs/plans/yutai-dashboard-plan.md](https://github.com/Yuichi-TanakaJP/mini-tools/blob/main/docs/plans/yutai-dashboard-plan.md) Phase 1）の準備として、`yutai-candidates/ToolClient.tsx` からダッシュボードと共用するロジックを `app/tools/_shared/` へ抽出する。挙動変更はなし。

## 変更内容

- `app/tools/_shared/yutai-credit.ts` 新規: 日興一般信用の判定（売建停止 / 貸株注意 / クロス可 / 在庫0 / 監視対象）、SBI 短期対象判定、バッジ文言の descriptor 化（`getNikkoCreditBadges`）
- `app/tools/_shared/yutai-selection.ts` 新規: ピック / パス / カードメモの LocalStorage キーと読み書き、`getAddedKeysFromMemoItems`
- `yutai-candidates/ToolClient.tsx`: ローカル定義を削除し共有モジュールを参照。バッジ描画は descriptor → style のマッピングに変更（表示結果は同一）
- 判定ロジックの単体テストを追加（14件）

## 確認項目

- [x] `npm run lint`
- [x] `npx vitest run`（163件パス。`tests/ui-smoke/*.spec.ts` 2ファイルの suite ロード失敗は Playwright スペックを vitest が拾う既存事象で、本 PR とは無関係）
- [x] `npm run build`
- [x] `git diff --check`

## 関連 Issue

なし（計画: docs/plans/yutai-dashboard-plan.md、判断: docs/decision-log/2026-07-05-yutai-dashboard-positioning.md）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
