### PR TITLE
chore(ci): run unit tests in CI and fix vitest collecting playwright specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm run test
+
       - name: Build
         run: npm run build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
   test: {
     environment: "node",
     globals: false,
+    exclude: [...configDefaults.exclude, "tests/ui-smoke/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 概要

2026-07-12監査R3。AGENTS.md はPR前の全テスト実行を前提としているが、CI では lint/build のみでテストが強制されていなかった点を是正する。

あわせて、`npm run test`（vitest）が Playwright 専用スペック（`tests/ui-smoke/*.spec.ts`）まで収集して `test.describe() を呼べない` エラーで red になる収集不備を修正する（この修正なしでは CI にテストを追加できないため同一PRに含めた）。

## 変更内容

- `vitest.config.ts`: `exclude: [...configDefaults.exclude, "tests/ui-smoke/**"]` を追加し、Playwright 専用スペックを vitest の収集対象から除外
- `.github/workflows/ci.yml`: Lint と Build の間に `npm run test` ステップを追加

## 確認項目

- [x] `npm run lint` green
- [x] `npm run test` green（Test Files 25 passed / Tests 180 passed、exit 0）
- [x] `tests/ui-smoke/` は従来どおり `npm run test:ui`（Playwright）で実行される想定（設定変更なし）

## 関連 Issue

なし（監査対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
