### PR TITLE
feat(yutai): Premium認証付きPrivate株価プロキシ

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,6 +10,10 @@ NEXT_PUBLIC_GA_ID=
 # response shape: as_of_date, from, to, days[] (date, market_closed, label)
 MARKET_INFO_API_BASE_URL=
 
+# 優待ダッシュボードのPrivate株価API用サーバー間Bearer token。
+# サーバー専用。NEXT_PUBLIC_を付けず、ブラウザーへ渡さないこと。
+MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN=
+
 # 共有リンク / QR 用の公開URL（任意）
 NEXT_PUBLIC_SITE_URL=
 

--- a/README.md
+++ b/README.md
@@ -94,11 +94,16 @@ npm run dev
     - `app/tools/yutai-candidates/data-loader.ts`
     - `app/tools/earnings-calendar/data-loader.ts`
     - `lib/jpx-market-closed.ts`
+- `MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`
+  - 優待ダッシュボードのPrivate株価APIを呼ぶサーバー間Bearer token
+  - `/api/yutai/stock-prices`だけがサーバー側で参照する
+  - `NEXT_PUBLIC_`を付けず、ブラウザーコード・HTML・ログへ渡さない
 
 Vercel では次の env を設定しておく運用を推奨します。
 
 - `NEXT_PUBLIC_SITE_URL`
 - `MARKET_INFO_API_BASE_URL`
+- `MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`（優待株価を使う場合）
 - `NEXT_PUBLIC_GA_ID`（GA を使う場合のみ）
 
 これらは公開 URL や公開 ID 用であり、アクセスキーや secret のような機密情報は含めません。

--- a/app/api/yutai/stock-prices/__tests__/route.test.ts
+++ b/app/api/yutai/stock-prices/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { cookies } from "next/headers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPremiumSessionValue } from "@/lib/premium-auth";
+import { GET } from "../route";
+
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+
+const mockedCookies = vi.mocked(cookies);
+
+function setSession(value?: string) {
+  mockedCookies.mockResolvedValue({
+    get: vi.fn(() => (value ? { value } : undefined)),
+  } as never);
+}
+
+describe("GET /api/yutai/stock-prices", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.PREMIUM_ACCESS_SECRET = "test-premium-secret";
+    process.env.MARKET_INFO_API_BASE_URL = "https://market.example.com";
+    process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN = "server-only-token";
+  });
+
+  afterEach(() => {
+    delete process.env.PREMIUM_ACCESS_SECRET;
+    delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN;
+    vi.unstubAllGlobals();
+  });
+
+  it("未ログインでは上流を呼ばず404を返す", async () => {
+    setSession();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("サーバー間token未設定では上流を呼ばず503を返す", async () => {
+    setSession(createPremiumSessionValue());
+    delete process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("認証後だけBearer token付きで上流のprivate endpointを呼ぶ", async () => {
+    setSession(createPremiumSessionValue());
+    const payload = {
+      schema_version: 1,
+      scope_month: "2026-07",
+      generated_at: "2026-07-20T06:05:04+00:00",
+      provider: "yahoo_finance_chart",
+      source_batch_dates: ["2026-07-20"],
+      record_count: 1,
+      success_count: 1,
+      records: [
+        {
+          code: "1000",
+          target_months: ["2026-07"],
+          status: "ok",
+          price: 100.5,
+          price_date: "2026-07-17",
+          fetched_at: "2026-07-20T05:50:00+00:00",
+          error_code: null,
+        },
+      ],
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    await expect(response.json()).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://market.example.com/yutai/stock-prices/latest");
+    expect(options).toMatchObject({
+      headers: { Authorization: "Bearer server-only-token" },
+      cache: "no-store",
+    });
+  });
+
+  it("上流認証エラーをtoken非公開の502へ変換する", async () => {
+    setSession(createPremiumSessionValue());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 401 })),
+    );
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: "優待株価APIからデータを取得できませんでした。",
+      upstreamStatus: 401,
+    });
+    expect(JSON.stringify(body)).not.toContain("server-only-token");
+  });
+
+  it("上流接続失敗をno-storeの502へ変換する", async () => {
+    setSession(createPremiumSessionValue());
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+});

--- a/app/api/yutai/stock-prices/route.ts
+++ b/app/api/yutai/stock-prices/route.ts
@@ -1,0 +1,69 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { getApiBaseUrl } from "@/lib/market-api";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PRIVATE_CACHE_CONTROL = "private, no-store";
+const UPSTREAM_PATH = "/yutai/stock-prices/latest";
+const UPSTREAM_TIMEOUT_MS = 5_000;
+
+function json(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "Cache-Control": PRIVATE_CACHE_CONTROL },
+  });
+}
+
+async function isAuthorized() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+  return verifyPremiumSession(session);
+}
+
+export async function GET() {
+  if (!(await isAuthorized())) {
+    return json(
+      { error: "ログインが必要です。/premium/login からログインしてください。" },
+      404,
+    );
+  }
+
+  const apiBase = getApiBaseUrl();
+  const apiToken = process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN?.trim();
+  if (!apiBase || !apiToken) {
+    return json({ error: "優待株価APIが設定されていません。" }, 503);
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${apiBase}${UPSTREAM_PATH}`, {
+      headers: { Authorization: `Bearer ${apiToken}` },
+      cache: "no-store",
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+  } catch {
+    return json({ error: "優待株価APIへ接続できませんでした。" }, 502);
+  }
+
+  if (!upstream.ok) {
+    if (upstream.status === 404) {
+      return json({ error: "優待株価データがまだありません。" }, 404);
+    }
+    return json(
+      {
+        error: "優待株価APIからデータを取得できませんでした。",
+        upstreamStatus: upstream.status,
+      },
+      502,
+    );
+  }
+
+  try {
+    return json(await upstream.json());
+  } catch {
+    return json({ error: "優待株価APIの応答形式が不正です。" }, 502);
+  }
+}

--- a/docs/decision-log/2026-07-20-yutai-private-stock-price-proxy.md
+++ b/docs/decision-log/2026-07-20-yutai-private-stock-price-proxy.md
@@ -12,6 +12,7 @@
 - 未ログイン・期限切れは404とし、上流リクエストを行わない。
 - 上流Bearer tokenは`MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`としてサーバー環境だけに置く。`NEXT_PUBLIC_`を付けない。
 - 成功・エラーとも`Cache-Control: private, no-store`を返し、ブラウザー/CDN/PWAへ保存させない。
+- `next-pwa`の既定`/api/*` cacheより前に、このrouteを`NetworkOnly`へ指定する。HTTP `no-store`だけに依存しない。
 - 上流の認証・設定エラーは502へ変換し、tokenや上流本文をクライアントへ返さない。
 - 株価を簡易優待効率へ適用するUI変更は、進行中のダッシュボード表示変更と分けて後続PRで行う。
 

--- a/docs/decision-log/2026-07-20-yutai-private-stock-price-proxy.md
+++ b/docs/decision-log/2026-07-20-yutai-private-stock-price-proxy.md
@@ -1,0 +1,37 @@
+# 2026-07-20 優待株価をPremium認証付きサーバールート経由にする
+
+## 背景
+
+- `market_info`が優待向け株価をPrivate R2へpublishし、`market-info-api`がBearer認証必須の`/yutai/stock-prices/latest`を提供するようになった。
+- 上流Bearer tokenをブラウザーへ渡すと、Premium認証を迂回してprivate endpointを直接呼べてしまう。
+- 優待ダッシュボード本体には、署名済みCookieを使う30日間のPremium認証がすでにある。
+
+## 決定
+
+- mini-toolsに`GET /api/yutai/stock-prices`を追加し、Premium Cookieを検証してからだけ上流を呼ぶ。
+- 未ログイン・期限切れは404とし、上流リクエストを行わない。
+- 上流Bearer tokenは`MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`としてサーバー環境だけに置く。`NEXT_PUBLIC_`を付けない。
+- 成功・エラーとも`Cache-Control: private, no-store`を返し、ブラウザー/CDN/PWAへ保存させない。
+- 上流の認証・設定エラーは502へ変換し、tokenや上流本文をクライアントへ返さない。
+- 株価を簡易優待効率へ適用するUI変更は、進行中のダッシュボード表示変更と分けて後続PRで行う。
+
+## データ経路
+
+```text
+Premium Cookie
+    |
+    v
+mini-tools /api/yutai/stock-prices
+    |  Authorization: Bearer <server-only token>
+    v
+market-info-api /yutai/stock-prices/latest
+    |
+    v
+Private R2 yutai/stock-prices/latest.json
+```
+
+## 関連
+
+- [優待ダッシュボードPremium認証](./2026-07-19-yutai-dashboard-premium-auth.md)
+- [優待ダッシュボード仕様](../specs/tools/yutai-dashboard.md)
+- [優待ダッシュボードUAT](../uat/yutai-dashboard.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-07-20 優待株価をPremium認証付きサーバールート経由にする](./decision-log/2026-07-20-yutai-private-stock-price-proxy.md)
 - [2026-07-12 取得＝仕込みの一本化と権利年ライフサイクル](./decision-log/2026-07-12-yutai-acquisition-equals-prep-lifecycle.md)
 - [2026-07-12 12ヶ月ビューの仕込み実績記録](./decision-log/2026-07-12-yutai-dashboard-prep-log.md)
 - [2026-07-12 取得実績の権利月ひもづけ（リード期間の当年寄せ）](./decision-log/2026-07-12-yutai-entitlement-attribution-lead-time.md)

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,9 @@ const withPWA = require("next-pwa")({
         if (url.origin !== self.origin) return false;
         return (
           url.pathname === "/tools/yutai-dashboard" ||
-          url.pathname.startsWith("/tools/yutai-dashboard/")
+          url.pathname.startsWith("/tools/yutai-dashboard/") ||
+          url.pathname === "/api/yutai/stock-prices" ||
+          url.pathname.startsWith("/api/yutai/stock-prices/")
         );
       },
       handler: "NetworkOnly",


### PR DESCRIPTION
## 概要

優待ダッシュボード向けPrivate株価を、Premium認証後だけ取得できるmini-toolsサーバールートを追加します。

## 変更内容

- `GET /api/yutai/stock-prices`を追加
- 署名済みPremium Cookieを検証し、未認証時は上流を呼ばず404
- market-info-apiへサーバー専用Bearer tokenを付けてリクエスト
- token未設定は503、上流障害・認証エラーは502へ変換
- 成功・エラーとも`Cache-Control: private, no-store`
- server-only環境変数の雛形と運用ドキュメントを追加

## 目的

上流Bearer tokenをブラウザーへ渡さず、30日PremiumセッションをPrivate株価のアクセス境界として使うためです。

## 影響

このPRでは内部routeだけを追加します。進行中の優待ダッシュボード表示変更と衝突させないため、株価を簡易効率へ適用するUI変更は後続PRへ分けます。

## 確認

- `npm run lint`
- `npm test`（29 files / 208 tests passed）
- `npm run build`
- 未認証時にupstream fetchが0回であること
- Bearer付与、no-store、設定不足、上流401、接続失敗の回帰テスト

## デプロイ前作業

`MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`をVercel ProductionへSensitive値として設定してからマージします。
