### PR TITLE
Add yutai launch display proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ npm run dev
     - `app/tools/earnings-calendar/data-loader.ts`
     - `lib/jpx-market-closed.ts`
 - `MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`
-  - 優待ダッシュボードのPrivate株価APIを呼ぶサーバー間Bearer token
-  - `/api/yutai/stock-prices`だけがサーバー側で参照する
+  - 優待ダッシュボードのPrivate株価API・公式条件APIを呼ぶサーバー間Bearer token
+  - `/api/yutai/stock-prices`と`/api/yutai/launch-display`だけがサーバー側で参照する
   - `NEXT_PUBLIC_`を付けず、ブラウザーコード・HTML・ログへ渡さない
 
 Vercel では次の env を設定しておく運用を推奨します。
 
 - `NEXT_PUBLIC_SITE_URL`
 - `MARKET_INFO_API_BASE_URL`
-- `MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`（優待株価を使う場合）
+- `MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`（優待株価・公式条件を使う場合）
 - `NEXT_PUBLIC_GA_ID`（GA を使う場合のみ）
 
 これらは公開 URL や公開 ID 用であり、アクセスキーや secret のような機密情報は含めません。

--- a/app/api/yutai/launch-display/__tests__/route.test.ts
+++ b/app/api/yutai/launch-display/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { cookies } from "next/headers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPremiumSessionValue } from "@/lib/premium-auth";
+import { GET } from "../route";
+
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+
+const mockedCookies = vi.mocked(cookies);
+
+function request(month = "2026-09") {
+  return new Request(`https://mini.example.com/api/yutai/launch-display?month=${month}`);
+}
+
+function setSession(value?: string) {
+  mockedCookies.mockResolvedValue({
+    get: vi.fn(() => (value ? { value } : undefined)),
+  } as never);
+}
+
+function payload(month = "2026-09") {
+  return {
+    schema_version: 1,
+    month,
+    record_count: 1,
+    counts: {
+      total: 1,
+      conditions_available: 1,
+      needs_normalization: 0,
+      auto_calculable: 1,
+      requires_user_valuation: 0,
+      excluded_from_initial_calculation: 0,
+    },
+    records: [
+      {
+        month,
+        code: "1000",
+        company_name: "テスト",
+        display_status: "conditions_available",
+        calculation_status: "auto_calculable",
+        requires_user_valuation: false,
+        normalized_status: "draft",
+        normalized_as_of_date: "2026-07-22",
+        programs: [],
+      },
+    ],
+    generated_at: "2026-07-22T14:57:25.239015Z",
+    source: "market_info_yutai_launch_display",
+  };
+}
+
+describe("GET /api/yutai/launch-display", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.PREMIUM_ACCESS_SECRET = "test-premium-secret";
+    process.env.MARKET_INFO_API_BASE_URL = "https://market.example.com";
+    process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN = "server-only-token";
+  });
+
+  afterEach(() => {
+    delete process.env.PREMIUM_ACCESS_SECRET;
+    delete process.env.MARKET_INFO_API_BASE_URL;
+    delete process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN;
+    vi.unstubAllGlobals();
+  });
+
+  it("未ログインでは上流を呼ばず404を返す", async () => {
+    setSession();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("認証後だけBearer token付きで指定月のprivate endpointを呼ぶ", async () => {
+    setSession(createPremiumSessionValue());
+    const body = payload();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=86400");
+    expect(response.headers.get("vary")).toBe("Cookie");
+    await expect(response.json()).resolves.toEqual(body);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://market.example.com/yutai/launch-display/monthly/2026-09");
+    expect(options).toMatchObject({
+      headers: { Authorization: "Bearer server-only-token" },
+      cache: "no-store",
+    });
+  });
+
+  it("月指定なしではlatest endpointを呼ぶ", async () => {
+    setSession(createPremiumSessionValue());
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(payload()), { status: 200 })));
+
+    const response = await GET(new Request("https://mini.example.com/api/yutai/launch-display"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://market.example.com/yutai/launch-display/latest",
+      expect.objectContaining({ headers: { Authorization: "Bearer server-only-token" } }),
+    );
+  });
+
+  it("上流認証エラーをtoken非公開の502へ変換する", async () => {
+    setSession(createPremiumSessionValue());
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body).toEqual({
+      error: "優待条件APIからデータを取得できませんでした。",
+      upstreamStatus: 401,
+    });
+    expect(JSON.stringify(body)).not.toContain("server-only-token");
+  });
+
+  it("画面が解釈できないschemaはキャッシュしない", async () => {
+    setSession(createPremiumSessionValue());
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ schema_version: 1 }))));
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+});

--- a/app/api/yutai/launch-display/route.ts
+++ b/app/api/yutai/launch-display/route.ts
@@ -1,0 +1,88 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { getApiBaseUrl } from "@/lib/market-api";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+import { parseYutaiLaunchDisplaySnapshot } from "@/app/tools/yutai-dashboard/launch-display";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PRIVATE_NO_STORE = "private, no-store";
+const PRIVATE_MONTH_CACHE = "private, max-age=86400";
+const UPSTREAM_TIMEOUT_MS = 5_000;
+
+function json(body: unknown, status = 200, cacheControl = PRIVATE_NO_STORE) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": cacheControl,
+      Vary: "Cookie",
+    },
+  });
+}
+
+function getRequestedMonth(request: Request) {
+  const month = new URL(request.url).searchParams.get("month")?.trim() ?? "";
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(month) ? month : null;
+}
+
+function getUpstreamPath(month: string | null) {
+  return month ? `/yutai/launch-display/monthly/${month}` : "/yutai/launch-display/latest";
+}
+
+async function isAuthorized() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+  return verifyPremiumSession(session);
+}
+
+export async function GET(request: Request) {
+  if (!(await isAuthorized())) {
+    return json(
+      { error: "ログインが必要です。/premium/login からログインしてください。" },
+      404,
+    );
+  }
+
+  const apiBase = getApiBaseUrl();
+  const apiToken = process.env.MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN?.trim();
+  if (!apiBase || !apiToken) {
+    return json({ error: "優待条件APIが設定されていません。" }, 503);
+  }
+
+  const requestedMonth = getRequestedMonth(request);
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${apiBase}${getUpstreamPath(requestedMonth)}`, {
+      headers: { Authorization: `Bearer ${apiToken}` },
+      cache: "no-store",
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+  } catch {
+    return json({ error: "優待条件APIへ接続できませんでした。" }, 502);
+  }
+
+  if (!upstream.ok) {
+    if (upstream.status === 404) {
+      return json({ error: "優待条件データがまだありません。" }, 404);
+    }
+    return json(
+      {
+        error: "優待条件APIからデータを取得できませんでした。",
+        upstreamStatus: upstream.status,
+      },
+      502,
+    );
+  }
+
+  try {
+    const payload: unknown = await upstream.json();
+    const snapshot = parseYutaiLaunchDisplaySnapshot(payload);
+    const cacheControl = requestedMonth && snapshot?.month === requestedMonth
+      ? PRIVATE_MONTH_CACHE
+      : PRIVATE_NO_STORE;
+    return json(payload, 200, cacheControl);
+  } catch {
+    return json({ error: "優待条件APIの応答形式が不正です。" }, 502);
+  }
+}

--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -18,6 +18,15 @@ import {
   type YutaiStockPriceQuote,
   type YutaiStockPriceSnapshot,
 } from "./stock-prices";
+import {
+  buildLaunchDisplayByKey,
+  getLaunchDisplayHint,
+  parseYutaiLaunchDisplaySnapshot,
+  type YutaiLaunchDisplayHint,
+  type YutaiLaunchDisplayItem,
+  type YutaiLaunchDisplayRecord,
+  type YutaiLaunchDisplaySnapshot,
+} from "./launch-display";
 import { useRouterTransition } from "@/app/tools/_shared/use-router-transition";
 import {
   canNikkoGeneralCrossNow,
@@ -49,6 +58,12 @@ type CalendarAxis = "entitlement" | "preparation";
 type StockPriceLoadState =
   | { status: "loading" }
   | { status: "ready"; snapshot: YutaiStockPriceSnapshot }
+  | { status: "error"; message: string };
+
+type LaunchDisplayLoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; snapshot: YutaiLaunchDisplaySnapshot }
   | { status: "error"; message: string };
 
 // data-loader の ALL_MONTHS_ID と同じ値。data-loader は node:fs を使うため client からは import しない。
@@ -108,6 +123,37 @@ function formatEfficiencyPercent(value: number) {
 function formatStockPriceProvider(value: string | null) {
   if (value === "yahoo_finance_chart") return "Yahoo Finance";
   return value || "株価API";
+}
+
+function getLatestMonthIdForEntitlementMonth(
+  manifest: MonthlyYutaiPageData["manifest"],
+  month: number,
+) {
+  const latest = manifest?.months
+    ?.filter((entry) => entry.month === month)
+    .sort((a, b) => b.year - a.year)[0];
+  return latest ? `${latest.year}-${String(latest.month).padStart(2, "0")}` : null;
+}
+
+function formatCalculationStatus(value: YutaiLaunchDisplayRecord["calculationStatus"]) {
+  switch (value) {
+    case "auto_calculable":
+      return "自動計算可";
+    case "mixed_user_input_required":
+      return "一部入力必要";
+    case "user_input_required":
+      return "評価額入力必要";
+    case "no_conditions":
+      return "条件未整備";
+  }
+}
+
+function formatBenefitItem(item: YutaiLaunchDisplayItem) {
+  const parts = [item.label];
+  if (typeof item.officialValueYen === "number") parts.push(formatYen(item.officialValueYen));
+  if (typeof item.quantity === "number" && item.unit) parts.push(`${item.quantity.toLocaleString("ja-JP")}${item.unit}`);
+  if (item.valuationPolicy === "user_estimate_required") parts.push("要評価");
+  return parts.join(" / ");
 }
 
 function getRowEfficiency(
@@ -180,6 +226,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
   const [archivedItems, setArchivedItems] = useState<ArchivedMemoItem[]>([]);
   const [cardMemos, setCardMemos] = useState<Record<string, CalendarCardMemo>>({});
   const [stockPriceState, setStockPriceState] = useState<StockPriceLoadState>({ status: "loading" });
+  const [launchDisplayState, setLaunchDisplayState] = useState<LaunchDisplayLoadState>({ status: "idle" });
   const [hydrated, setHydrated] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null);
@@ -238,6 +285,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
       controller.abort();
     };
   }, [stockPriceScopeMonth]);
+
 
   useEffect(() => {
     // hydrated 前は空 Set を保存しない
@@ -306,6 +354,11 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
   const stockPriceByCode = useMemo(
     () => buildStockPriceByCode(stockPriceSnapshot),
     [stockPriceSnapshot],
+  );
+  const launchDisplaySnapshot = launchDisplayState.status === "ready" ? launchDisplayState.snapshot : null;
+  const launchDisplayByKey = useMemo(
+    () => buildLaunchDisplayByKey(launchDisplaySnapshot),
+    [launchDisplaySnapshot],
   );
 
   // 12ヶ月ビュー用の行。登録済みメモを対象にし、検索・クロス戦略で絞り込む。
@@ -471,6 +524,70 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
   const selectedCardMemo = selectedEfficiencyMemoKey ? cardMemos[selectedEfficiencyMemoKey] : undefined;
   const selectedEfficiency = selectedRow ? getRowEfficiency(selectedRow, cardMemos, stockPriceByCode) : null;
   const selectedStockPriceQuote = selectedRow ? stockPriceByCode.get(selectedRow.code) : undefined;
+  const selectedCandidateMonth = selectedRow?.candidate?.month ?? null;
+  const launchDisplayMonth = isAllMonths && selectedCandidateMonth !== null
+    ? getLatestMonthIdForEntitlementMonth(data.manifest, selectedCandidateMonth)
+    : isAllMonths
+      ? null
+      : data.selectedMonthId;
+  const selectedLaunchDisplay = selectedRow?.candidate ? launchDisplayByKey.get(`${selectedRow.code}:${selectedRow.candidate.month}`) : undefined;
+  const selectedLaunchHint = getLaunchDisplayHint(selectedLaunchDisplay);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    setLaunchDisplayState({ status: "loading" });
+
+    async function loadLaunchDisplay() {
+      try {
+        const query = launchDisplayMonth ? `?month=${encodeURIComponent(launchDisplayMonth)}` : "";
+        const response = await fetch(`/api/yutai/launch-display${query}`, {
+          cache: "default",
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const snapshot = parseYutaiLaunchDisplaySnapshot(await response.json());
+        if (!snapshot) throw new Error("invalid payload");
+        if (active) setLaunchDisplayState({ status: "ready", snapshot });
+      } catch (error) {
+        if (active && !controller.signal.aborted) {
+          setLaunchDisplayState({
+            status: "error",
+            message: error instanceof Error ? error.message : "unknown error",
+          });
+        }
+      }
+    }
+
+    void loadLaunchDisplay();
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [launchDisplayMonth]);
+
+  function applyLaunchDisplayHint(hint: YutaiLaunchDisplayHint) {
+    if (!selectedEfficiencyMemoKey) return;
+    setCardMemos((prev) => {
+      const current = prev[selectedEfficiencyMemoKey] ?? {
+        longTermRequired: false,
+        longTermBenefit: false,
+        updatedAt: "",
+      };
+      const next = {
+        ...prev,
+        [selectedEfficiencyMemoKey]: {
+          ...current,
+          requiredShares: hint.requiredShares,
+          benefitValueYen: hint.benefitValueYen,
+          updatedAt: new Date().toISOString(),
+        },
+      };
+      saveCardMemos(next);
+      return next;
+    });
+    setNotice(`${hint.label} を簡易優待効率へ反映しました。`);
+  }
 
   function updateSelectedEfficiencyInput(
     field: "requiredShares" | "benefitValueYen",
@@ -1363,6 +1480,59 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
                     </div>
                   </section>
                 ) : null}
+
+
+                <section style={styles.detailSection}>
+                  <h3 style={styles.detailSectionTitle}>公式条件</h3>
+                  {selectedLaunchDisplay ? (
+                    <>
+                      <div style={styles.launchSummaryRow}>
+                        <span style={styles.launchStatusChip}>{formatCalculationStatus(selectedLaunchDisplay.calculationStatus)}</span>
+                        {selectedLaunchDisplay.normalizedAsOfDate ? (
+                          <span style={styles.detailSub}>正規化: {selectedLaunchDisplay.normalizedAsOfDate}</span>
+                        ) : null}
+                      </div>
+                      {selectedLaunchHint ? (
+                        <div style={styles.launchHintBox}>
+                          <div>
+                            <strong>{selectedLaunchHint.label}</strong>
+                            <span>必要株数 {selectedLaunchHint.requiredShares.toLocaleString("ja-JP")}株 / 優待価値 {formatYen(selectedLaunchHint.benefitValueYen)}</span>
+                          </div>
+                          {selectedEfficiencyMemoKey ? (
+                            <button type="button" style={styles.launchApplyButton} onClick={() => applyLaunchDisplayHint(selectedLaunchHint)}>
+                              効率入力へ反映
+                            </button>
+                          ) : null}
+                        </div>
+                      ) : selectedLaunchDisplay.requiresUserValuation ? (
+                        <p style={styles.detailSub}>公式条件はありますが、評価額の入力が必要です。</p>
+                      ) : (
+                        <p style={styles.detailSub}>この銘柄はまだ自動計算できる条件がありません。</p>
+                      )}
+                      {selectedLaunchDisplay.programs.length > 0 ? (
+                        <div style={styles.launchProgramList}>
+                          {selectedLaunchDisplay.programs.slice(0, 3).map((program) => (
+                            <div key={program.programId} style={styles.launchProgramItem}>
+                              <div style={styles.launchProgramTitle}>{program.label}</div>
+                              {program.tiers.slice(0, 3).map((tier) => (
+                                <div key={`${program.programId}:${tier.minimumShares}:${tier.requiredHoldingMonths}`} style={styles.launchTierText}>
+                                  {tier.minimumShares.toLocaleString("ja-JP")}株{tier.requiredHoldingMonths > 0 ? ` / ${tier.requiredHoldingMonths}ヶ月保有` : ""}: {tier.groups.flatMap((group) => group.items).slice(0, 4).map(formatBenefitItem).join("、")}
+                                </div>
+                              ))}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                      {selectedLaunchDisplay.notes ? <p style={styles.efficiencyNote}>{selectedLaunchDisplay.notes}</p> : null}
+                    </>
+                  ) : launchDisplayState.status === "loading" ? (
+                    <p style={styles.detailSub}>公式条件を取得中です。</p>
+                  ) : launchDisplayState.status === "error" ? (
+                    <p style={styles.detailSub}>公式条件データを取得できませんでした。</p>
+                  ) : (
+                    <p style={styles.detailSub}>この月の公式条件データはまだありません。</p>
+                  )}
+                </section>
 
                 <section style={styles.detailSection}>
                   <h3 style={styles.detailSectionTitle}>簡易優待効率</h3>
@@ -2609,6 +2779,65 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#94a3b8",
     fontSize: 10,
     lineHeight: 1.5,
+  },
+  launchSummaryRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  launchStatusChip: {
+    ...baseChip,
+    background: "#ecfdf5",
+    border: "1px solid rgba(16,185,129,0.24)",
+    color: "#047857",
+    fontWeight: 800,
+  },
+  launchHintBox: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+    marginTop: 8,
+    padding: "10px 12px",
+    borderRadius: 10,
+    background: "#f0fdf4",
+    border: "1px solid rgba(22,163,74,0.16)",
+    color: "#166534",
+    fontSize: 12,
+  },
+  launchApplyButton: {
+    flexShrink: 0,
+    border: "1px solid rgba(22,163,74,0.25)",
+    background: "#ffffff",
+    color: "#15803d",
+    borderRadius: 8,
+    padding: "5px 9px",
+    fontSize: 11,
+    fontWeight: 800,
+    cursor: "pointer",
+  },
+  launchProgramList: {
+    display: "grid",
+    gap: 8,
+    marginTop: 10,
+  },
+  launchProgramItem: {
+    padding: "9px 10px",
+    borderRadius: 10,
+    background: "#f8fafc",
+    border: "1px solid rgba(15,23,42,0.06)",
+  },
+  launchProgramTitle: {
+    fontSize: 12,
+    fontWeight: 800,
+    color: "#334155",
+    marginBottom: 4,
+  },
+  launchTierText: {
+    fontSize: 11,
+    lineHeight: 1.55,
+    color: "#64748b",
   },
   detailLinks: {
     display: "flex",

--- a/app/tools/yutai-dashboard/__tests__/launch-display.test.ts
+++ b/app/tools/yutai-dashboard/__tests__/launch-display.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildLaunchDisplayByKey, getLaunchDisplayHint, parseYutaiLaunchDisplaySnapshot } from "../launch-display";
+
+describe("parseYutaiLaunchDisplaySnapshot", () => {
+  it("公式条件payloadをdashboard用に変換する", () => {
+    const snapshot = parseYutaiLaunchDisplaySnapshot({
+      schema_version: 1,
+      month: "2026-09",
+      record_count: 1,
+      counts: { conditions_available: 1, auto_calculable: 1, requires_user_valuation: 0 },
+      generated_at: "2026-07-22T14:57:25.239015Z",
+      records: [
+        {
+          month: "2026-09",
+          code: "1822",
+          company_name: "大豊建設",
+          display_status: "conditions_available",
+          calculation_status: "auto_calculable",
+          requires_user_valuation: false,
+          normalized_status: "draft",
+          normalized_as_of_date: "2026-07-22",
+          programs: [
+            {
+              program_id: "quo-card",
+              label: "QUOカード",
+              rights_months: [3, 9],
+              tiers: [
+                {
+                  minimum_shares: 100,
+                  required_holding_months: 0,
+                  groups: [
+                    {
+                      mode: "all",
+                      allow_repeated_choices: false,
+                      items: [
+                        {
+                          label: "QUOカード",
+                          kind: "money_voucher",
+                          official_value_yen: 500,
+                          valuation_policy: "face_value",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const record = buildLaunchDisplayByKey(snapshot).get("1822:9");
+    expect(record?.programs[0].label).toBe("QUOカード");
+    expect(getLaunchDisplayHint(record)).toEqual({
+      requiredShares: 100,
+      benefitValueYen: 500,
+      label: "QUOカード 100株",
+    });
+  });
+
+  it.each([null, {}, { schema_version: 2, records: [] }, { schema_version: 1, records: [] }])("必須メタデータがない応答は拒否する: %o", (value) => {
+    expect(parseYutaiLaunchDisplaySnapshot(value)).toBeNull();
+  });
+});

--- a/app/tools/yutai-dashboard/launch-display.ts
+++ b/app/tools/yutai-dashboard/launch-display.ts
@@ -1,0 +1,210 @@
+export type YutaiLaunchDisplayItem = {
+  label: string;
+  kind: "discount" | "goods" | "money_voucher" | "points" | "service";
+  officialValueYen: number | null;
+  valuationPolicy: "face_value" | "official_equivalent" | "user_estimate_required";
+  quantity: number | null;
+  unit: string | null;
+  notes: string | null;
+};
+
+export type YutaiLaunchDisplayGroup = {
+  mode: "all" | "choose_one";
+  allowRepeatedChoices: boolean;
+  items: YutaiLaunchDisplayItem[];
+};
+
+export type YutaiLaunchDisplayTier = {
+  minimumShares: number;
+  maximumShares: number | null;
+  requiredHoldingMonths: number;
+  groups: YutaiLaunchDisplayGroup[];
+};
+
+export type YutaiLaunchDisplayProgram = {
+  programId: string;
+  label: string;
+  rightsMonths: number[];
+  tiers: YutaiLaunchDisplayTier[];
+  notes: string | null;
+};
+
+export type YutaiLaunchDisplayRecord = {
+  month: string;
+  code: string;
+  companyName: string;
+  displayStatus: "conditions_available" | "needs_normalization";
+  calculationStatus: "auto_calculable" | "mixed_user_input_required" | "no_conditions" | "user_input_required";
+  requiresUserValuation: boolean;
+  normalizedStatus: string | null;
+  normalizedAsOfDate: string | null;
+  programs: YutaiLaunchDisplayProgram[];
+  notes: string | null;
+};
+
+export type YutaiLaunchDisplaySnapshot = {
+  generatedAt: string;
+  month: string;
+  recordCount: number;
+  conditionsAvailable: number;
+  autoCalculable: number;
+  requiresUserValuation: number;
+  records: YutaiLaunchDisplayRecord[];
+};
+
+export type YutaiLaunchDisplayHint = {
+  requiredShares: number;
+  benefitValueYen: number;
+  label: string;
+};
+
+const DISPLAY_STATUSES = ["conditions_available", "needs_normalization"] as const;
+const CALCULATION_STATUSES = ["auto_calculable", "mixed_user_input_required", "no_conditions", "user_input_required"] as const;
+
+function isDisplayStatus(value: unknown): value is YutaiLaunchDisplayRecord["displayStatus"] {
+  return typeof value === "string" && DISPLAY_STATUSES.includes(value as YutaiLaunchDisplayRecord["displayStatus"]);
+}
+
+function isCalculationStatus(value: unknown): value is YutaiLaunchDisplayRecord["calculationStatus"] {
+  return typeof value === "string" && CALCULATION_STATUSES.includes(value as YutaiLaunchDisplayRecord["calculationStatus"]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function optionalNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseItem(value: unknown): YutaiLaunchDisplayItem | null {
+  if (!isRecord(value) || typeof value.label !== "string" || typeof value.kind !== "string" || typeof value.valuation_policy !== "string") {
+    return null;
+  }
+  if (!["discount", "goods", "money_voucher", "points", "service"].includes(value.kind)) return null;
+  if (!["face_value", "official_equivalent", "user_estimate_required"].includes(value.valuation_policy)) return null;
+  return {
+    label: value.label,
+    kind: value.kind as YutaiLaunchDisplayItem["kind"],
+    officialValueYen: optionalNumber(value.official_value_yen),
+    valuationPolicy: value.valuation_policy as YutaiLaunchDisplayItem["valuationPolicy"],
+    quantity: optionalNumber(value.quantity),
+    unit: optionalString(value.unit),
+    notes: optionalString(value.notes),
+  };
+}
+
+function parseGroup(value: unknown): YutaiLaunchDisplayGroup | null {
+  if (!isRecord(value) || (value.mode !== "all" && value.mode !== "choose_one") || typeof value.allow_repeated_choices !== "boolean" || !Array.isArray(value.items)) {
+    return null;
+  }
+  const items = value.items.map(parseItem).filter((item): item is YutaiLaunchDisplayItem => item !== null);
+  return { mode: value.mode, allowRepeatedChoices: value.allow_repeated_choices, items };
+}
+
+function parseTier(value: unknown): YutaiLaunchDisplayTier | null {
+  if (!isRecord(value) || typeof value.minimum_shares !== "number" || typeof value.required_holding_months !== "number" || !Array.isArray(value.groups)) {
+    return null;
+  }
+  const groups = value.groups.map(parseGroup).filter((group): group is YutaiLaunchDisplayGroup => group !== null);
+  return {
+    minimumShares: value.minimum_shares,
+    maximumShares: optionalNumber(value.maximum_shares),
+    requiredHoldingMonths: value.required_holding_months,
+    groups,
+  };
+}
+
+function parseProgram(value: unknown): YutaiLaunchDisplayProgram | null {
+  if (!isRecord(value) || typeof value.program_id !== "string" || typeof value.label !== "string" || !Array.isArray(value.rights_months) || !Array.isArray(value.tiers)) {
+    return null;
+  }
+  const rightsMonths = value.rights_months.filter((month): month is number => typeof month === "number" && Number.isInteger(month));
+  const tiers = value.tiers.map(parseTier).filter((tier): tier is YutaiLaunchDisplayTier => tier !== null);
+  return {
+    programId: value.program_id,
+    label: value.label,
+    rightsMonths,
+    tiers,
+    notes: optionalString(value.notes),
+  };
+}
+
+function parseDisplayRecord(value: unknown): YutaiLaunchDisplayRecord | null {
+  if (
+    !isRecord(value) ||
+    typeof value.month !== "string" ||
+    typeof value.code !== "string" ||
+    typeof value.company_name !== "string" ||
+    !isDisplayStatus(value.display_status) ||
+    !isCalculationStatus(value.calculation_status) ||
+    typeof value.requires_user_valuation !== "boolean" ||
+    !Array.isArray(value.programs)
+  ) {
+    return null;
+  }
+  const programs = value.programs.map(parseProgram).filter((program): program is YutaiLaunchDisplayProgram => program !== null);
+  return {
+    month: value.month,
+    code: value.code,
+    companyName: value.company_name,
+    displayStatus: value.display_status,
+    calculationStatus: value.calculation_status,
+    requiresUserValuation: value.requires_user_valuation,
+    normalizedStatus: optionalString(value.normalized_status),
+    normalizedAsOfDate: optionalString(value.normalized_as_of_date),
+    programs,
+    notes: optionalString(value.notes),
+  };
+}
+
+export function parseYutaiLaunchDisplaySnapshot(value: unknown): YutaiLaunchDisplaySnapshot | null {
+  if (!isRecord(value) || value.schema_version !== 1 || !Array.isArray(value.records) || !isRecord(value.counts)) return null;
+  if (typeof value.generated_at !== "string" || typeof value.month !== "string" || typeof value.record_count !== "number") return null;
+  const records = value.records.map(parseDisplayRecord).filter((record): record is YutaiLaunchDisplayRecord => record !== null);
+  return {
+    generatedAt: value.generated_at,
+    month: value.month,
+    recordCount: value.record_count,
+    conditionsAvailable: typeof value.counts.conditions_available === "number" ? value.counts.conditions_available : 0,
+    autoCalculable: typeof value.counts.auto_calculable === "number" ? value.counts.auto_calculable : 0,
+    requiresUserValuation: typeof value.counts.requires_user_valuation === "number" ? value.counts.requires_user_valuation : 0,
+    records,
+  };
+}
+
+export function buildLaunchDisplayByKey(snapshot: YutaiLaunchDisplaySnapshot | null) {
+  return new Map(snapshot?.records.map((record) => [`${record.code}:${Number(record.month.slice(5, 7))}`, record]) ?? []);
+}
+
+function groupValueYen(group: YutaiLaunchDisplayGroup) {
+  const values = group.items
+    .map((item) => item.officialValueYen)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0);
+  if (values.length === 0) return 0;
+  return group.mode === "choose_one" ? Math.max(...values) : values.reduce((sum, value) => sum + value, 0);
+}
+
+export function getLaunchDisplayHint(record: YutaiLaunchDisplayRecord | null | undefined): YutaiLaunchDisplayHint | null {
+  if (!record || record.calculationStatus === "no_conditions") return null;
+  for (const program of record.programs) {
+    const sortedTiers = [...program.tiers].sort((a, b) => a.minimumShares - b.minimumShares || a.requiredHoldingMonths - b.requiredHoldingMonths);
+    for (const tier of sortedTiers) {
+      const benefitValueYen = tier.groups.reduce((sum, group) => sum + groupValueYen(group), 0);
+      if (benefitValueYen > 0) {
+        const hold = tier.requiredHoldingMonths > 0 ? `・${tier.requiredHoldingMonths}ヶ月保有` : "";
+        return {
+          requiredShares: tier.minimumShares,
+          benefitValueYen,
+          label: `${program.label} ${tier.minimumShares}株${hold}`,
+        };
+      }
+    }
+  }
+  return null;
+}
+

--- a/docs/decision-log/2026-07-23-yutai-launch-display-private-proxy.md
+++ b/docs/decision-log/2026-07-23-yutai-launch-display-private-proxy.md
@@ -1,0 +1,41 @@
+# 2026-07-23 優待公式条件をPremium認証付きサーバールート経由にする
+
+## 背景
+
+- `market_info`が公式HTML/PDF/TDNET由来の優待条件を正規化し、Private R2へ`yutai/launch-display/*.json`としてpublishする。
+- `market-info-api`はPrivate R2を読み、Bearer認証必須の`/yutai/launch-display/latest`、`/yutai/launch-display/manifest`、`/yutai/launch-display/monthly/{year_month}`を提供する。
+- ブラウザーからPrivate R2や上流Bearer tokenへ直接アクセスさせると、Premium認証とprivate保管の境界が崩れる。
+- 優待ダッシュボードには、署名済みCookieを使うPremium認証がすでにある。
+
+## 決定
+
+- mini-toolsに`GET /api/yutai/launch-display`を追加し、Premium Cookieを検証してからだけ上流APIを呼ぶ。
+- 未ログイン・期限切れは404とし、上流リクエストを行わない。
+- 上流Bearer tokenは既存の`MARKET_INFO_API_YUTAI_STOCK_PRICES_TOKEN`をサーバー環境で再利用する。`NEXT_PUBLIC_`を付けない。
+- 月指定がある場合は`/yutai/launch-display/monthly/{year_month}`、月指定がない場合は`/yutai/launch-display/latest`を呼ぶ。
+- 指定月とpayloadの`month`が一致し、画面parserで解釈できる成功レスポンスだけ`Cache-Control: private, max-age=86400`にする。それ以外は`private, no-store`にする。
+- `next-pwa`の既定`/api/*` cacheより前に、このrouteを`NetworkOnly`へ指定する。
+- 上流の認証・設定エラーは502へ変換し、tokenや上流本文をクライアントへ返さない。
+- 優待ダッシュボードは公式条件を詳細パネルに表示し、自動計算できる最初の条件だけをユーザー操作で簡易優待効率へ反映する。自動上書きはしない。
+
+## データ経路
+
+```text
+Premium Cookie
+    |
+    v
+mini-tools /api/yutai/launch-display
+    |  Authorization: Bearer <server-only token>
+    v
+market-info-api /yutai/launch-display/monthly/{year_month}
+    |
+    v
+Private R2 yutai/launch-display/{year_month}.json
+```
+
+## 関連
+
+- [優待株価をPremium認証付きサーバールート経由にする](./2026-07-20-yutai-private-stock-price-proxy.md)
+- [優待ダッシュボードPremium認証](./2026-07-19-yutai-dashboard-premium-auth.md)
+- [優待ダッシュボード仕様](../specs/tools/yutai-dashboard.md)
+- [優待ダッシュボードUAT](../uat/yutai-dashboard.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-07-23 優待公式条件をPremium認証付きサーバールート経由にする](./decision-log/2026-07-23-yutai-launch-display-private-proxy.md)
 - [2026-07-20 優待株価JSONを24時間private HTTPキャッシュする](./decision-log/2026-07-20-yutai-stock-price-private-http-cache.md)
 - [2026-07-20 優待効率へPrivate実株価を適用する](./decision-log/2026-07-20-yutai-dashboard-live-stock-price-efficiency.md)
 - [2026-07-20 優待株価をPremium認証付きサーバールート経由にする](./decision-log/2026-07-20-yutai-private-stock-price-proxy.md)

--- a/next.config.js
+++ b/next.config.js
@@ -15,7 +15,9 @@ const withPWA = require("next-pwa")({
           url.pathname === "/tools/yutai-dashboard" ||
           url.pathname.startsWith("/tools/yutai-dashboard/") ||
           url.pathname === "/api/yutai/stock-prices" ||
-          url.pathname.startsWith("/api/yutai/stock-prices/")
+          url.pathname.startsWith("/api/yutai/stock-prices/") ||
+          url.pathname === "/api/yutai/launch-display" ||
+          url.pathname.startsWith("/api/yutai/launch-display/")
         );
       },
       handler: "NetworkOnly",


### PR DESCRIPTION
## Summary
- Add Premium-gated `/api/yutai/launch-display` proxy for market-info-api launch display JSON
- Parse official yutai condition payloads and show them in the yutai dashboard detail panel
- Allow a user action to apply the first auto-calculable official condition to simple efficiency inputs
- Keep the launch-display route NetworkOnly in next-pwa and document the private proxy decision

## Verification
- `npm run lint`
- `npm run test` (32 files, 230 tests)
- `npm run build`
- `codex review --uncommitted` after fixing the all-month selected-row month issue: no discrete regressions found

## Notes
- The browser still never receives the upstream Bearer token.
- In all-month dashboard mode, selecting a row loads the latest manifest year for that row's entitlement month instead of only using upstream latest.
