### PR TITLE
fix(yutai-dashboard): 詳細パネルの閉じるボタン隠れを修正＋tscエラー解消

### DIFF
--- a/app/tools/earnings-calendar/__tests__/data-loader.test.ts
+++ b/app/tools/earnings-calendar/__tests__/data-loader.test.ts
@@ -128,7 +128,7 @@ function makeFetch404(): Response {
 describe("loadEarningsCalendarPageData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -136,6 +136,7 @@ describe("loadEarningsCalendarPageData", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき domestic はローカルファイルから取得する（fetch しない）", async () => {
@@ -186,7 +187,7 @@ describe("loadEarningsCalendarPageData", () => {
   });
 
   it("production で domestic API 失敗時はローカル JSON にフォールバックしない", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     makeLocalFiles();
     vi.mocked(fetch).mockImplementation(async (url) => {
@@ -222,7 +223,7 @@ describe("loadEarningsCalendarPageData", () => {
   });
 
   it("production で domestic monthly 失敗時は同梱 JSON で補完しない", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     makeLocalFiles();
     vi.mocked(fetch).mockImplementation(async (url) => {

--- a/app/tools/investor-flow/__tests__/data-loader.test.ts
+++ b/app/tools/investor-flow/__tests__/data-loader.test.ts
@@ -111,13 +111,14 @@ function makeFetch404(): Response {
 describe("investor-flow data-loader", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき null を返す", async () => {

--- a/app/tools/nikkei-contribution/__tests__/data-loader.test.ts
+++ b/app/tools/nikkei-contribution/__tests__/data-loader.test.ts
@@ -38,7 +38,7 @@ function makeFetch404(): Response {
 describe("loadContributionManifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -46,6 +46,7 @@ describe("loadContributionManifest", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルファイルのマニフェストを返す", async () => {
@@ -91,7 +92,7 @@ describe("loadContributionManifest", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず EMPTY_MANIFEST を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();
@@ -117,7 +118,7 @@ describe("loadContributionManifest", () => {
 describe("loadContributionDayData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -125,6 +126,7 @@ describe("loadContributionDayData", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("空文字を渡したとき null を即返す（fetch しない）", async () => {
@@ -177,7 +179,7 @@ describe("loadContributionDayData", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず null を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();

--- a/app/tools/stock-ranking/__tests__/data-loader.test.ts
+++ b/app/tools/stock-ranking/__tests__/data-loader.test.ts
@@ -24,7 +24,7 @@ function makeFetch404(): Response {
 describe("loadRankingManifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -32,6 +32,7 @@ describe("loadRankingManifest", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルファイルのマニフェストを返す", async () => {
@@ -77,7 +78,7 @@ describe("loadRankingManifest", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず null を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();
@@ -132,7 +133,7 @@ describe("loadRankingManifest", () => {
 describe("loadRankingDayData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -140,6 +141,7 @@ describe("loadRankingDayData", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルファイルのデータを返す", async () => {
@@ -185,7 +187,7 @@ describe("loadRankingDayData", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず null を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();

--- a/app/tools/topix33/__tests__/data-loader.test.ts
+++ b/app/tools/topix33/__tests__/data-loader.test.ts
@@ -39,7 +39,7 @@ function makeFetch404(): Response {
 describe("loadTopix33Manifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -47,6 +47,7 @@ describe("loadTopix33Manifest", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルファイルのマニフェストを返す", async () => {
@@ -92,7 +93,7 @@ describe("loadTopix33Manifest", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず EMPTY_MANIFEST を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();
@@ -118,7 +119,7 @@ describe("loadTopix33Manifest", () => {
 describe("loadTopix33DayData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -126,6 +127,7 @@ describe("loadTopix33DayData", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("空文字を渡したとき null を即返す（fetch しない）", async () => {
@@ -178,7 +180,7 @@ describe("loadTopix33DayData", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず null を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();

--- a/app/tools/yutai-candidates/__tests__/data-loader.test.ts
+++ b/app/tools/yutai-candidates/__tests__/data-loader.test.ts
@@ -64,7 +64,7 @@ function makeFetch404(): Response {
 describe("loadMonthlyYutaiManifest", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -72,6 +72,7 @@ describe("loadMonthlyYutaiManifest", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルファイルのマニフェストを返す", async () => {
@@ -117,7 +118,7 @@ describe("loadMonthlyYutaiManifest", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず null を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();
@@ -143,7 +144,7 @@ describe("loadMonthlyYutaiManifest", () => {
 describe("loadMonthlyYutaiMonthData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -151,6 +152,7 @@ describe("loadMonthlyYutaiMonthData", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルファイルの月次データを返す", async () => {
@@ -186,7 +188,7 @@ describe("loadMonthlyYutaiMonthData", () => {
   });
 
   it("production で API 失敗時はローカル fallback せず null を返す", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     vi.mocked(fetch).mockRejectedValue(new Error("network error"));
     mockReadFile.mockClear();
@@ -212,12 +214,13 @@ describe("loadMonthlyYutaiMonthData", () => {
 describe("nikko/SBI credit: API あり・fetch 失敗時はサンプルを返さない", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -275,7 +278,7 @@ describe("nikko/SBI credit: API あり・fetch 失敗時はサンプルを返さ
 describe("loadMonthlyYutaiPageData", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     process.env.MARKET_INFO_API_BASE_URL = "https://api.example.com";
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -283,6 +286,7 @@ describe("loadMonthlyYutaiPageData", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     delete process.env.MARKET_INFO_API_BASE_URL;
   });
 

--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useSearchParams } from "next/navigation";
 import { addMemoItemFromCandidate, isImportedMonthlyYutaiCandidate } from "@/app/tools/yutai-memo/candidate-import";
 import { loadArchivedItems, loadItems, saveItems } from "@/app/tools/yutai-memo/storage";
@@ -71,6 +71,21 @@ const ALL_MONTHS_ID = "all";
 
 // 表のセルからその場で編集できる項目
 type InlineField = "crossType" | "preparationMonthsBefore" | "oneShareStartedAt";
+
+// SSR 安全なメディアクエリ。サーバー/Hydration 中は必ず false（=Desktop 扱い）。
+function useMediaQuery(query: string) {
+  const subscribe = (onStoreChange: () => void) => {
+    if (typeof window === "undefined") return () => {};
+    const mql = window.matchMedia(query);
+    mql.addEventListener("change", onStoreChange);
+    return () => mql.removeEventListener("change", onStoreChange);
+  };
+  const getSnapshot = () => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  };
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
 
 type DashboardRow = {
   key: string;
@@ -209,6 +224,8 @@ const creditChipStyleByKind: Record<NikkoCreditBadgeKind, string> = {
 export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
   const { navigate, isPendingFor } = useRouterTransition();
   const searchParams = useSearchParams();
+  // モバイルでは詳細を全画面オーバーレイにする（横並びパネルだとスクロールバーが2本になり上端が隠れるため）
+  const isMobile = useMediaQuery("(max-width: 699px)");
   const jstNow = useMemo(() => toJstYearMonth(new Date()), []);
   const calendarNowIso = useMemo(() => new Date().toISOString(), []);
   const [query, setQuery] = useState("");
@@ -522,6 +539,8 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
     () => filteredRows.find((row) => row.key === selectedRowKey) ?? null,
     [filteredRows, selectedRowKey],
   );
+  // モバイルのみ全画面オーバーレイ。hydration 前は Desktop 扱い（SSR と一致させる）。
+  const showDetailOverlay = hydrated && isMobile;
   const selectedEfficiencyMemoKey = selectedRow?.candidate && !selectedRow.key.startsWith("memo:")
     ? getCardMemoKey(selectedRow.candidate)
     : null;
@@ -1443,27 +1462,40 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
             </div>
 
             {selectedRow ? (
-              <aside style={styles.detailPanel}>
+              <>
+              {showDetailOverlay ? (
+                <div
+                  style={styles.detailBackdrop}
+                  onClick={() => {
+                    setSelectedRowKey(null);
+                    closeMemoEdit();
+                  }}
+                  aria-hidden="true"
+                />
+              ) : null}
+              <aside style={showDetailOverlay ? styles.detailPanelMobile : styles.detailPanel}>
                 <div style={styles.detailHeader}>
-                  <div>
-                    <span style={styles.codeChip}>{selectedRow.code || "コードなし"}</span>
-                    <h2 style={styles.detailTitle}>{selectedRow.name}</h2>
-                    <div style={styles.detailMonths}>権利月: {formatMonths(selectedRow.months)}</div>
+                  <div style={styles.detailHeaderTop}>
+                    <div>
+                      <span style={styles.codeChip}>{selectedRow.code || "コードなし"}</span>
+                      <h2 style={styles.detailTitle}>{selectedRow.name}</h2>
+                      <div style={styles.detailMonths}>権利月: {formatMonths(selectedRow.months)}</div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSelectedRowKey(null);
+                        closeMemoEdit();
+                      }}
+                      style={styles.detailClose}
+                      aria-label="詳細を閉じる"
+                    >
+                      ✕
+                    </button>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSelectedRowKey(null);
-                      closeMemoEdit();
-                    }}
-                    style={styles.detailClose}
-                    aria-label="詳細を閉じる"
-                  >
-                    ✕
-                  </button>
+                  {/* アクション行も固定領域に含め、スクロールで潰れないようにする */}
+                  <div style={styles.detailActions}>{renderRowActions(selectedRow)}</div>
                 </div>
-
-                <div style={styles.detailActions}>{renderRowActions(selectedRow)}</div>
 
                 {selectedRow.candidate ? (
                   <section style={styles.detailSection}>
@@ -1816,6 +1848,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
                   )}
                 </section>
               </aside>
+              </>
             ) : null}
           </div>
           )}
@@ -2666,16 +2699,49 @@ const styles: Record<string, React.CSSProperties> = {
     background: "#fdfdfe",
     padding: "16px 16px 20px",
     position: "sticky",
-    top: 16,
-    maxHeight: "calc(100vh - 32px)",
+    // サイトヘッダー（sticky, 高さ54px）の下に収める。上端が裏に潜らないように。
+    top: 68,
+    maxHeight: "calc(100vh - 84px)",
     overflowY: "auto",
   },
+  detailBackdrop: {
+    position: "fixed",
+    inset: 0,
+    zIndex: 40,
+    background: "rgba(8,10,18,0.45)",
+  },
+  detailPanelMobile: {
+    // モバイルは全画面オーバーレイ。スクロールは1本、ヘッダーは detailHeader が上端固定。
+    position: "fixed",
+    inset: 0,
+    zIndex: 41,
+    maxWidth: "none",
+    border: "none",
+    borderRadius: 0,
+    background: "#fdfdfe",
+    padding: "16px 16px 24px",
+    overflowY: "auto",
+    WebkitOverflowScrolling: "touch",
+  },
   detailHeader: {
+    // タイトル行とアクション行をまとめて上端に固定する。
+    // padding 分をキャンセルして全幅で背景を敷き、下に流れる内容を覆う。
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+    position: "sticky",
+    top: 0,
+    zIndex: 3,
+    margin: "-16px -16px 12px",
+    padding: "14px 16px 10px",
+    background: "#fdfdfe",
+    borderBottom: "1px solid rgba(15,23,42,0.06)",
+  },
+  detailHeaderTop: {
     display: "flex",
     justifyContent: "space-between",
     alignItems: "flex-start",
     gap: 8,
-    marginBottom: 10,
   },
   codeChip: {
     display: "inline-flex",
@@ -2713,7 +2779,7 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0,
   },
   detailActions: {
-    marginBottom: 12,
+    // detailHeader の gap で余白を取るため marginBottom は不要
   },
   detailSection: {
     paddingTop: 12,

--- a/app/tools/yutai-memo/__tests__/data-loader.test.ts
+++ b/app/tools/yutai-memo/__tests__/data-loader.test.ts
@@ -27,7 +27,7 @@ describe("loadNikkoShortBalance", () => {
   beforeEach(() => {
     mockReadFile.mockReset();
     vi.stubGlobal("fetch", vi.fn());
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.MARKET_INFO_API_BASE_URL;
     delete process.env.MINI_TOOLS_ENABLE_LOCAL_DATA_FALLBACK;
   });
@@ -35,6 +35,7 @@ describe("loadNikkoShortBalance", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("API 未設定のとき、ローカルサンプルを返す（fetch しない）", async () => {

--- a/lib/__tests__/market-trading-dates.test.ts
+++ b/lib/__tests__/market-trading-dates.test.ts
@@ -15,9 +15,12 @@ describe("filterVisibleTradingDates", () => {
         "2025-04-08",
       ],
       {
+        as_of_date: "2025-04-04",
+        from: "2025-04-04",
+        to: "2025-04-08",
         days: [
-          { date: "2025-04-07", market_closed: true },
-          { date: "2025-04-08", market_closed: false },
+          { date: "2025-04-07", market_closed: true, label: "臨時休場" },
+          { date: "2025-04-08", market_closed: false, label: "" },
         ],
       },
     );


### PR DESCRIPTION
## 概要
優待ダッシュボードの詳細パネルで、スクロール時にヘッダー(閉じるボタン)が隠れて閉じられない不具合を修正。あわせて `@types/node` v25 由来の tsc エラーも解消する。2系統・2コミット構成。

## 変更内容

### 1. 詳細パネルのスクロール改善 (`ToolClient.tsx`)
- **原因**: パネルが `sticky; top:16` でサイトヘッダー(`sticky; zIndex:10`, 54px)の裏に潜り込み、閉じるボタンが隠れていた。加えて `overflowY:auto` でスクロールバーが2本になりモバイルで窮屈だった。
- **修正**:
  - ヘッダー(タイトル行+アクション行 ☆/✕/＋メモ)をパネル内で上端固定し、スクロールしても常に見えるように。
  - モバイル(`<=699px`)は詳細を**全画面オーバーレイ**(fixed)化。スクロール1本・潜り込み解消・背景タップで閉じる。SSR 安全な `useMediaQuery`(useSyncExternalStore)で判定し、hydration 前は Desktop 扱い。
  - デスクトップはサイトヘッダー下に収まるよう `top`/`maxHeight` を補正。

### 2. tsc エラー解消 (テスト8ファイル)
- `process.env.NODE_ENV` への直接代入(v25 で読み取り専用化→TS2540)を `vi.stubEnv` に置換し、`afterEach` に `vi.unstubAllEnvs` を追加。
- `market-trading-dates.test.ts` のフィクスチャに `JpxMarketClosedDay.label` と `JpxMarketClosedResponse` の `as_of_date/from/to` を補完。

## 検証
- `npx tsc --noEmit` → エラー0
- `npx vitest run` → 32ファイル / 230テスト 全パス
- dev サーバーで `/tools/yutai-dashboard` が HTTP 200、モバイル幅で閉じるボタン・＋メモが常時表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)