### PR TITLE
fix(yutai-dashboard): 詳細パネルのモバイル全画面オーバーレイを廃止

### DIFF
--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { addMemoItemFromCandidate, isImportedMonthlyYutaiCandidate } from "@/app/tools/yutai-memo/candidate-import";
 import { loadArchivedItems, loadItems, saveItems } from "@/app/tools/yutai-memo/storage";
@@ -71,21 +71,6 @@ const ALL_MONTHS_ID = "all";
 
 // 表のセルからその場で編集できる項目
 type InlineField = "crossType" | "preparationMonthsBefore" | "oneShareStartedAt";
-
-// SSR 安全なメディアクエリ。サーバー/Hydration 中は必ず false（=Desktop 扱い）。
-function useMediaQuery(query: string) {
-  const subscribe = (onStoreChange: () => void) => {
-    if (typeof window === "undefined") return () => {};
-    const mql = window.matchMedia(query);
-    mql.addEventListener("change", onStoreChange);
-    return () => mql.removeEventListener("change", onStoreChange);
-  };
-  const getSnapshot = () => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(query).matches;
-  };
-  return useSyncExternalStore(subscribe, getSnapshot, () => false);
-}
 
 type DashboardRow = {
   key: string;
@@ -224,8 +209,6 @@ const creditChipStyleByKind: Record<NikkoCreditBadgeKind, string> = {
 export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
   const { navigate, isPendingFor } = useRouterTransition();
   const searchParams = useSearchParams();
-  // モバイルでは詳細を全画面オーバーレイにする（横並びパネルだとスクロールバーが2本になり上端が隠れるため）
-  const isMobile = useMediaQuery("(max-width: 699px)");
   const jstNow = useMemo(() => toJstYearMonth(new Date()), []);
   const calendarNowIso = useMemo(() => new Date().toISOString(), []);
   const [query, setQuery] = useState("");
@@ -539,8 +522,6 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
     () => filteredRows.find((row) => row.key === selectedRowKey) ?? null,
     [filteredRows, selectedRowKey],
   );
-  // モバイルのみ全画面オーバーレイ。hydration 前は Desktop 扱い（SSR と一致させる）。
-  const showDetailOverlay = hydrated && isMobile;
   const selectedEfficiencyMemoKey = selectedRow?.candidate && !selectedRow.key.startsWith("memo:")
     ? getCardMemoKey(selectedRow.candidate)
     : null;
@@ -1462,18 +1443,7 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
             </div>
 
             {selectedRow ? (
-              <>
-              {showDetailOverlay ? (
-                <div
-                  style={styles.detailBackdrop}
-                  onClick={() => {
-                    setSelectedRowKey(null);
-                    closeMemoEdit();
-                  }}
-                  aria-hidden="true"
-                />
-              ) : null}
-              <aside style={showDetailOverlay ? styles.detailPanelMobile : styles.detailPanel}>
+              <aside style={styles.detailPanel}>
                 <div style={styles.detailHeader}>
                   <div style={styles.detailHeaderTop}>
                     <div>
@@ -1848,7 +1818,6 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
                   )}
                 </section>
               </aside>
-              </>
             ) : null}
           </div>
           )}
@@ -2703,25 +2672,6 @@ const styles: Record<string, React.CSSProperties> = {
     top: 68,
     maxHeight: "calc(100vh - 84px)",
     overflowY: "auto",
-  },
-  detailBackdrop: {
-    position: "fixed",
-    inset: 0,
-    zIndex: 40,
-    background: "rgba(8,10,18,0.45)",
-  },
-  detailPanelMobile: {
-    // モバイルは全画面オーバーレイ。スクロールは1本、ヘッダーは detailHeader が上端固定。
-    position: "fixed",
-    inset: 0,
-    zIndex: 41,
-    maxWidth: "none",
-    border: "none",
-    borderRadius: 0,
-    background: "#fdfdfe",
-    padding: "16px 16px 24px",
-    overflowY: "auto",
-    WebkitOverflowScrolling: "touch",
   },
   detailHeader: {
     // タイトル行とアクション行をまとめて上端に固定する。


### PR DESCRIPTION
## 概要
モバイルで詳細パネルを全画面オーバーレイ表示していたのを、デスクトップと同じ**元のインライン表示領域**に戻す。スクロール課題の修正は維持する。

## 背景
PR #424 で「閉じるボタンが隠れる」問題を修正した際、モバイル(<=699px)では詳細を fixed 全画面オーバーレイ化した。しかしユーザー要望により、モバイルでも元の表示領域のほうが好ましいと判明。スクロール課題（閉じるボタン等が常に見える）だけ直っていればよい。

## 変更点
- モバイル用の全画面オーバーレイを廃止し、常に `styles.detailPanel`（インライン）を使用
- スクロール修正は維持: `detailHeader` を sticky 固定し、閉じる/☆/✕/＋メモ をスクロールしても常時表示
- 不要になったコードを削除: `useMediaQuery` / `isMobile` / `showDetailOverlay` / `detailPanelMobile` / `detailBackdrop`

## 確認
- `npx tsc --noEmit` クリーン
- +2 / -52（オーバーレイ導入分を巻き戻し、スクロール修正は残置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)