### PR TITLE
fix(yutai-dashboard): 詳細パネルの最大高さを dvh に変更しモバイルのはみ出しを解消

### DIFF
--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -2670,7 +2670,9 @@ const styles: Record<string, React.CSSProperties> = {
     position: "sticky",
     // サイトヘッダー（sticky, 高さ54px）の下に収める。上端が裏に潜らないように。
     top: 68,
-    maxHeight: "calc(100vh - 84px)",
+    // dvh を使う。モバイル Chrome の 100vh はアドレスバー分だけ実可視領域より大きく、
+    // vh だとパネル底が画面外にはみ出し、内部スクロールで最下部まで届かなくなるため。
+    maxHeight: "calc(100dvh - 84px)",
     overflowY: "auto",
   },
   detailHeader: {


### PR DESCRIPTION
## 概要
モバイルで詳細パネルの内部スクロールを最下部まで送ってもパネル底が画面外にはみ出し、裏のページをスクロールしないと見えない問題を修正する。

## 原因
詳細パネルは `position: sticky` + `maxHeight: calc(100vh - 84px)` + `overflowY: auto` で「ビューポート内に収めて内部スクロール」する設計。しかしモバイル Chrome の `100vh` は**アドレスバーが隠れた最大状態の高さ**を指すため、アドレスバー表示中の実可視領域より背が高くなる。結果、パネル底が可視領域の下端より下に来て、内部スクロールでは最下部まで到達できない。

## 変更点
- `maxHeight: calc(100vh - 84px)` → `calc(100dvh - 84px)`（動的ビューポート単位）
- `dvh` はブラウザ UI を考慮した高さで、可視領域と一致する（Android Chrome 対応済み）

## 確認
- `npx tsc --noEmit` クリーン
- +3 / -1

🤖 Generated with [Claude Code](https://claude.com/claude-code)