### PR TITLE
fix(yutai-dashboard): 詳細パネル底が下部固定ナビ裏に潜る問題を修正

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -26,6 +26,10 @@
   --color-error:         #dc2626;
   --color-success:       #16a34a;
   --color-warning:       #d97706;
+
+  /* モバイル下部固定ナビ(MobileBottomNav)が占める高さ。デスクトップは 0。
+     sticky なパネル等が 100dvh 基準で高さを計算する際に差し引くために使う。 */
+  --bottom-nav-space:    0px;
 }
 
 *,
@@ -41,8 +45,11 @@ body {
 }
 
 @media (max-width: 720px) {
+  :root {
+    --bottom-nav-space: calc(64px + env(safe-area-inset-bottom));
+  }
   body {
-    padding-bottom: calc(64px + env(safe-area-inset-bottom));
+    padding-bottom: var(--bottom-nav-space);
   }
 }
 

--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -2672,7 +2672,9 @@ const styles: Record<string, React.CSSProperties> = {
     top: 68,
     // dvh を使う。モバイル Chrome の 100vh はアドレスバー分だけ実可視領域より大きく、
     // vh だとパネル底が画面外にはみ出し、内部スクロールで最下部まで届かなくなるため。
-    maxHeight: "calc(100dvh - 84px)",
+    // さらに下部固定ナビ(MobileBottomNav)の高さ分を差し引き、底がナビ裏に潜らないようにする
+    // （--bottom-nav-space はデスクトップでは 0）。
+    maxHeight: "calc(100dvh - 84px - var(--bottom-nav-space, 0px))",
     overflowY: "auto",
   },
   detailHeader: {


### PR DESCRIPTION
## 概要
モバイルで詳細パネルを最下部までスクロールしても、パネル底が画面下部の固定ナビ（MobileBottomNav: ホーム/マイ銘柄/優待/カレンダー/開示）の裏に潜り込み、最後のセクションが読めない問題を修正する。

## 原因
詳細パネルは `position: sticky` + `maxHeight: calc(100dvh - 84px)` で高さを viewport 基準に計算しているが、下部固定ナビ（`position: fixed; bottom: 0`、高さ 64px + safe-area、≤720px でのみ表示）の分を差し引いていなかった。そのためパネル底がナビ上端より下に来て裏に隠れていた。

## 変更点
- `globals.css` に `--bottom-nav-space` トークンを追加
  - デスクトップ: `0px`
  - `≤720px`: `calc(64px + env(safe-area-inset-bottom))`
- `body` の `padding-bottom` も同トークンを再利用（重複値を一元化）
- 詳細パネルの `maxHeight` を `calc(100dvh - 84px - var(--bottom-nav-space, 0px))` に変更
  - デスクトップは 0px なので従来どおり、モバイルのみナビ分を確保

## 確認
- `npx tsc --noEmit` クリーン
- +11 / -2（globals.css + ToolClient.tsx）

🤖 Generated with [Claude Code](https://claude.com/claude-code)