### PR TITLE
fix(yutai-dashboard): モバイル固定詳細パネルの横幅を従来の340px右寄せに戻す

### DIFF
--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -2701,14 +2701,14 @@ const styles: Record<string, React.CSSProperties> = {
   detailPanelMobile: {
     // モバイルはビューポート固定。ヘッダー(68px)〜下部ナビの間にドックし、
     // 内部の 1 本スクロールだけで常に最下部まで届くようにする（sticky の段階せり上がりを解消）。
-    // 全画面 inset:0 のオーバーレイではなく、左右に余白を残した「その場のカード」。
+    // 全画面ではなく、従来と同じ 340px 幅を右寄せで維持（狭い端末では画面幅に収める）。
     position: "fixed",
     top: 68,
-    left: 8,
     right: 8,
     bottom: "calc(8px + var(--bottom-nav-space, 0px))",
+    width: 340,
+    maxWidth: "calc(100vw - 16px)",
     zIndex: 41,
-    maxWidth: "none",
     borderRadius: 14,
     border: "1px solid rgba(15,23,42,0.08)",
     background: "#fdfdfe",


### PR DESCRIPTION
## 概要
#428 でモバイル固定パネルを左右8pxの全幅にしたが、「横幅は前（狭いパネル）の方が好み」とのフィードバックを受け、従来と同じ **340px 幅・右寄せ**に戻す。

## 変更点
- `detailPanelMobile`: `left:8` / 全幅をやめ、`width: 340` を `right: 8` で右寄せドック
- 狭い端末向けに `maxWidth: calc(100vw - 16px)` で画面内に収める
- 動き（`position: fixed` によるビューポート固定・内部1本スクロール・`overscroll-behavior: contain`）は #428 のまま維持

## 確認
- `npx tsc --noEmit` クリーン
- +3 / -3

🤖 Generated with [Claude Code](https://claude.com/claude-code)