### PR TITLE
feat(yutai-dashboard): 簡易効率の2段目に日興クロス取引の概算手数料を表示

### DIFF
--- a/app/tools/_shared/__tests__/yutai-cross-fee.test.ts
+++ b/app/tools/_shared/__tests__/yutai-cross-fee.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  NIKKO_CROSS_FEE_RATES,
+  calculateNikkoCrossFee,
+  resolveCrossSellSide,
+} from "../yutai-cross-fee";
+
+describe("resolveCrossSellSide", () => {
+  it("一般信用売りが可能なら一般を優先する", () => {
+    expect(resolveCrossSellSide({ generalShort: true, institutionalShort: true })).toBe("general");
+    expect(resolveCrossSellSide({ generalShort: true, institutionalShort: false })).toBe("general");
+  });
+
+  it("一般が不可で制度が可なら制度を使う", () => {
+    expect(resolveCrossSellSide({ generalShort: false, institutionalShort: true })).toBe("institutional");
+  });
+
+  it("どちらも不可なら null", () => {
+    expect(resolveCrossSellSide({ generalShort: false, institutionalShort: false })).toBeNull();
+  });
+});
+
+describe("calculateNikkoCrossFee", () => {
+  const tradeAmountYen = 1_000_000;
+  const holdingDays = 10;
+
+  it("買方金利＋一般貸株料を日割りで合算する", () => {
+    const fee = calculateNikkoCrossFee({ tradeAmountYen, holdingDays, sellSide: "general" });
+    const expectedBuy =
+      (tradeAmountYen * NIKKO_CROSS_FEE_RATES.institutionalBuyAnnualRate * holdingDays) / 365;
+    const expectedSell =
+      (tradeAmountYen * NIKKO_CROSS_FEE_RATES.generalLendingAnnualRate * holdingDays) / 365;
+    expect(fee).not.toBeNull();
+    expect(fee?.buyInterestYen).toBeCloseTo(expectedBuy, 6);
+    expect(fee?.sellLendingYen).toBeCloseTo(expectedSell, 6);
+    expect(fee?.totalYen).toBeCloseTo(expectedBuy + expectedSell, 6);
+    expect(fee?.hasReverseChargeRisk).toBe(false);
+  });
+
+  it("制度信用売りは制度貸株料を使い逆日歩リスクありとなる", () => {
+    const fee = calculateNikkoCrossFee({ tradeAmountYen, holdingDays, sellSide: "institutional" });
+    const expectedSell =
+      (tradeAmountYen * NIKKO_CROSS_FEE_RATES.institutionalLendingAnnualRate * holdingDays) / 365;
+    expect(fee?.sellLendingYen).toBeCloseTo(expectedSell, 6);
+    expect(fee?.hasReverseChargeRisk).toBe(true);
+  });
+
+  it("約定金額・保有日数が不正なら null", () => {
+    expect(calculateNikkoCrossFee({ tradeAmountYen: 0, holdingDays, sellSide: "general" })).toBeNull();
+    expect(calculateNikkoCrossFee({ tradeAmountYen, holdingDays: 0, sellSide: "general" })).toBeNull();
+  });
+});

--- a/app/tools/_shared/__tests__/yutai-kenri-date.test.ts
+++ b/app/tools/_shared/__tests__/yutai-kenri-date.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  getKenriLastDateForMonthId,
+  getKenriLastDay,
+  getUpcomingKenriInfoByMonth,
+} from "../yutai-kenri-date";
+
+describe("getKenriLastDay", () => {
+  it("月末最終営業日の2営業日前を返す（2026-03: 月末31日(火) → 27日(金)）", () => {
+    // 2026-03-31 は火曜。最終営業日=31、その2営業日前=27（金）。
+    expect(getKenriLastDay(2026, 3)).toBe(27);
+  });
+
+  it("月末が土日をまたぐ場合も営業日ベースで遡る（2026-05: 31日(日)）", () => {
+    // 2026-05-31 は日曜。最終営業日=29(金)、2営業日前=27(水)。
+    expect(getKenriLastDay(2026, 5)).toBe(27);
+  });
+});
+
+describe("getKenriLastDateForMonthId", () => {
+  it("YYYY-MM から権利付最終日の ISO 文字列を返す", () => {
+    expect(getKenriLastDateForMonthId("2026-03")).toBe("2026-03-27");
+  });
+
+  it("不正な入力は null", () => {
+    expect(getKenriLastDateForMonthId("2026-13")).toBeNull();
+    expect(getKenriLastDateForMonthId("bad")).toBeNull();
+  });
+});
+
+describe("getUpcomingKenriInfoByMonth", () => {
+  it("権利付最終日を過ぎた月は翌年扱いにする", () => {
+    // 2026-03-28 時点: 3月の権利付最終日(27)は過ぎているので翌年へ。
+    const info = getUpcomingKenriInfoByMonth({ year: 2026, month: 3, day: 28 });
+    expect(info[3].kenriLastDate).toBe("2027-03-29");
+    expect(info[3].daysFromToday).toBeGreaterThan(300);
+  });
+
+  it("同年の未来の権利付最終日までの暦日数を返す", () => {
+    const info = getUpcomingKenriInfoByMonth({ year: 2026, month: 3, day: 1 });
+    expect(info[3].kenriLastDate).toBe("2026-03-27");
+    expect(info[3].daysFromToday).toBe(26);
+  });
+
+  it("全 12 か月分を返し、日数は最低 1", () => {
+    const info = getUpcomingKenriInfoByMonth({ year: 2026, month: 7, day: 26 });
+    expect(Object.keys(info)).toHaveLength(12);
+    for (let m = 1; m <= 12; m++) {
+      expect(info[m].daysFromToday).toBeGreaterThanOrEqual(1);
+    }
+  });
+});

--- a/app/tools/_shared/yutai-cross-fee.ts
+++ b/app/tools/_shared/yutai-cross-fee.ts
@@ -1,0 +1,81 @@
+/**
+ * 日興（SMBC日興証券）でのクロス取引（つなぎ売り）にかかる手数料の概算。
+ *
+ * 前提:
+ * - 買い: 制度信用買い → 現引き（信用委託手数料・現引き手数料ともに 0 円）
+ *   コストは制度信用の買方金利のみ。
+ * - 売り: 一般信用売りが可能ならそれを使い（逆日歩なし）、無ければ制度信用売り。
+ *   コストは各区分の貸株料。制度信用売り時は逆日歩が別途発生し得る（予測不可のため非計上）。
+ * - 保有日数: 今日 → 権利付最終日（月末の 2 営業日前）の暦日数。
+ *
+ * 率は変動するため、改定時はこの定数のみ更新すること。
+ * 出所: SMBC日興証券 公式（2026-07-21 約定分〜の金利改定、2026-03-30 約定分〜の貸株料を反映）。
+ */
+export const NIKKO_CROSS_FEE_RATES = {
+  /** 制度信用 買方金利（年率） */
+  institutionalBuyAnnualRate: 0.0254,
+  /** 制度信用 貸株料（年率） */
+  institutionalLendingAnnualRate: 0.0115,
+  /** 一般信用 貸株料（年率） */
+  generalLendingAnnualRate: 0.019,
+} as const;
+
+export type CrossSellSide = "general" | "institutional";
+
+export type NikkoCrossFee = {
+  /** 実際に使う売り建て区分 */
+  sellSide: CrossSellSide;
+  /** 保有日数（暦日） */
+  holdingDays: number;
+  /** 約定金額（株価 × 必要株数） */
+  tradeAmountYen: number;
+  /** 買い側（制度信用買い→現引き）の買方金利コスト */
+  buyInterestYen: number;
+  /** 売り側の貸株料コスト */
+  sellLendingYen: number;
+  /** 合計手数料 */
+  totalYen: number;
+  /** 制度信用売りを使うため逆日歩が別途発生し得る */
+  hasReverseChargeRisk: boolean;
+};
+
+/**
+ * 日興の制度信用可否から、使う売り建て区分を決める。
+ * 一般信用売りを優先し、無ければ制度信用売り。どちらも不可なら null。
+ */
+export function resolveCrossSellSide(availability: {
+  generalShort: boolean;
+  institutionalShort: boolean;
+}): CrossSellSide | null {
+  if (availability.generalShort) return "general";
+  if (availability.institutionalShort) return "institutional";
+  return null;
+}
+
+export function calculateNikkoCrossFee(params: {
+  tradeAmountYen: number;
+  holdingDays: number;
+  sellSide: CrossSellSide;
+}): NikkoCrossFee | null {
+  const { tradeAmountYen, holdingDays, sellSide } = params;
+  if (!(tradeAmountYen > 0) || !Number.isFinite(tradeAmountYen)) return null;
+  if (!(holdingDays > 0) || !Number.isFinite(holdingDays)) return null;
+
+  const buyInterestYen =
+    (tradeAmountYen * NIKKO_CROSS_FEE_RATES.institutionalBuyAnnualRate * holdingDays) / 365;
+  const lendingRate =
+    sellSide === "general"
+      ? NIKKO_CROSS_FEE_RATES.generalLendingAnnualRate
+      : NIKKO_CROSS_FEE_RATES.institutionalLendingAnnualRate;
+  const sellLendingYen = (tradeAmountYen * lendingRate * holdingDays) / 365;
+
+  return {
+    sellSide,
+    holdingDays,
+    tradeAmountYen,
+    buyInterestYen,
+    sellLendingYen,
+    totalYen: buyInterestYen + sellLendingYen,
+    hasReverseChargeRisk: sellSide === "institutional",
+  };
+}

--- a/app/tools/_shared/yutai-kenri-date.ts
+++ b/app/tools/_shared/yutai-kenri-date.ts
@@ -1,0 +1,105 @@
+/**
+ * 権利付き最終日の算出（TSE 月末最終営業日 - 2 営業日）。
+ *
+ * 優待の権利確定日は銘柄ごとに異なるが、大半は月末締めのため
+ * 「権利月の月末最終営業日の 2 営業日前」を権利付最終日として近似する。
+ * 月末締め以外（15 日・20 日締め等）の銘柄は対象外（ズレを許容）。
+ *
+ * fs へ依存しない純粋関数のみを置き、サーバー / クライアント双方から利用する。
+ */
+
+/**
+ * 月末近く（月の後半）に位置する TSE 非営業日。
+ * これ以外の祝日は月末最終営業日の計算に影響しないため対象外。
+ *
+ * - 4/29 昭和の日（固定）: 翌月切替判定に影響する唯一の固定祝日
+ * - 4/30 振替: 4/29 が日曜の年（2029 年）
+ * - 12/31 大納会: TSE 年末休場（固定）
+ *
+ * 2030 年以降に利用する場合は末尾に追記すること。
+ */
+const JP_LATE_MONTH_NON_TRADING = new Set([
+  "2025-04-29",
+  "2026-04-29",
+  "2027-04-29",
+  "2028-04-29",
+  "2029-04-29",
+  "2029-04-30", // 4/29 が日曜のため振替
+  "2025-12-31",
+  "2026-12-31",
+  "2027-12-31",
+  "2028-12-31",
+  "2029-12-31",
+]);
+
+export function isBusinessDay(year: number, month: number, day: number): boolean {
+  const dow = new Date(year, month - 1, day).getDay();
+  if (dow === 0 || dow === 6) return false;
+  const key = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  return !JP_LATE_MONTH_NON_TRADING.has(key);
+}
+
+export function formatIsoDate(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * 権利付き最終日（日）を返す。
+ * = 月末最終営業日 - 2 営業日
+ */
+export function getKenriLastDay(year: number, month: number): number {
+  const lastCalendarDay = new Date(year, month, 0).getDate();
+  // 月末から遡って最終営業日を探す
+  let day = lastCalendarDay;
+  while (!isBusinessDay(year, month, day)) day--;
+  // そこからさらに 2 営業日戻る
+  let remaining = 2;
+  while (remaining > 0) {
+    day--;
+    if (isBusinessDay(year, month, day)) remaining--;
+  }
+  return day;
+}
+
+export function getKenriLastDateForMonthId(monthId: string): string | null {
+  const match = monthId.match(/^(\d{4})-(\d{2})$/);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) return null;
+  return formatIsoDate(year, month, getKenriLastDay(year, month));
+}
+
+export type UpcomingKenriInfo = {
+  /** 権利付最終日（YYYY-MM-DD） */
+  kenriLastDate: string;
+  /** 今日から権利付最終日までの暦日数（最低 1） */
+  daysFromToday: number;
+};
+
+/**
+ * 権利月（1..12）ごとに、今日から見て次回の権利付最終日と、そこまでの暦日数を返す。
+ * 今年の権利付最終日を既に過ぎている月は翌年扱いにする。
+ */
+export function getUpcomingKenriInfoByMonth(
+  today: { year: number; month: number; day: number },
+): Record<number, UpcomingKenriInfo> {
+  const todayDate = new Date(today.year, today.month - 1, today.day);
+  const result: Record<number, UpcomingKenriInfo> = {};
+  for (let month = 1; month <= 12; month++) {
+    let year = today.year;
+    let kenriDay = getKenriLastDay(year, month);
+    let kenriDate = new Date(year, month - 1, kenriDay);
+    if (kenriDate.getTime() < todayDate.getTime()) {
+      year += 1;
+      kenriDay = getKenriLastDay(year, month);
+      kenriDate = new Date(year, month - 1, kenriDay);
+    }
+    const daysFromToday = Math.max(
+      1,
+      Math.round((kenriDate.getTime() - todayDate.getTime()) / 86_400_000),
+    );
+    result[month] = { kenriLastDate: formatIsoDate(year, month, kenriDay), daysFromToday };
+  }
+  return result;
+}

--- a/app/tools/yutai-candidates/data-loader.ts
+++ b/app/tools/yutai-candidates/data-loader.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { canUseLocalMarketDataFallback, getApiBaseUrl, fetchJson } from "@/lib/market-api";
+import { getKenriLastDay, getKenriLastDateForMonthId } from "@/app/tools/_shared/yutai-kenri-date";
 import type {
   MonthlyYutaiManifest,
   MonthlyYutaiMonthData,
@@ -23,68 +24,6 @@ function getJstToday(): { year: number; month: number; day: number } {
     month: Number(parts.find((p) => p.type === "month")?.value ?? "0"),
     day: Number(parts.find((p) => p.type === "day")?.value ?? "0"),
   };
-}
-
-/**
- * 月末近く（月の後半）に位置する TSE 非営業日。
- * これ以外の祝日は月末最終営業日の計算に影響しないため対象外。
- *
- * - 4/29 昭和の日（固定）: 翌月切替判定に影響する唯一の固定祝日
- * - 4/30 振替: 4/29 が日曜の年（2029 年）
- * - 12/31 大納会: TSE 年末休場（固定）
- *
- * 2030 年以降に利用する場合は末尾に追記すること。
- */
-const JP_LATE_MONTH_NON_TRADING = new Set([
-  "2025-04-29",
-  "2026-04-29",
-  "2027-04-29",
-  "2028-04-29",
-  "2029-04-29",
-  "2029-04-30", // 4/29 が日曜のため振替
-  "2025-12-31",
-  "2026-12-31",
-  "2027-12-31",
-  "2028-12-31",
-  "2029-12-31",
-]);
-
-function isBusinessDay(year: number, month: number, day: number): boolean {
-  const dow = new Date(year, month - 1, day).getDay();
-  if (dow === 0 || dow === 6) return false;
-  const key = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-  return !JP_LATE_MONTH_NON_TRADING.has(key);
-}
-
-function formatIsoDate(year: number, month: number, day: number): string {
-  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-}
-
-/**
- * 権利付き最終日（日）を返す。
- * = 月末最終営業日 - 2 営業日
- */
-function getKenriLastDay(year: number, month: number): number {
-  const lastCalendarDay = new Date(year, month, 0).getDate();
-  // 月末から遡って最終営業日を探す
-  let day = lastCalendarDay;
-  while (!isBusinessDay(year, month, day)) day--;
-  // そこからさらに 2 営業日戻る
-  let remaining = 2;
-  while (remaining > 0) {
-    day--;
-    if (isBusinessDay(year, month, day)) remaining--;
-  }
-  return day;
-}
-
-function getKenriLastDateForMonthId(monthId: string): string | null {
-  const match = monthId.match(/^(\d{4})-(\d{2})$/);
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  if (!Number.isInteger(year) || !Number.isInteger(month) || month < 1 || month > 12) return null;
-  return formatIsoDate(year, month, getKenriLastDay(year, month));
 }
 
 /**

--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -47,6 +47,12 @@ import {
   type CalendarCardMemo,
 } from "@/app/tools/_shared/yutai-selection";
 import { calculateSimpleYutaiEfficiency } from "@/app/tools/_shared/yutai-efficiency";
+import {
+  calculateNikkoCrossFee,
+  resolveCrossSellSide,
+  type NikkoCrossFee,
+} from "@/app/tools/_shared/yutai-cross-fee";
+import type { UpcomingKenriInfo } from "@/app/tools/_shared/yutai-kenri-date";
 import type { MonthlyYutaiCandidate, MonthlyYutaiPageData, NikkoCreditRecord } from "@/app/tools/yutai-candidates/types";
 
 type StatusFilter = "all" | "added" | "picked" | "passed" | "unselected";
@@ -188,6 +194,46 @@ function getRowEfficiency(
     benefitValueYen: cardMemo?.benefitValueYen ?? launchHint?.benefitValueYen,
   });
 }
+type RowCrossFee =
+  | { status: "ok"; fee: NikkoCrossFee; kenriLastDate: string }
+  | { status: "no_buy" }
+  | { status: "no_sell" };
+
+/**
+ * 行のクロス手数料（日興・制度信用買い→現引き ＋ 一般優先の売り）を概算する。
+ * 手数料を出せる場合のみ status:"ok"。買い/売りが組めない場合はその旨を返し、
+ * それ以外（候補でない・株価未取得・日興データ無し）は null（＝表示しない）。
+ */
+function getRowCrossFee(
+  row: DashboardRow,
+  requiredCapitalYen: number | undefined,
+  nikkoRecord: NikkoCreditRecord | undefined,
+  kenriInfoByMonth: Record<number, UpcomingKenriInfo>,
+): RowCrossFee | null {
+  if (!row.candidate || row.key.startsWith("memo:")) return null;
+  if (!requiredCapitalYen || !Number.isFinite(requiredCapitalYen)) return null;
+  if (!nikkoRecord) return null;
+  const kenri = kenriInfoByMonth[row.candidate.month];
+  if (!kenri) return null;
+
+  // 買い: 制度信用買い→現引き が前提。制度買い不可なら組めない。
+  if (!nikkoRecord.institutional_buy) return { status: "no_buy" };
+
+  const sellSide = resolveCrossSellSide({
+    generalShort: nikkoRecord.general_short,
+    institutionalShort: nikkoRecord.institutional_short,
+  });
+  if (!sellSide) return { status: "no_sell" };
+
+  const fee = calculateNikkoCrossFee({
+    tradeAmountYen: requiredCapitalYen,
+    holdingDays: kenri.daysFromToday,
+    sellSide,
+  });
+  if (!fee) return null;
+  return { status: "ok", fee, kenriLastDate: kenri.kenriLastDate };
+}
+
 // oneShareStartedAt（YYYY-MM 想定）から開始の年・月を取り出す。フリーテキストは null。
 function parseOneShareStart(value: string | undefined): { year: number; month: number } | null {
   const matched = value ? /^(\d{4})-(\d{2})$/.exec(value) : null;
@@ -221,7 +267,13 @@ const creditChipStyleByKind: Record<NikkoCreditBadgeKind, string> = {
   institutional: "chipInstitutional",
 };
 
-export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
+export default function ToolClient({
+  data,
+  kenriInfoByMonth,
+}: {
+  data: MonthlyYutaiPageData;
+  kenriInfoByMonth: Record<number, UpcomingKenriInfo>;
+}) {
   const { navigate, isPendingFor } = useRouterTransition();
   const searchParams = useSearchParams();
   // モバイル(<=720px, 下部ナビが出る幅)は詳細をビューポート固定にする。
@@ -902,6 +954,32 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
     );
   }
 
+  // 簡易効率セルの 2 段目: 日興クロス手数料の概算。
+  function renderCrossFeeLine(crossFee: RowCrossFee | null) {
+    if (!crossFee) return null;
+    if (crossFee.status === "no_buy") {
+      return <span style={styles.crossFeeMuted} title="制度信用買いが不可のため現引きクロスを組めません">買建不可</span>;
+    }
+    if (crossFee.status === "no_sell") {
+      return <span style={styles.crossFeeMuted} title="一般・制度とも信用売りが不可のためクロスを組めません">売建不可</span>;
+    }
+    const { fee, kenriLastDate } = crossFee;
+    const sellLabel = fee.sellSide === "general" ? "一般売" : "制度売";
+    const title =
+      `日興クロス手数料 概算 ${formatYen(fee.totalYen)}\n` +
+      `＝ 買方金利 ${formatYen(fee.buyInterestYen)}（制度買→現引）` +
+      ` ＋ 貸株料 ${formatYen(fee.sellLendingYen)}（${sellLabel}）\n` +
+      `約定 ${formatYen(fee.tradeAmountYen)} × ${fee.holdingDays}日（〜権利付最終日 ${kenriLastDate}）\n` +
+      `信用手数料・現引現渡は0円` +
+      (fee.hasReverseChargeRisk ? "。制度売りのため逆日歩は別途" : "");
+    return (
+      <span style={styles.crossFeeLine} title={title}>
+        手数料 ≈{formatYen(fee.totalYen)}
+        {fee.hasReverseChargeRisk ? <span style={styles.crossFeeWarn} title="逆日歩は別途発生し得る">＋逆日歩</span> : null}
+      </span>
+    );
+  }
+
   function renderNikkoCell(code: string) {
     if (!data.nikkoCredit) return <span style={styles.cellMuted}>-</span>;
     const badges = getNikkoCreditBadges(data.nikkoCredit.by_code[code]);
@@ -1408,6 +1486,12 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
                     filteredRows.map((row) => {
                       const acquired = acquiredByCode.get(row.code);
                       const efficiency = getRowEfficiency(row, cardMemos, stockPriceByCode, rowLaunchDisplayByKey);
+                      const crossFee = getRowCrossFee(
+                        row,
+                        efficiency?.requiredCapitalYen,
+                        data.nikkoCredit?.by_code[row.code],
+                        kenriInfoByMonth,
+                      );
                       const isSelected = row.key === selectedRowKey;
                       const rowStyle = isSelected
                         ? styles.trSelected
@@ -1433,16 +1517,19 @@ export default function ToolClient({ data }: { data: MonthlyYutaiPageData }) {
                           </td>
                           <td style={styles.td}>{formatMonths(row.months)}</td>
                           <td style={styles.td}>
-                            {efficiency ? (
-                              <span
-                                style={styles.chipEfficiency}
-                                title={"必要資金: " + formatYen(efficiency.requiredCapitalYen)}
-                              >
-                                {formatEfficiencyPercent(efficiency.efficiencyPercent)}
-                              </span>
-                            ) : (
-                              <span style={styles.cellMuted}>-</span>
-                            )}
+                            <div style={styles.efficiencyCell}>
+                              {efficiency ? (
+                                <span
+                                  style={styles.chipEfficiency}
+                                  title={"必要資金: " + formatYen(efficiency.requiredCapitalYen)}
+                                >
+                                  {formatEfficiencyPercent(efficiency.efficiencyPercent)}
+                                </span>
+                              ) : (
+                                <span style={styles.cellMuted}>-</span>
+                              )}
+                              {renderCrossFeeLine(crossFee)}
+                            </div>
                           </td>
                           <td style={styles.td}>{renderNikkoCell(row.code)}</td>
                           <td style={styles.td}>{renderSbiCell(row.code)}</td>
@@ -2653,6 +2740,29 @@ const styles: Record<string, React.CSSProperties> = {
     color: "#c2410c",
     fontWeight: 800,
     border: "1px solid rgba(249,115,22,0.22)",
+  },
+  efficiencyCell: {
+    // 1 段目: 簡易効率チップ / 2 段目: クロス手数料
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: 3,
+  },
+  crossFeeLine: {
+    fontSize: 11,
+    color: "#475569",
+    whiteSpace: "nowrap",
+    cursor: "help",
+  },
+  crossFeeMuted: {
+    fontSize: 11,
+    color: "#94a3b8",
+    whiteSpace: "nowrap",
+  },
+  crossFeeWarn: {
+    marginLeft: 3,
+    fontSize: 10,
+    color: "#b45309",
   },
   addedChip: {
     ...baseChip,

--- a/app/tools/yutai-dashboard/page.tsx
+++ b/app/tools/yutai-dashboard/page.tsx
@@ -9,6 +9,22 @@ import {
 } from "@/app/tools/yutai-candidates/data-loader";
 import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 import { getYutaiDashboardPath } from "@/lib/premium-navigation";
+import { getUpcomingKenriInfoByMonth } from "@/app/tools/_shared/yutai-kenri-date";
+
+/** JST の今日の年・月・日を返す */
+function getJstToday(): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+  return {
+    year: Number(parts.find((p) => p.type === "year")?.value ?? "0"),
+    month: Number(parts.find((p) => p.type === "month")?.value ?? "0"),
+    day: Number(parts.find((p) => p.type === "day")?.value ?? "0"),
+  };
+}
 
 export const dynamic = "force-dynamic";
 
@@ -44,5 +60,7 @@ export default async function Page({ searchParams }: PageProps) {
   const data = params?.month === ALL_MONTHS_ID
     ? await loadMonthlyYutaiAllMonthsPageData()
     : await loadMonthlyYutaiPageData(params?.month);
-  return <ToolClient data={data} />;
+  // 権利月ごとの「今日→権利付最終日」の暦日数（クロス手数料の保有日数に使う）
+  const kenriInfoByMonth = getUpcomingKenriInfoByMonth(getJstToday());
+  return <ToolClient data={data} kenriInfoByMonth={kenriInfoByMonth} />;
 }


### PR DESCRIPTION
## 概要
優待ダッシュボードの「簡易効率」列の2段目に、**その日購入した場合の日興（SMBC日興証券）クロス取引の概算手数料**を表示する。

## 手数料モデル
- **買い**: 制度信用買い → 現引き（信用委託手数料・現引き手数料は0円、買方金利のみ）
- **売り**: 一般信用売りを優先（`general_short`、逆日歩なし）／不可なら制度信用売り（`institutional_short`、逆日歩は別途の旨を注記）
- **保有日数**: 今日 → 権利付最終日（権利月の月末の2営業日前）の暦日数
  - 権利確定日は月末締め前提の近似。15日・20日締め等はズレる（対象外・割り切り）
- **率**（2026-07時点の日興公式値、`yutai-cross-fee.ts` の定数に集約・改定時はここだけ更新）
  - 制度信用 買方金利: 年2.54%
  - 制度信用 貸株料: 年1.15%
  - 一般信用 貸株料: 年1.90%

計算: `手数料 = 約定金額 × 年率 × 日数 ÷ 365`（買方金利＋貸株料）

## 表示
- 2段目に `手数料 ≈¥XXX`。制度売り時は `＋逆日歩` を付記
- 内訳（買方金利・貸株料・約定金額・保有日数・権利付最終日・逆日歩注記）は title ツールチップ
- 買い建て不可（制度買い不可）→ `買建不可`、売り建て両方不可 → `売建不可`

## 実装
- `_shared/yutai-kenri-date.ts`: 権利付最終日ロジックを `data-loader` から切り出して共有化＋「今日→次回権利付最終日」の暦日数を算出（サーバー/クライアント両用の純粋関数）
- `_shared/yutai-cross-fee.ts`: 率定数・売り建て区分の解決・手数料計算
- `page.tsx`: 月別の権利付最終日情報を算出し `ToolClient` へ props で渡す
- `ToolClient`: 簡易効率セルを2段構成にして描画

## テスト・確認
- 新規ユニットテスト: `yutai-cross-fee.test.ts` / `yutai-kenri-date.test.ts`
- `npx tsc --noEmit` クリーン、`eslint` クリーン、`vitest` 77件パス（既存含む・data-loader リファクタの回帰なし）

## 注意（数値の正確性）
率は2026-07時点の公式値を反映していますが変動します。実運用前に日興口座の現行値と突き合わせ、必要なら `NIKKO_CROSS_FEE_RATES` を更新してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)