### PR TITLE
feat(yutai-dashboard): display benefit metadata

### DIFF
--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -138,6 +138,29 @@ function formatYen(value: number) {
   return `¥${Math.round(value).toLocaleString("ja-JP")}`;
 }
 
+function formatPercent(value: number) {
+  return `${value.toLocaleString("ja-JP", { maximumFractionDigits: 2 })}%`;
+}
+
+function isSamePercentValue(item: YutaiLaunchDisplayItem, value: number) {
+  return item.unit === "%" && typeof item.quantity === "number" && Math.abs(item.quantity - value) < 0.0001;
+}
+
+function formatDiscountMetadata(item: YutaiLaunchDisplayItem) {
+  if (item.discountTerms?.length) {
+    return item.discountTerms
+      .map((term) => {
+        const suffix = [term.label, term.appliesTo].filter(Boolean).join("・");
+        return suffix ? `割引率 ${formatPercent(term.ratePct)}（${suffix}）` : `割引率 ${formatPercent(term.ratePct)}`;
+      })
+      .join(" / ");
+  }
+  if (typeof item.discountRatePct === "number" && !isSamePercentValue(item, item.discountRatePct)) {
+    return `割引率 ${formatPercent(item.discountRatePct)}`;
+  }
+  return null;
+}
+
 function formatEfficiencyPercent(value: number) {
   return `${value.toLocaleString("ja-JP", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
 }
@@ -174,6 +197,8 @@ function formatBenefitItem(item: YutaiLaunchDisplayItem) {
   const parts = [item.label];
   if (typeof item.officialValueYen === "number") parts.push(formatYen(item.officialValueYen));
   if (typeof item.quantity === "number" && item.unit) parts.push(`${item.quantity.toLocaleString("ja-JP")}${item.unit}`);
+  const discountMetadata = formatDiscountMetadata(item);
+  if (discountMetadata) parts.push(discountMetadata);
   if (item.valuationPolicy === "user_estimate_required") parts.push("要評価");
   return parts.join(" / ");
 }

--- a/app/tools/yutai-dashboard/__tests__/launch-display.test.ts
+++ b/app/tools/yutai-dashboard/__tests__/launch-display.test.ts
@@ -59,6 +59,63 @@ describe("parseYutaiLaunchDisplaySnapshot", () => {
     });
   });
 
+
+  it("割引率メタデータを任意フィールドとして受け取る", () => {
+    const snapshot = parseYutaiLaunchDisplaySnapshot({
+      schema_version: 1,
+      month: "2026-09",
+      record_count: 1,
+      counts: { conditions_available: 1, auto_calculable: 0, requires_user_valuation: 1 },
+      generated_at: "2026-07-22T14:57:25.239015Z",
+      records: [
+        {
+          month: "2026-09",
+          code: "9202",
+          company_name: "ANA",
+          display_status: "conditions_available",
+          calculation_status: "user_input_required",
+          requires_user_valuation: true,
+          programs: [
+            {
+              program_id: "discount",
+              label: "割引",
+              rights_months: [3, 9],
+              tiers: [
+                {
+                  minimum_shares: 100,
+                  required_holding_months: 0,
+                  groups: [
+                    {
+                      mode: "all",
+                      allow_repeated_choices: false,
+                      items: [
+                        {
+                          label: "運賃割引",
+                          kind: "discount",
+                          official_value_yen: null,
+                          valuation_policy: "user_estimate_required",
+                          discount_rate_pct: 50,
+                          discount_terms: [
+                            { rate_pct: 50, label: "株主優待番号", applies_to: "国内線" },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const item = buildLaunchDisplayByKey(snapshot).get("9202:9")?.programs[0].tiers[0].groups[0].items[0];
+    expect(item?.discountRatePct).toBe(50);
+    expect(item?.discountTerms).toEqual([{ label: "株主優待番号", ratePct: 50, appliesTo: "国内線" }]);
+    expect(getLaunchDisplayHint(buildLaunchDisplayByKey(snapshot).get("9202:9"))).toBeNull();
+  });
+
   it.each([null, {}, { schema_version: 2, records: [] }, { schema_version: 1, records: [] }])("必須メタデータがない応答は拒否する: %o", (value) => {
     expect(parseYutaiLaunchDisplaySnapshot(value)).toBeNull();
   });

--- a/app/tools/yutai-dashboard/launch-display.ts
+++ b/app/tools/yutai-dashboard/launch-display.ts
@@ -5,7 +5,16 @@ export type YutaiLaunchDisplayItem = {
   valuationPolicy: "face_value" | "official_equivalent" | "user_estimate_required";
   quantity: number | null;
   unit: string | null;
+  discountRatePct: number | null;
+  discountTerms: YutaiLaunchDisplayDiscountTerm[] | null;
   notes: string | null;
+};
+
+
+export type YutaiLaunchDisplayDiscountTerm = {
+  label: string | null;
+  ratePct: number;
+  appliesTo: string | null;
 };
 
 export type YutaiLaunchDisplayGroup = {
@@ -81,6 +90,15 @@ function optionalNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function parseDiscountTerm(value: unknown): YutaiLaunchDisplayDiscountTerm | null {
+  if (!isRecord(value) || typeof value.rate_pct !== "number" || !Number.isFinite(value.rate_pct)) return null;
+  return {
+    label: optionalString(value.label),
+    ratePct: value.rate_pct,
+    appliesTo: optionalString(value.applies_to),
+  };
+}
+
 function parseItem(value: unknown): YutaiLaunchDisplayItem | null {
   if (!isRecord(value) || typeof value.label !== "string" || typeof value.kind !== "string" || typeof value.valuation_policy !== "string") {
     return null;
@@ -94,6 +112,10 @@ function parseItem(value: unknown): YutaiLaunchDisplayItem | null {
     valuationPolicy: value.valuation_policy as YutaiLaunchDisplayItem["valuationPolicy"],
     quantity: optionalNumber(value.quantity),
     unit: optionalString(value.unit),
+    discountRatePct: optionalNumber(value.discount_rate_pct),
+    discountTerms: Array.isArray(value.discount_terms)
+      ? value.discount_terms.map(parseDiscountTerm).filter((term): term is YutaiLaunchDisplayDiscountTerm => term !== null)
+      : null,
     notes: optionalString(value.notes),
   };
 }

--- a/docs/decision-log/2026-07-26-yutai-launch-display-benefit-metadata.md
+++ b/docs/decision-log/2026-07-26-yutai-launch-display-benefit-metadata.md
@@ -1,0 +1,35 @@
+# 2026-07-26 優待公式条件の割引率・長期保有メタデータ表示
+
+## 背景
+
+- market_info 側で優待JSONの正規化を進める中で、ANA などの割引率情報や長期保有条件を mini-tools でも落とさず扱う必要が出た
+- 一方で、割引率は利用金額・利用条件に依存するため、簡易優待効率の円換算に自動算入すると過大評価になりやすい
+
+## 今回決めたこと
+
+- launch-display の優待 item は任意フィールドとして `discount_rate_pct` と `discount_terms` を受け取れるようにする
+- 割引率メタデータは詳細パネルの公式条件に表示するが、簡易優待効率の優待価値には自動算入しない
+- 長期保有条件は既存の tier `required_holding_months` を使って表示する
+
+## 判断理由
+
+- parser が先に受け口を持つことで、market_info 側の公開payload拡張を段階的に進められる
+- 割引率を利回り計算に使うには、利用額・対象商品・併用条件などユーザー別の前提が必要になる
+- 既存の `required_holding_months` はtier単位の条件としてすでに表示でき、現時点では新しい保存キーを増やさずに長期条件を確認できる
+
+## 影響範囲
+
+- `/tools/yutai-dashboard` の公式条件詳細表示
+- `/api/yutai/launch-display` のpayload parser
+- 簡易優待効率の計算式には影響しない
+
+## 残課題
+
+- `has_long_term_benefit` / `requires_long_term_holding` のような銘柄単位の集計表示をmini-toolsに出すかは後続で判断する
+- `discount_terms` を複数条件で見やすく表示するUIは、実データ公開後の見え方を確認して必要なら調整する
+
+## 関連
+
+- Issue:
+- PR:
+- 参照 docs: [優待ダッシュボード 仕様](../specs/tools/yutai-dashboard.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 
 設計・方針・トレードオフの判断理由を記録します。
 
+- [2026-07-26 優待公式条件の割引率・長期保有メタデータ表示](./decision-log/2026-07-26-yutai-launch-display-benefit-metadata.md)
 - [2026-07-26 優待ダッシュボードの日興クロス手数料 概算表示](./decision-log/2026-07-26-yutai-dashboard-cross-fee.md)
 - [2026-07-23 優待公式条件をPremium認証付きサーバールート経由にする](./decision-log/2026-07-23-yutai-launch-display-private-proxy.md)
 - [2026-07-20 優待株価JSONを24時間private HTTPキャッシュする](./decision-log/2026-07-20-yutai-stock-price-private-http-cache.md)

--- a/docs/specs/tools/yutai-dashboard.md
+++ b/docs/specs/tools/yutai-dashboard.md
@@ -75,6 +75,8 @@
 - ピック / パス / カードメモ: `_shared/yutai-selection.ts`（`yutai-candidates` と同一キーを共有）
 
 - 簡易効率の最低投資金額: 月次候補の minimum_investment_yen（みんかぶ由来の取得済みデータ）。必要株数・優待価値はユーザー入力であり、この段階では OCR や追加スクレイピングを行わない
+- 公式条件APIの割引率メタデータ（`discount_rate_pct` / `discount_terms`）は詳細パネルで表示するが、簡易優待効率の優待価値には自動算入しない。割引は利用条件・購入額に依存し、円換算にユーザー判断が必要なため
+- 公式条件APIの長期保有条件は tier の `required_holding_months` として表示する。長期保有特典の有無や必須条件の集計表示は後続検討とし、現時点ではtier別条件の表示に留める
 
 ### 保存先
 
@@ -152,6 +154,7 @@
 - UAT: [優待ダッシュボード UAT](../../uat/yutai-dashboard.md)
 - Plan: [優待統合ダッシュボード（PC）実装計画](../../plans/yutai-dashboard-plan.md)
 - Decision Log:
+  - [2026-07-26 優待公式条件の割引率・長期保有メタデータ表示](../../decision-log/2026-07-26-yutai-launch-display-benefit-metadata.md)
   - [2026-07-26 日興クロス手数料の概算表示](../../decision-log/2026-07-26-yutai-dashboard-cross-fee.md)
   - [2026-07-18 簡易優待効率MVP](../../decision-log/2026-07-18-yutai-dashboard-simple-efficiency.md)
   - [2026-07-20 優待効率へのPrivate実株価適用](../../decision-log/2026-07-20-yutai-dashboard-live-stock-price-efficiency.md)


### PR DESCRIPTION
## 概要

優待ダッシュボードの公式条件表示で、market_info の優待JSON正規化から来る割引率・長期保有メタデータを受けられるようにします。

## 変更内容

- launch-display parser に任意フィールド `discount_rate_pct` / `discount_terms` を追加
- 詳細パネルの公式条件に割引率メタデータを表示
- 割引率は簡易優待効率の優待価値へ自動算入しない方針を仕様書・decision-logへ記録
- 長期保有条件は既存の tier `required_holding_months` 表示を継続する方針を記録

## 確認項目

- `npm test -- app/tools/yutai-dashboard/__tests__/launch-display.test.ts app/api/yutai/launch-display/__tests__/route.test.ts`
- `npm run lint`
- `npm test`
- `npm run build`

## 関連 Issue

- なし
