### PR TITLE
fix(yutai-dashboard): align discount terms contract

### DIFF
--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -150,8 +150,14 @@ function formatDiscountMetadata(item: YutaiLaunchDisplayItem) {
   if (item.discountTerms?.length) {
     return item.discountTerms
       .map((term) => {
-        const suffix = [term.label, term.appliesTo].filter(Boolean).join("・");
-        return suffix ? `割引率 ${formatPercent(term.ratePct)}（${suffix}）` : `割引率 ${formatPercent(term.ratePct)}`;
+        const suffix = [
+          term.label,
+          typeof term.quantity === "number" && term.unit ? `${term.quantity.toLocaleString("ja-JP")}${term.unit}` : null,
+          term.notes,
+        ]
+          .filter(Boolean)
+          .join("・");
+        return suffix ? `割引率 ${formatPercent(term.discountRatePct)}（${suffix}）` : `割引率 ${formatPercent(term.discountRatePct)}`;
       })
       .join(" / ");
   }

--- a/app/tools/yutai-dashboard/__tests__/launch-display.test.ts
+++ b/app/tools/yutai-dashboard/__tests__/launch-display.test.ts
@@ -96,7 +96,7 @@ describe("parseYutaiLaunchDisplaySnapshot", () => {
                           valuation_policy: "user_estimate_required",
                           discount_rate_pct: 50,
                           discount_terms: [
-                            { rate_pct: 50, label: "株主優待番号", applies_to: "国内線" },
+                            { discount_rate_pct: 50, label: "株主優待番号", quantity: 1, unit: "枚", notes: "国内線" },
                           ],
                         },
                       ],
@@ -112,8 +112,59 @@ describe("parseYutaiLaunchDisplaySnapshot", () => {
 
     const item = buildLaunchDisplayByKey(snapshot).get("9202:9")?.programs[0].tiers[0].groups[0].items[0];
     expect(item?.discountRatePct).toBe(50);
-    expect(item?.discountTerms).toEqual([{ label: "株主優待番号", ratePct: 50, appliesTo: "国内線" }]);
+    expect(item?.discountTerms).toEqual([{ label: "株主優待番号", discountRatePct: 50, quantity: 1, unit: "枚", notes: "国内線" }]);
     expect(getLaunchDisplayHint(buildLaunchDisplayByKey(snapshot).get("9202:9"))).toBeNull();
+  });
+
+
+  it("移行期間の旧discount_termsフィールドも受け取る", () => {
+    const snapshot = parseYutaiLaunchDisplaySnapshot({
+      schema_version: 1,
+      month: "2026-09",
+      record_count: 1,
+      counts: { conditions_available: 1, auto_calculable: 0, requires_user_valuation: 1 },
+      generated_at: "2026-07-22T14:57:25.239015Z",
+      records: [
+        {
+          month: "2026-09",
+          code: "9202",
+          company_name: "ANA",
+          display_status: "conditions_available",
+          calculation_status: "user_input_required",
+          requires_user_valuation: true,
+          programs: [
+            {
+              program_id: "discount",
+              label: "割引",
+              rights_months: [9],
+              tiers: [
+                {
+                  minimum_shares: 100,
+                  required_holding_months: 0,
+                  groups: [
+                    {
+                      mode: "all",
+                      allow_repeated_choices: false,
+                      items: [
+                        {
+                          label: "運賃割引",
+                          kind: "discount",
+                          valuation_policy: "user_estimate_required",
+                          discount_terms: [{ rate_pct: 50, label: "旧形式", applies_to: "国内線" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const item = buildLaunchDisplayByKey(snapshot).get("9202:9")?.programs[0].tiers[0].groups[0].items[0];
+    expect(item?.discountTerms).toEqual([{ label: "旧形式", discountRatePct: 50, quantity: null, unit: null, notes: "国内線" }]);
   });
 
   it.each([null, {}, { schema_version: 2, records: [] }, { schema_version: 1, records: [] }])("必須メタデータがない応答は拒否する: %o", (value) => {

--- a/app/tools/yutai-dashboard/launch-display.ts
+++ b/app/tools/yutai-dashboard/launch-display.ts
@@ -13,8 +13,10 @@ export type YutaiLaunchDisplayItem = {
 
 export type YutaiLaunchDisplayDiscountTerm = {
   label: string | null;
-  ratePct: number;
-  appliesTo: string | null;
+  discountRatePct: number;
+  quantity: number | null;
+  unit: string | null;
+  notes: string | null;
 };
 
 export type YutaiLaunchDisplayGroup = {
@@ -91,11 +93,15 @@ function optionalNumber(value: unknown): number | null {
 }
 
 function parseDiscountTerm(value: unknown): YutaiLaunchDisplayDiscountTerm | null {
-  if (!isRecord(value) || typeof value.rate_pct !== "number" || !Number.isFinite(value.rate_pct)) return null;
+  if (!isRecord(value)) return null;
+  const discountRatePct = optionalNumber(value.discount_rate_pct) ?? optionalNumber(value.rate_pct);
+  if (discountRatePct === null) return null;
   return {
     label: optionalString(value.label),
-    ratePct: value.rate_pct,
-    appliesTo: optionalString(value.applies_to),
+    discountRatePct,
+    quantity: optionalNumber(value.quantity),
+    unit: optionalString(value.unit),
+    notes: optionalString(value.notes) ?? optionalString(value.applies_to),
   };
 }
 


### PR DESCRIPTION
## 概要

market_info / market-info-api の `discount_terms` 契約に合わせて、mini-tools 側のparserと表示を補正します。

## 変更内容

- `discount_terms[].discount_rate_pct` を読むように修正
- term の補足表示を `label` / `quantity + unit` / `notes` に変更
- launch-display parser test を公開契約と同じフィールド名へ更新

## 確認項目

- `npm test -- app/tools/yutai-dashboard/__tests__/launch-display.test.ts app/api/yutai/launch-display/__tests__/route.test.ts`
- `npm run lint`

## 関連 Issue

- なし
