### PR TITLE
test(yutai-dashboard): getRowCrossType を純関数化し単体テスト追加

### DIFF
--- a/app/tools/yutai-dashboard/ToolClient.tsx
+++ b/app/tools/yutai-dashboard/ToolClient.tsx
@@ -12,6 +12,7 @@ import {
   type MemoEditDraft,
 } from "@/app/tools/_shared/yutai-memo-edit";
 import { buildCalendarCells } from "./calendar";
+import { getRowCrossType } from "./cross-strategy";
 import {
   buildStockPriceByCode,
   parseYutaiStockPriceSnapshot,
@@ -238,25 +239,6 @@ function getRowEfficiency(
     requiredShares: cardMemo?.requiredShares ?? launchHint?.requiredShares,
     benefitValueYen: cardMemo?.benefitValueYen ?? launchHint?.benefitValueYen,
   });
-}
-
-/**
- * 行のクロス戦略の実効値。手動メモがあればその値、無ければ公式条件から導出する。
- * - メモあり: ユーザー設定値をそのまま使う（derived=false）。
- * - メモ無し＋公式レコードあり＋長期特典なし: 戦略判断が不要なので「長期優遇なし」を導出（derived=true）。
- * - それ以外（特典あり未トリアージ／レコード無し＝不明）: null＝未設定のまま。
- * 公式レコードが無い（undefined）銘柄は「長期特典なし」と断定せず未設定に残す。
- */
-function getRowCrossType(
-  row: DashboardRow,
-  launchDisplayByKey: ReadonlyMap<string, YutaiLaunchDisplayRecord>,
-): { value: CrossType; derived: boolean } | null {
-  if (row.memo) return { value: row.memo.crossType, derived: false };
-  const record = row.candidate ? launchDisplayByKey.get(`${row.code}:${row.candidate.month}`) : undefined;
-  if (record && !getLongTermFlags(record).benefit) {
-    return { value: "長期優遇なし", derived: true };
-  }
-  return null;
 }
 
 type RowCrossFee = {

--- a/app/tools/yutai-dashboard/__tests__/cross-strategy.test.ts
+++ b/app/tools/yutai-dashboard/__tests__/cross-strategy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { getRowCrossType, type CrossStrategyRowInput } from "../cross-strategy";
+import { type YutaiLaunchDisplayRecord } from "../launch-display";
+
+function recordWithHoldingMonths(monthsPerTier: number[]): YutaiLaunchDisplayRecord {
+  return {
+    month: "2026-09",
+    code: "1234",
+    companyName: "テスト",
+    displayStatus: "conditions_available",
+    calculationStatus: "auto_calculable",
+    requiresUserValuation: false,
+    hasLongTermBenefit: monthsPerTier.some((month) => month > 0),
+    requiresLongTermHolding: monthsPerTier.length > 0 && monthsPerTier.every((month) => month > 0),
+    longTermRequiredHoldingMonths: [...new Set(monthsPerTier.filter((month) => month > 0))].sort((a, b) => a - b),
+    longTermBenefitTiers: [],
+    normalizedStatus: null,
+    normalizedAsOfDate: null,
+    notes: null,
+    programs: [
+      {
+        programId: "p",
+        label: "優待",
+        rightsMonths: [9],
+        notes: null,
+        tiers: monthsPerTier.map((m, i) => ({
+          minimumShares: 100 * (i + 1),
+          maximumShares: null,
+          requiredHoldingMonths: m,
+          groups: [],
+        })),
+      },
+    ],
+  };
+}
+
+const candidateRow: CrossStrategyRowInput = {
+  code: "1234",
+  memo: null,
+  candidate: { month: 9 },
+};
+
+describe("getRowCrossType", () => {
+  it("メモがあれば手動値をそのまま返す（derived=false）", () => {
+    const byKey = new Map([["1234:9", recordWithHoldingMonths([0, 0])]]);
+    const row: CrossStrategyRowInput = { ...candidateRow, memo: { crossType: "連続クロス" } };
+    // 公式が長期特典なしでも、手動値が優先される
+    expect(getRowCrossType(row, byKey)).toEqual({ value: "連続クロス", derived: false });
+  });
+
+  it("メモ無し×公式レコードあり×長期特典なし: 長期優遇なしを導出（derived=true）", () => {
+    const byKey = new Map([["1234:9", recordWithHoldingMonths([0, 0])]]);
+    expect(getRowCrossType(candidateRow, byKey)).toEqual({ value: "長期優遇なし", derived: true });
+  });
+
+  it("メモ無し×公式レコードあり×長期特典あり: 未トリアージなので未設定（null）", () => {
+    const byKey = new Map([["1234:9", recordWithHoldingMonths([0, 12])]]);
+    expect(getRowCrossType(candidateRow, byKey)).toBeNull();
+  });
+
+  it("メモ無し×公式レコード無し（不明）: 断定せず未設定（null）", () => {
+    // getLongTermFlags(undefined) が benefit:false でも、レコード不在は導出しない
+    expect(getRowCrossType(candidateRow, new Map())).toBeNull();
+  });
+
+  it("メモ無し×候補行でない（candidate=null）: 未設定（null）", () => {
+    const byKey = new Map([["1234:9", recordWithHoldingMonths([0, 0])]]);
+    const row: CrossStrategyRowInput = { ...candidateRow, candidate: null };
+    expect(getRowCrossType(row, byKey)).toBeNull();
+  });
+
+  it("全月ビュー相当（空Map）: 公式判定が働かず未設定（null）", () => {
+    expect(getRowCrossType(candidateRow, new Map())).toBeNull();
+  });
+});

--- a/app/tools/yutai-dashboard/cross-strategy.ts
+++ b/app/tools/yutai-dashboard/cross-strategy.ts
@@ -1,0 +1,34 @@
+import type { CrossType } from "@/app/tools/yutai-memo/types";
+import { getLongTermFlags, type YutaiLaunchDisplayRecord } from "./launch-display";
+
+/**
+ * getRowCrossType が必要とする行の最小情報。ToolClient の DashboardRow は
+ * 構造的にこの型を満たすため、そのまま渡せる（純関数として単体テストできるよう
+ * client component への依存を持たせない）。
+ */
+export type CrossStrategyRowInput = {
+  code: string;
+  memo: { crossType: CrossType } | null;
+  candidate: { month: number } | null;
+};
+
+/**
+ * 行のクロス戦略の実効値。手動メモがあればその値、無ければ公式条件から導出する。
+ * - メモあり: ユーザー設定値をそのまま使う（derived=false）。
+ * - メモ無し＋公式レコードあり＋長期特典なし: 戦略判断が不要なので「長期優遇なし」を導出（derived=true）。
+ * - それ以外（特典あり未トリアージ／レコード無し＝不明）: null＝未設定のまま。
+ * 公式レコードが無い（undefined）銘柄は「長期特典なし」と断定せず未設定に残す。
+ * なお全月ビューでは launchDisplayByKey が空で渡されるため、この導出は働かず未設定になる
+ * （launch-display は権利月単位のデータで、全月表示は per-month の公式条件を持たないため）。
+ */
+export function getRowCrossType(
+  row: CrossStrategyRowInput,
+  launchDisplayByKey: ReadonlyMap<string, YutaiLaunchDisplayRecord>,
+): { value: CrossType; derived: boolean } | null {
+  if (row.memo) return { value: row.memo.crossType, derived: false };
+  const record = row.candidate ? launchDisplayByKey.get(`${row.code}:${row.candidate.month}`) : undefined;
+  if (record && !getLongTermFlags(record).benefit) {
+    return { value: "長期優遇なし", derived: true };
+  }
+  return null;
+}

--- a/docs/decision-log/2026-07-29-yutai-dashboard-derive-cross-strategy.md
+++ b/docs/decision-log/2026-07-29-yutai-dashboard-derive-cross-strategy.md
@@ -24,13 +24,15 @@
 
 ## 影響範囲
 
+- `app/tools/yutai-dashboard/cross-strategy.ts`
+  - `getRowCrossType()` を純関数として実装（実効クロス戦略の導出。メモ優先、無ければ公式条件から導出）。単体テストは `__tests__/cross-strategy.test.ts`。
 - `app/tools/yutai-dashboard/ToolClient.tsx`
-  - `getRowCrossType()` を追加（実効クロス戦略の導出。メモ優先、無ければ公式条件から導出）。
-  - クロス戦略フィルタ（`filteredRows`）と表示セル（`renderCrossTypeCell`）の両方で導出値を使用。
+  - `getRowCrossType()` を import し、クロス戦略フィルタ（`filteredRows`）と表示セル（`renderCrossTypeCell`）の両方で導出値を使用。
   - 導出値は手動値と区別できるよう控えめ表示（`cellMuted`）＋ツールチップ。手動値は従来どおりチップ。
 - 仕込み月軸（`calendarRows`）は登録メモ限定のため対象外（現状維持）。
 - 詳細パネルのクロス戦略は `selectedRow.memo` 存在時のみ表示で従来どおり（導出値は出さない）。
 - 互換性: メモや保存データの形式は変更なし。表示・絞り込みのみの差分。
+- **全月ビューでは自動導出が働かない**: `rowLaunchDisplayByKey` は全月表示時に空 Map で渡されるため、メモ無し行は常に「未設定」となり「長期優遇なし」フィルタにも掛からない。launch-display は権利月単位のデータで全月表示が per-month 公式条件を持たない仕様に沿ったもので、既存の長/特チップと同じ挙動。自動導出は対象月を選択したときだけ働く。
 
 ## 残課題
 


### PR DESCRIPTION
PR #444 のセルフレビュー指摘へのフォローアップ。

## 変更内容

- **指摘2（テストギャップ）**: クロス戦略の実効値導出 `getRowCrossType` を `ToolClient.tsx` から `cross-strategy.ts` へ切り出し、client component 非依存の純関数化。`__tests__/cross-strategy.test.ts` で6ケースをカバー:
  - メモあり→手動値優先（derived=false）
  - メモ無し×レコードあり×特典なし→「長期優遇なし」導出（derived=true）
  - メモ無し×レコードあり×特典あり→未設定（null）
  - メモ無し×**レコード無し（不明）→断定せず未設定**（このPRの肝）
  - candidate=null→未設定
  - 全月ビュー相当（空Map）→未設定
- **指摘1（全月制約）**: 全月ビューでは `rowLaunchDisplayByKey` が空 Map のため自動導出が働かない制約を Decision Log に明記。

## テスト

- `npx tsc --noEmit` / `eslint` クリーン
- `npx vitest run app/tools/yutai-dashboard` 30 tests passed（既存24＋新規6）

## 補足

導出ロジック・UI 挙動そのものは #444 から不変。純関数抽出＋テスト＋docs追記のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)