### PR TITLE
feat(portfolio): review参照policyを表示

### DIFF
--- a/app/premium/portfolio/PortfolioDecision.tsx
+++ b/app/premium/portfolio/PortfolioDecision.tsx
@@ -181,6 +181,19 @@ function PolicyCard({ data }: { data: PortfolioData }) {
   );
 }
 
+export function reviewPolicyReferenceLabel(data: PortfolioData): string | null {
+  if (!data.review) return null;
+  const policyId = data.review.policyVersionId;
+  const policy = policyId ? data.policyHistory.find((item) => item.id === policyId) : null;
+  return policy ? `v${policy.versionNumber} / ${policy.status === "active" ? "active" : policy.status}` : policyId ? `未取得（${policyId.slice(0, 8)}…）` : "未紐付け（legacy review）";
+}
+
+function ReviewPolicyReference({ data }: { data: PortfolioData }) {
+  const label = reviewPolicyReferenceLabel(data);
+  if (!label) return null;
+  return <div><strong>review参照方針</strong><br />{label}</div>;
+}
+
 function ReflectionCard({ data }: { data: PortfolioData }) {
   const reflection = data.latestReflection;
   if (!reflection) {
@@ -232,6 +245,7 @@ export default function PortfolioDecision({ data }: { data: PortfolioData }) {
             <div><strong>保有基準日</strong><br />{formatDateTime(data.currentSnapshot?.asOf)}</div>
             <div><strong>review基準日</strong><br />{formatDateTime(data.review?.asOf)}</div>
             <div><strong>review状態</strong><br />{data.review?.status === "finalized" ? "確定" : data.review ? "下書き" : "未作成"}</div>
+            <ReviewPolicyReference data={data} />
           </div>
         </div>
       </Card>

--- a/app/premium/portfolio/data.test.ts
+++ b/app/premium/portfolio/data.test.ts
@@ -91,7 +91,7 @@ describe("portfolio data loader", () => {
           error: null,
         },
         stock_notes_portfolio_reviews: {
-          data: { id: "review-1", title: "8月棚卸し", status: "draft", as_of: "2026-08-14T00:02:00Z", new_capital_amount: "100000", summary: "分散を維持", allocation_policy: "押し目を待つ", updated_at: "2026-08-14T00:02:00Z" },
+          data: { id: "review-1", policy_version_id: "policy-2", title: "8月棚卸し", status: "draft", as_of: "2026-08-14T00:02:00Z", new_capital_amount: "100000", summary: "分散を維持", allocation_policy: "押し目を待つ", updated_at: "2026-08-14T00:02:00Z" },
           error: null,
         },
         stock_notes_portfolio_policy_versions: {
@@ -127,6 +127,7 @@ describe("portfolio data loader", () => {
     expect(data.dbPositions).toHaveLength(2);
     expect(data.dbPositions[1]).toMatchObject({ id: "position-2", accountName: null, accountId: "account-missing" });
     expect(data.review?.items[0]).toMatchObject({ stance: "hold", targetAllocationPct: 10, buyConditions: ["押し目"] });
+    expect(data.review?.policyVersionId).toBe("policy-2");
     expect(data.activePolicy).toMatchObject({ versionNumber: 2, status: "active", title: "高配当を軸に成長も重視" });
     expect(data.activePolicy?.rules[0]).toMatchObject({ dimension: "cycle_profile", targetKey: "cyclical", minPct: 70, maxPct: 70 });
     expect(data.latestReflection).toMatchObject({ policyChangeRecommended: true, lessons: ["分類の鮮度を確認する"] });
@@ -161,7 +162,7 @@ describe("portfolio data loader", () => {
           error: null,
         },
         stock_notes_portfolio_reviews: {
-          data: { id: "review-1", title: "8月棚卸し", status: "draft", as_of: "2026-08-14T00:02:00Z", new_capital_amount: null, summary: null, allocation_policy: null, updated_at: "2026-08-14T00:02:00Z" },
+          data: { id: "review-1", policy_version_id: null, title: "8月棚卸し", status: "draft", as_of: "2026-08-14T00:02:00Z", new_capital_amount: null, summary: null, allocation_policy: null, updated_at: "2026-08-14T00:02:00Z" },
           error: null,
         },
         stock_notes_portfolio_review_items: {

--- a/app/premium/portfolio/data.ts
+++ b/app/premium/portfolio/data.ts
@@ -337,7 +337,19 @@ export async function loadPortfolio(supabase: SupabaseClient): Promise<Portfolio
     .returns<PolicyRow[]>();
   if (policiesError) throw policiesError;
 
-  const policyRows = policyData ?? [];
+  let policyRows = policyData ?? [];
+  const referencedPolicyId = reviewRow?.policy_version_id;
+  if (referencedPolicyId && !policyRows.some((row) => row.id === referencedPolicyId)) {
+    const { data: referencedPolicy, error: referencedPolicyError } = await supabase
+      .from("stock_notes_portfolio_policy_versions")
+      .select(
+        "id, version_number, status, title, objective, time_horizon, income_priority, capital_growth_priority, risk_statement, cash_policy, buy_policy, sell_policy, principles, constraints, change_reason, based_on_policy_id, effective_from, created_at, updated_at",
+      )
+      .eq("id", referencedPolicyId)
+      .maybeSingle<PolicyRow>();
+    if (referencedPolicyError) throw referencedPolicyError;
+    if (referencedPolicy) policyRows = [...policyRows, referencedPolicy];
+  }
   const policyIds = policyRows.map((row) => row.id);
   const { data: policyRuleData, error: policyRulesError } = policyIds.length > 0
     ? await supabase

--- a/app/premium/portfolio/data.ts
+++ b/app/premium/portfolio/data.ts
@@ -57,6 +57,7 @@ type PositionRow = {
 
 type ReviewRow = {
   id: string;
+  policy_version_id: string | null;
   title: string;
   status: PortfolioReview["status"];
   as_of: string;
@@ -318,7 +319,7 @@ export async function loadPortfolio(supabase: SupabaseClient): Promise<Portfolio
   }
   const { data: reviewRow, error: reviewError } = await supabase
     .from("stock_notes_portfolio_reviews")
-    .select("id, title, status, as_of, new_capital_amount, summary, allocation_policy, updated_at")
+    .select("id, policy_version_id, title, status, as_of, new_capital_amount, summary, allocation_policy, updated_at")
     .eq("portfolio_id", portfolio.id)
     .order("as_of", { ascending: false })
     .limit(1)
@@ -446,6 +447,7 @@ export async function loadPortfolio(supabase: SupabaseClient): Promise<Portfolio
   if (reviewRow) {
     review = {
       id: reviewRow.id,
+      policyVersionId: reviewRow.policy_version_id,
       title: reviewRow.title,
       status: reviewRow.status,
       asOf: reviewRow.as_of,

--- a/app/premium/portfolio/decision.test.ts
+++ b/app/premium/portfolio/decision.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getPortfolioDecisionState } from "./PortfolioDecision";
+import { getPortfolioDecisionState, reviewPolicyReferenceLabel } from "./PortfolioDecision";
 import type { PortfolioData } from "./types";
 
 const baseData: PortfolioData = {
@@ -10,7 +10,7 @@ const baseData: PortfolioData = {
   dbPositionSnapshot: null,
   positions: [],
   dbPositions: [],
-  review: { id: "review-1", title: "レビュー", status: "draft", asOf: "2026-08-14T00:02:00Z", newCapitalAmount: null, summary: null, allocationPolicy: null, updatedAt: "2026-08-14T00:02:00Z", items: [] },
+  review: { id: "review-1", policyVersionId: null, title: "レビュー", status: "draft", asOf: "2026-08-14T00:02:00Z", newCapitalAmount: null, summary: null, allocationPolicy: null, updatedAt: "2026-08-14T00:02:00Z", items: [] },
   activePolicy: null,
   policyHistory: [],
   latestReflection: null,
@@ -45,5 +45,35 @@ describe("portfolio decision view state", () => {
       ...baseData,
       currentSnapshot: { ...baseData.currentSnapshot!, asOf: "2026-08-20T00:00:00Z" },
     }).label).toBe("要再レビュー");
+  });
+
+  it("reviewが参照したpolicy versionを表示できる", () => {
+    expect(reviewPolicyReferenceLabel({
+      ...baseData,
+      review: { ...baseData.review!, policyVersionId: "policy-2" },
+      policyHistory: [{
+        id: "policy-2",
+        versionNumber: 2,
+        status: "active",
+        title: "v2",
+        objective: null,
+        timeHorizon: null,
+        incomePriority: null,
+        capitalGrowthPriority: null,
+        riskStatement: null,
+        cashPolicy: null,
+        buyPolicy: null,
+        sellPolicy: null,
+        principles: [],
+        constraints: [],
+        changeReason: null,
+        basedOnPolicyId: null,
+        effectiveFrom: null,
+        createdAt: "2026-08-14T00:00:00Z",
+        updatedAt: "2026-08-14T00:00:00Z",
+        rules: [],
+      }],
+    })).toBe("v2 / active");
+    expect(reviewPolicyReferenceLabel(baseData)).toBe("未紐付け（legacy review）");
   });
 });

--- a/app/premium/portfolio/types.ts
+++ b/app/premium/portfolio/types.ts
@@ -53,6 +53,7 @@ export type PortfolioReviewItem = {
 
 export type PortfolioReview = {
   id: string;
+  policyVersionId: string | null;
   title: string;
   status: "draft" | "finalized";
   asOf: string;

--- a/docs/decision-log/2026-08-22-portfolio-what-and-policy-reflection-display.md
+++ b/docs/decision-log/2026-08-22-portfolio-what-and-policy-reflection-display.md
@@ -15,6 +15,7 @@ MiniToolsは主入力画面ではなく、stock-notes API/DBに保存された�
 - MiniToolsからpolicyのactive化、reviewのfinalize、reflection保存は行わない
 - 今回は新規APIや新規DBテーブルを追加せず、既存Supabaseの本人データを読み取る
 - MiniToolsとstock-notesの集計定義を別実装にしないため、exposure・差分・鮮度判定は共有読み取り契約へ移行する候補として残す
+- reviewとactive policyの取り違えを防ぐため、reviewの`policy_version_id`を読み取り、policy履歴からv2等の版表示へ解決する。legacy reviewは未紐付けとして表示する
 
 ## 実装範囲
 

--- a/docs/plans/portfolio-decision-workspace-plan.md
+++ b/docs/plans/portfolio-decision-workspace-plan.md
@@ -43,7 +43,7 @@ MiniToolsはポートフォリオ方針の主入力画面ではない。主入�
 - 保存済みreview/itemの読み取り表示
 - 保存済みrecommendation/actionの読み取り表示（MiniToolsからの書き込みは行わない）
 - 「意思決定」画面で、判断状態・全体要約・金額なしの補強/調査候補・次のActionを表示
-- DBのpolicy versionをreviewの一時メモと分離して読み取り表示
+- DBのactive policy・policy履歴をreviewの一時メモと分離して読み取り表示し、reviewが参照したpolicy versionも表示
 - policy履歴とlatest reflectionの読み取り表示
 
 ### 未実装

--- a/docs/specs/tools/portfolio.md
+++ b/docs/specs/tools/portfolio.md
@@ -1,6 +1,6 @@
 # ポートフォリオ 仕様
 
-> **実装状態:** 2026-08-22時点の画面は、最新snapshot、active policy・policy履歴、保存済みreview/recommendation/action、latest reflectionを読むUI-1〜UI-2初回版である。
+> **実装状態:** 2026-08-22時点の画面は、最新snapshot、active policy・policy履歴、保存済みreview/recommendation/action、latest reflectionを読むUI-1〜UI-2初回版である。reviewが参照したpolicy versionも表示する。
 > ポートフォリオ意思決定プラットフォームの完成品ではない。目標運用とUIの実装順序は
 > [ポートフォリオ意思決定ワークスペース実装計画](../../plans/portfolio-decision-workspace-plan.md) を参照する。
 
@@ -36,6 +36,7 @@
 ### 出力
 
 - 「意思決定」では、保存済みreviewの基準日・状態・要約、recommendationの対象/優先順位/条件/理由、actionの状態/実行条件を表示する
+- 「意思決定」では、reviewが参照したpolicy versionを表示する。旧reviewで参照先が未保存の場合は「未紐付け（legacy review）」と表示し、active policyと混同しない
 - `proposed_amount` と `proposed_pct` が未設定のrecommendationは「金額未指定」「金額を仮定しない」と明示する
 - 株式・投資信託を商品単位で表示する
 - 口座別の同一商品は「表示」では集約し、「記録」では分けて表示する

--- a/docs/uat/portfolio.md
+++ b/docs/uat/portfolio.md
@@ -11,6 +11,7 @@
 - [ ] `/premium/portfolio` がPremiumログイン後に表示される
 - [ ] 「意思決定」「表示」「記録」「方針・履歴」「DB確認」の5タブを切り替えられる
 - [ ] 「意思決定」でsnapshot/reviewの基準日と判断状態を確認できる
+- [ ] 「意思決定」でreviewが参照したpolicy versionを確認できる（v2等。legacy reviewは未紐付けと表示）
 - [ ] 「意思決定」でactive policyの版、原則、構造化ルールを確認できる
 - [ ] active policyがreviewの一時メモとは別に表示される
 - [ ] 「意思決定」でlatest reflectionの期待、結果、学び、方針変更案を確認できる


### PR DESCRIPTION
## 概要

保存済みreviewが参照したpolicy versionを、MiniToolsのポートフォリオ意思決定画面で確認できるようにする。

対象Phaseはポートフォリオ意思決定ワークスペース計画のUI-1〜UI-2初回実装。受入条件は、active policyとreviewの一時判断を混同せず、reviewの参照policyをv2等の版として表示できること。

## 変更内容

- `stock_notes_portfolio_reviews.policy_version_id`を読み取りクエリへ追加
- MiniToolsの`PortfolioReview`型とデータ変換へ`policyVersionId`を追加
- policy履歴から参照先の版番号・statusを解決し、意思決定画面に表示
- legacy review（参照先null）は「未紐付け（legacy review）」と表示
- policy履歴の最新20件に含まれない古い参照先は、参照IDを追加取得して正しく解決
- 仕様、計画、UAT、decision logを更新

## 確認

- `npm run lint` : pass
- `npm test` : 49 files / 540 tests passed
- `npm run build` : pass
- `codex --profile review-low review --base main` : blocking issueなし

## 本PRの範囲外

- MiniToolsからのpolicy/review書き込み
- Custom GPTのActions設定変更
- 既存legacy draft reviewの自動変更
- review未作成時のChatGPT起点相談導線

Custom GPTでv2 reviewを保存した後、MiniToolsを再読み込みすれば`v2 / active`として表示できる。現在の本番draftはlegacyのため、既存データは変更しない。
