### PR TITLE
fix(routines): 棚卸し台帳を実機に合わせ直す

### DIFF
--- a/app/premium/routines/data/routines.ts
+++ b/app/premium/routines/data/routines.ts
@@ -7,12 +7,12 @@
 //   `market_info/docs/operations/{daily,monthly}_operations.md`
 //
 // 実行実績を自動で取り込む仕組みは持たない。棚卸ししたときに手で更新する。
-// 最終棚卸し: 2026-08-08
+// 最終棚卸し: 2026-08-23
 
 import type { Routine } from "../types";
 
 /** この定義を最後に実機と突き合わせた日。画面に鮮度として出す。 */
-export const ROUTINES_SURVEYED_ON = "2026-08-08";
+export const ROUTINES_SURVEYED_ON = "2026-08-23";
 
 export const ROUTINES: Routine[] = [
   // ---- 自動: 毎日 ----
@@ -106,6 +106,18 @@ export const ROUTINES: Routine[] = [
     source: "tdnet_meta_daily",
     repo: "market_info",
   },
+  // 2026-08-08 の棚卸しから漏れていた既存の自動タスク（今回のタスク変更とは無関係）。
+  // 実行時刻は未確認のため「時刻未定」として扱う。要確認。
+  {
+    id: "yutai-stock-prices-daily",
+    label: "優待銘柄 株価取得",
+    description: "優待銘柄の株価を日次で取得する。",
+    mode: "auto",
+    domain: "market-data",
+    schedule: { kind: "daily", times: [] },
+    source: "yutai_stock_prices_daily",
+    repo: "market_info",
+  },
 
   // ---- 自動: 週次 ----
   {
@@ -166,54 +178,57 @@ export const ROUTINES: Routine[] = [
     repo: "market_info",
   },
 
-  // ---- 半自動: リマインダー起点 ----
+  // ---- 手動: 市場データ取得 ----
+  // 2026-08-23 時点、以下はすべて Windows タスクスケジューラに
+  // \market_info\ 配下でトリガーなし登録されている。pc-saas-health-monitor
+  // の実行画面からタスク名で起動するためだけの登録で、自動実行はしない。
+  // 起動は完全に本人の意思なので mode は manual とした（auto は無人実行が
+  // 前提のため不適合、semi はリマインダー起点だが該当するリマインダーは
+  // 廃止済みのため不適合）。
   {
-    id: "credit-inventory-nikko",
-    label: "信用在庫 取得（日興）",
+    id: "naito-daily-run",
+    label: "market ランキング取得・publish",
     description:
-      "リマインダーを受けて日興の一般信用売り在庫を取得し publish する。/weekend-credit-inventory を使う。",
-    mode: "semi",
+      "内藤証券にログイン（2FA を手で処理）して 9tables を取得し、株価ランキング / 日経225寄与度 / TOPIX33 / 米国株ランキングを publish してバックアップまで流す。火曜は信用残、木曜は投資部門別の追加取得が走る。pc-saas-health-monitor の実行画面からも起動できる。run_naito_and_backup.ps1。",
+    mode: "manual",
     domain: "market-data",
-    schedule: { kind: "weekly", weekdays: [6], times: ["09:00"] },
-    source: "credit_inventory_reminder_nikko",
+    schedule: { kind: "weekday", times: ["20:00"] },
+    source: "manual_run_naito_and_backup",
     repo: "market_info",
   },
   {
-    id: "credit-inventory-sbi",
+    id: "sbi-credit-inventory",
     label: "信用在庫 取得（SBI）",
     description:
-      "リマインダーを受けて SBI の一般信用売り在庫を取得し publish する。/weekend-credit-inventory を使う。",
-    mode: "semi",
+      "SBI の一般信用売り在庫を取得し publish する。ブラウザでパスキー認証を待つため無人実行できず、pc-saas-health-monitor の実行画面から手動で起動する。旧リマインダー（credit_inventory_reminder_sbi）は廃止済み。run_sbi_inventory_and_publish.ps1。",
+    mode: "manual",
     domain: "market-data",
-    schedule: { kind: "weekly", weekdays: [0], times: ["09:00"] },
-    source: "credit_inventory_reminder_sbi",
+    schedule: { kind: "weekly", weekdays: [0], times: [] },
+    source: "manual_run_sbi_credit_inventory",
+    repo: "market_info",
+  },
+  {
+    id: "nikko-credit-inventory",
+    label: "信用在庫 取得（日興）",
+    description:
+      "日興の一般信用売り在庫を取得し publish する。ブラウザでパスキー認証を待つため無人実行できず、pc-saas-health-monitor の実行画面から手動で起動する。旧リマインダー（credit_inventory_reminder_nikko）は廃止済み。run_nikko_inventory_and_publish.ps1。",
+    mode: "manual",
+    domain: "market-data",
+    schedule: { kind: "weekly", weekdays: [6], times: [] },
+    source: "manual_run_nikko_credit_inventory",
     repo: "market_info",
   },
   {
     id: "monthly-rankings",
     label: "月次ランキング取得",
     description:
-      "月初のポップアップを受けて信用残・売買代金ランキングの月次取得を手で流す。",
-    mode: "semi",
-    domain: "market-data",
-    schedule: { kind: "monthly", daysOfMonth: [1], times: ["09:00"] },
-    source: "monthly_rankings_reminder",
-    repo: "market_info",
-  },
-
-  // ---- 手動: 市場データ取得 ----
-  {
-    id: "naito-daily-run",
-    label: "market ランキング取得・publish",
-    description:
-      "内藤証券にログイン（2FA を手で処理）して 9tables を取得し、株価ランキング / 日経225寄与度 / TOPIX33 / 米国株ランキングを publish してバックアップまで流す。火曜は信用残、木曜は投資部門別の追加取得が走る。run_naito_and_backup.ps1。",
+      "時価総額・配当利回りランキングを月初に取得し publish する。pc-saas-health-monitor の実行画面から手動で起動する。旧リマインダー（monthly_rankings_reminder）は廃止済み。run_monthly_rankings.ps1。",
     mode: "manual",
     domain: "market-data",
-    schedule: { kind: "weekday", times: ["20:00"] },
-    source: "scripts/run_naito_and_backup.ps1",
+    schedule: { kind: "monthly", daysOfMonth: [1], times: [] },
+    source: "manual_run_monthly_rankings",
     repo: "market_info",
   },
-
   // ---- 手動: 保有・優待・入金の確認 ----
   {
     id: "yutai-purchase-check",

--- a/docs/decision-log/2026-08-23-routines-inventory-resync.md
+++ b/docs/decision-log/2026-08-23-routines-inventory-resync.md
@@ -1,0 +1,87 @@
+# 2026-08-23 ルーティン一覧の棚卸しズレを直す
+
+## 背景
+
+- `/premium/routines` は棚卸し時点の設定を静的にハードコードする方式
+  （[2026-08-08 決定](./2026-08-08-routines-static-inventory.md)）。
+- 2026-08-08 の棚卸し後、実機のタスクスケジューラ登録が変わり、
+  `data/routines.ts` と実態がズレた。
+  - `credit_inventory_reminder_nikko` / `credit_inventory_reminder_sbi` /
+    `monthly_rankings_reminder` の 3 リマインダータスクを削除。
+    このうち nikko は `msg.exe`（Windows Home 非搭載）を呼んでいて数か月前から
+    サイレントに失敗していた。
+  - 該当のリマインダー起点の作業は `pc-saas-health-monitor` 側の新しい実行画面に
+    移り、その画面からタスク名で起動するためだけの **トリガーなしタスク**が
+    `\market_info\` 配下に 4 件（`manual_run_naito_and_backup` /
+    `manual_run_sbi_credit_inventory` / `manual_run_nikko_credit_inventory` /
+    `manual_run_monthly_rankings`）登録された。
+  - `yutai_stock_prices_daily`（既存の自動タスク）が 2026-08-08 の棚卸しから
+    単純に漏れていたことも判明（今回の変更とは無関係）。
+
+## 今回決めたこと
+
+- 削除: `credit-inventory-nikko` / `credit-inventory-sbi` / `monthly-rankings`
+  （semi モードのリマインダー起点エントリ）。
+- `naito-daily-run` は **新規追加ではなく既存エントリの `source` を更新**。
+  `scripts/run_naito_and_backup.ps1` → `manual_run_naito_and_backup`。
+  実体（内藤証券ログイン＋2FA の日次運用）は変わっておらず、実行画面から
+  起動できるようになっただけなので、別エントリにすると同じ作業を二重計上
+  してしまう。
+- 新規追加（3件、mode: `manual`）:
+  `sbi-credit-inventory` / `nikko-credit-inventory` / `monthly-rankings`
+  （source をそれぞれ `manual_run_sbi_credit_inventory` /
+  `manual_run_nikko_credit_inventory` / `manual_run_monthly_rankings` に変更）。
+  旧リマインダーが廃止された以上、実質的に別物の運用として扱う。
+- 新規追加（1件）: `yutai-stock-prices-daily`（mode: `auto`、時刻未確認のため
+  `schedule.times` は空＝時刻未定行に表示）。
+- `ROUTINES_SURVEYED_ON` を `2026-08-23` に更新。
+
+## 判断理由
+
+### トリガーなしタスクの mode を `manual` にした理由
+
+既存語彙は `auto`（無人実行前提）/ `semi`（リマインダー起点）/
+`manual`（完全に自分の意思で起動）の 3 分類。
+
+- `auto` は不適合: トリガーが無いので無人実行されない。SBI・日興の 2 件は
+  パスキー認証待ちがあり、そもそも無人完走できない。
+- `semi` は不適合: この分類は「リマインダーが飛んできて実行する」を指すが、
+  該当のリマインダータスクは今回廃止された。何かに促されて動くのではなく、
+  実行画面のボタンを押すという本人の能動的な操作が起点になる。
+- `manual` の定義文「完全に自分の意思で起動する」に文字どおり一致する。
+  実行画面からタスク名で起動する、という手段が変わっただけで、
+  起動判断が本人にある点は他の manual エントリ（X 投稿スキルなど）と同じ。
+
+新しい mode を追加する必要はないと判断した。
+
+### naito を新規エントリにしなかった理由
+
+このツールの目的は「作業総量と偏りの把握」（[2026-08-08 決定](./2026-08-08-routines-static-inventory.md)背景）。
+`manual_run_naito_and_backup` は既存の `naito-daily-run`（平日20時、
+run_naito_and_backup.ps1）と完全に同一の作業を指しており、
+別エントリとして追加すると平日20時の作業を二重計上し、
+週あたり実行回数のサマリーが実態より多く出る。目的に反するため、
+実体が同じものは統合し、traceable な識別子（タスク名）に更新するに留めた。
+
+## 影響範囲
+
+- `app/premium/routines/data/routines.ts` のみ。型定義・集計ロジック・UI は変更なし。
+- 既存テスト（`app/premium/routines/__tests__/timetable.test.ts`）はハードコードされた
+  ルーティンではなくヘルパーで組み立てているため影響なし。全16件パス確認済み。
+
+## 残課題
+
+- `yutai-stock-prices-daily` の実行時刻が未確認。本人確認のうえ
+  `schedule.times` を埋める。
+- この棚卸しが「今回の変更を人が言わなければ気付かれず、実機とズレたまま
+  静止していた」ことが判明した。目的（作業総量の可視化）にとって
+  ズレたままの表示は実害があるため、[2026-08-08 決定](./2026-08-08-routines-static-inventory.md)
+  の「今後の選択肢」に挙げられている実行実績の自動取り込みや、
+  最低限「最終棚卸し日から N 日経過したら画面に警告を出す」程度の
+  鮮度チェックを検討する価値がある（今回は未着手）。
+
+## 関連
+
+- Issue:
+- PR:
+- 参照 docs: [2026-08-08 ルーティン可視化を静的棚卸しにする](./2026-08-08-routines-static-inventory.md)

--- a/docs/specs/tools/routines.md
+++ b/docs/specs/tools/routines.md
@@ -137,3 +137,4 @@ Get-ScheduledTask -TaskPath '\market_info\','\' | ForEach-Object {
 ## 関連 docs
 
 - Decision Log: [2026-08-08 ルーティン可視化を静的棚卸しにする](../../decision-log/2026-08-08-routines-static-inventory.md)
+- Decision Log: [2026-08-23 ルーティン一覧の棚卸しズレを直す](../../decision-log/2026-08-23-routines-inventory-resync.md)


### PR DESCRIPTION
## 背景

`/premium/routines` は**手で維持する静的な棚卸し台帳**です（ヘッダに「棚卸ししたときに手で更新する」「最終棚卸し: 2026-08-08」）。

2026-08-23 に `pc-saas-health-monitor` 側で実機のタスク構成を変えたにもかかわらず、**この台帳を更新しませんでした。** その結果、台帳は両方向にずれていました。Windows タスクスケジューラを直接読み、`routines.ts` の全 `source` と突き合わせて確認しています。

## ずれの内容

**台帳が指すタスクが実機に無い（3件、いずれも今日削除したもの）**

| source | label | 削除した理由 |
| --- | --- | --- |
| `credit_inventory_reminder_nikko` | 信用在庫 取得（日興） | 通知のみのタスク。役目は新しい実行画面に移行 |
| `credit_inventory_reminder_sbi` | 信用在庫 取得（SBI） | 同上 |
| `monthly_rankings_reminder` | 月次ランキング取得 | 同上。しかも `msg.exe` を呼んでおり、**Windows Home には同梱されていない**ため毎月静かに失敗していた |

**実機にあるが台帳に無い（5件）**

`manual_run_naito_and_backup` / `manual_run_sbi_credit_inventory` / `manual_run_nikko_credit_inventory` / `manual_run_monthly_rankings` の4つは、
**トリガーを持たない**タスクとして `\market_info\` に登録されています。自分では動かず、監視ツールの実行画面から名前で起動されるためだけに存在します。

`yutai_stock_prices_daily` は今日の変更とは無関係で、**2026-08-08 の棚卸し時点で漏れていた**ものです。

## 判断したこと

**naito は二重登録していません。** 既存エントリの `source` をスクリプトパスから新しいタスク名に**更新**しました。作業の実体（2FA ログイン、平日20時）は変わっておらず、
エントリを増やすと**週あたりの実行回数が二重に数えられ**、「自分の作業量を正しく把握する」というこのツールの目的を損なうためです。

**トリガー無しタスクの `mode` は `manual`** にしました。`auto` は当てはまらず（トリガーが無く、2つはそもそも無人で完了できない）、
`semi` は仕様上「リマインダーが飛んできて自分で実行する」を指しますが、**そのリマインダーはまさに今日削除した**ので当てはまりません。
`manual`（完全に自分の意思で起動する）が定義どおりです。起動手段がボタンになっただけで、判断の主体は変わっていません。新しい mode は作っていません。

判断の根拠は `docs/decision-log/2026-08-23-routines-inventory-resync.md` に残しました。

## 残課題

**この台帳が黙って古くなるのは2回目**です（初回の棚卸し漏れと、今日の同日ずれ）。
正確な総量把握が目的のツールで、鮮度の検査が無い静的ファイルは、**間違っているときにこそ自信を与えます**。
決定ログの残課題に、軽い「N日で古い」警告と、実行履歴の自動取り込みの2案を書いてあります。

## 確認

`npx tsc --noEmit` クリーン ／ `npx vitest run app/premium/routines` 16/16 ／ `npm run lint` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
