### PR TITLE
feat(theme-viewer): add read-only Premium Theme Viewer

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -31,6 +31,11 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 PREMIUM_ACCESS_PASSWORD=
 PREMIUM_ACCESS_SECRET=
 
+# stock-notes Theme Viewer API（server-only。ブラウザーへtokenを渡さない）
+# GET /viewer/themes と GET /viewer/themes/{theme_id} を利用する。
+STOCK_NOTES_API_BASE_URL=
+STOCK_NOTES_API_TOKEN=
+
 # Gemini API キー（yutai-expiry の画像認識用、任意）
 # https://aistudio.google.com/ で API key を発行する。
 # 無料枠あり。最新の上限・条件は公式ドキュメントを確認すること:

--- a/app/premium/page.tsx
+++ b/app/premium/page.tsx
@@ -38,6 +38,13 @@ const FEATURE_CARDS: FeatureCard[] = [
     tone: "amber",
   },
   {
+    href: "/premium/themes",
+    icon: "🧭",
+    title: "テーマViewer",
+    description: "ChatGPT + Supabaseで整備したテーマの概要・根拠・履歴を読み取り専用で確認します。",
+    tone: "violet",
+  },
+  {
     href: "/premium/routines",
     icon: "🗓",
     title: "ルーティン一覧",

--- a/app/premium/themes/ThemeViewer.tsx
+++ b/app/premium/themes/ThemeViewer.tsx
@@ -1,0 +1,1075 @@
+import type { CSSProperties, ReactNode } from "react";
+import Link from "next/link";
+import type {
+  ThemeConfidence,
+  ThemeDataState,
+  ThemeDetailLoadResult,
+  ThemeListLoadResult,
+  ThemeMetricDefinition,
+  ThemeProvenance,
+  ThemeSectionAvailability,
+  ThemeStatus,
+} from "./types";
+
+const STATUS_LABELS: Record<ThemeStatus, string> = {
+  draft: "下書き",
+  active: "active",
+  archived: "アーカイブ",
+};
+
+const CONFIDENCE_LABELS: Record<ThemeConfidence, string> = {
+  high: "確度 高",
+  medium: "確度 中",
+  low: "確度 低",
+};
+
+const DATA_STATE_LABELS: Record<ThemeDataState, string> = {
+  present: "登録あり",
+  empty: "登録なし",
+  missing: "未提供",
+};
+
+const DATA_STATE_COLORS: Record<ThemeDataState, { bg: string; fg: string; border: string }> = {
+  present: { bg: "#f0fdf4", fg: "#166534", border: "#bbf7d0" },
+  empty: { bg: "#fffbeb", fg: "#92400e", border: "#fde68a" },
+  missing: { bg: "#f1f5f9", fg: "#475569", border: "#cbd5e1" },
+};
+
+const cardStyle: CSSProperties = {
+  background: "#fff",
+  border: "1px solid rgba(15,23,42,0.08)",
+  borderRadius: 18,
+  padding: 18,
+  boxShadow: "0 10px 30px rgba(15,23,42,0.05)",
+};
+
+const mutedStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--color-text-muted)",
+  fontSize: 13,
+  lineHeight: 1.75,
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(0, 10);
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeZone: "Asia/Tokyo",
+  }).format(date);
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Tokyo",
+  }).format(date);
+}
+
+function formatNumber(value: number | null | undefined) {
+  if (value === null || value === undefined) return "—";
+  return new Intl.NumberFormat("ja-JP", { maximumFractionDigits: 6 }).format(value);
+}
+
+function StatusBadge({ status }: { status: ThemeStatus }) {
+  const color = status === "active"
+    ? { bg: "#dcfce7", fg: "#166534", border: "#bbf7d0" }
+    : status === "draft"
+      ? { bg: "#dbeafe", fg: "#1d4ed8", border: "#bfdbfe" }
+      : { bg: "#f1f5f9", fg: "#475569", border: "#cbd5e1" };
+  return (
+    <span style={{ ...styles.badge, background: color.bg, color: color.fg, borderColor: color.border }}>
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+function ConfidenceBadge({ confidence }: { confidence: ThemeConfidence | null | undefined }) {
+  if (!confidence) return <span style={styles.mutedBadge}>確度未登録</span>;
+  return <span style={styles.mutedBadge}>{CONFIDENCE_LABELS[confidence]}</span>;
+}
+
+function AvailabilityBadge({ availability }: { availability: ThemeSectionAvailability }) {
+  const color = DATA_STATE_COLORS[availability.state];
+  return (
+    <span
+      style={{
+        ...styles.badge,
+        background: color.bg,
+        color: color.fg,
+        borderColor: color.border,
+      }}
+    >
+      {DATA_STATE_LABELS[availability.state]}
+      {availability.state === "present" ? ` ${availability.count}` : ""}
+    </span>
+  );
+}
+
+function Provenance({ provenance }: { provenance: ThemeProvenance }) {
+  return (
+    <div style={styles.provenance}>
+      <span>source: {provenance.source ?? "未登録"}</span>
+      <span>as-of: {formatDateTime(provenance.asOf)}</span>
+      <ConfidenceBadge confidence={provenance.confidence} />
+    </div>
+  );
+}
+
+function Section({
+  title,
+  availability,
+  children,
+  description,
+}: {
+  title: string;
+  availability: ThemeSectionAvailability;
+  children: ReactNode;
+  description?: string;
+}) {
+  return (
+    <section style={cardStyle}>
+      <div style={styles.sectionHeading}>
+        <div>
+          <h2 style={styles.sectionTitle}>{title}</h2>
+          {description ? <p style={{ ...mutedStyle, marginTop: 5 }}>{description}</p> : null}
+        </div>
+        <AvailabilityBadge availability={availability} />
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function AvailabilityMessage({
+  availability,
+  presentMessage,
+  emptyMessage,
+  missingMessage,
+}: {
+  availability: ThemeSectionAvailability;
+  presentMessage?: string;
+  emptyMessage: string;
+  missingMessage: string;
+}) {
+  if (availability.state === "present") return presentMessage ? <p style={mutedStyle}>{presentMessage}</p> : null;
+  return (
+    <p style={{ ...mutedStyle, marginTop: 14 }}>
+      {availability.state === "empty" ? emptyMessage : missingMessage}
+    </p>
+  );
+}
+
+function ExternalLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noreferrer" style={styles.externalLink}>
+      {children} ↗
+    </a>
+  );
+}
+
+function ViewerState({
+  result,
+  emptyMessage,
+}: {
+  result: ThemeListLoadResult | ThemeDetailLoadResult;
+  emptyMessage: string;
+}) {
+  if (result.status === "ok") return null;
+  if (result.status === "empty") {
+    return (
+      <div style={{ ...cardStyle, background: "#fffbeb", borderColor: "#fde68a" }}>
+        <h2 style={styles.stateTitle}>データはまだありません</h2>
+        <p style={mutedStyle}>{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  const title = result.status === "not_configured"
+    ? "サーバー設定が未完了です"
+    : result.status === "unauthorized"
+      ? "stock-notes APIの認証に失敗しました"
+      : result.status === "not_found"
+        ? "テーマが見つかりません"
+        : result.status === "invalid_response"
+          ? "APIレスポンスを表示できません"
+          : "stock-notes APIから取得できません";
+  const background = result.status === "not_configured" ? "#fffbeb" : "#fef2f2";
+  const border = result.status === "not_configured" ? "#fde68a" : "#fecaca";
+  const foreground = result.status === "not_configured" ? "#92400e" : "#991b1b";
+
+  return (
+    <div style={{ ...cardStyle, background, borderColor: border, color: foreground }}>
+      <h2 style={{ ...styles.stateTitle, color: foreground }}>{title}</h2>
+      <p style={{ ...mutedStyle, color: foreground }}>{result.message}</p>
+      {result.status === "not_configured" ? (
+        <p style={{ ...mutedStyle, color: foreground, marginTop: 10 }}>
+          `STOCK_NOTES_API_BASE_URL` と `STOCK_NOTES_API_TOKEN` はServer側だけに設定してください。
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ViewerHero({
+  eyebrow,
+  title,
+  description,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  children?: ReactNode;
+}) {
+  return (
+    <section style={styles.hero}>
+      <div style={styles.eyebrow}>{eyebrow}</div>
+      <h1 style={styles.title}>{title}</h1>
+      <p style={styles.heroDescription}>{description}</p>
+      {children}
+    </section>
+  );
+}
+
+export function ThemeListView({ result }: { result: ThemeListLoadResult }) {
+  const meta = result.status === "ok" || result.status === "empty" ? result.data : null;
+  return (
+    <main style={styles.page}>
+      <div style={styles.shell}>
+        <nav style={styles.topNav}>
+          <Link href="/premium" style={styles.backLink}>← Premium ホーム</Link>
+          <span style={styles.readOnlyChip}>読み取り専用</span>
+        </nav>
+
+        <ViewerHero
+          eyebrow="theme viewer / v1"
+          title="テーマViewer"
+          description="ChatGPT + Supabaseで整備したテーマの概要と履歴を、stock-notesの専用read modelから確認します。ここではテーマから売買判断を確定しません。"
+        >
+          {meta ? <Provenance provenance={{ source: meta.source, asOf: meta.asOf, confidence: null }} /> : null}
+        </ViewerHero>
+
+        <ViewerState
+          result={result}
+          emptyMessage="表示できるテーマがありません。ChatGPT + Supabaseの編集チャネルでテーマを登録すると、ここへ反映されます。"
+        />
+
+        {result.status === "ok" ? (
+          <section style={styles.listGrid}>
+            {result.data.themes.map((theme) => (
+              <Link key={theme.id} href={`/premium/themes/${encodeURIComponent(theme.id)}`} style={styles.themeCard}>
+                <div style={styles.themeCardTop}>
+                  <StatusBadge status={theme.status} />
+                  <span style={styles.themeSlug}>{theme.slug}</span>
+                </div>
+                <h2 style={styles.themeTitle}>{theme.displayName}</h2>
+                <p style={{ ...mutedStyle, minHeight: 44 }}>
+                  {theme.summary ?? "概要未登録"}
+                </p>
+                <div style={styles.themeCardMeta}>
+                  <span>as-of {formatDateTime(theme.asOf)}</span>
+                  <ConfidenceBadge confidence={theme.confidence} />
+                </div>
+                <div style={styles.themeCardMeta}>
+                  <span>{theme.analysisCount === null ? "分析履歴数未提供" : `分析 ${theme.analysisCount}件`}</span>
+                  <span>{theme.openActionCount === null ? "Action数未提供" : `open action ${theme.openActionCount}件`}</span>
+                </div>
+                <span style={styles.openLabel}>詳細を見る →</span>
+              </Link>
+            ))}
+          </section>
+        ) : null}
+
+        <p style={styles.footnote}>
+          テーマの根拠・関連・指標は保存済み情報の表示です。データが空または未提供の場合は、未判明や0件と混同しないよう状態を分けて表示します。
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function OverviewSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const { theme } = data;
+  return (
+    <Section
+      title="概要"
+      availability={data.availability.overview}
+      description="テーマの登録内容。テーマの存在だけで投資推奨や業績寄与を意味しません。"
+    >
+      <div style={{ display: "grid", gap: 14, marginTop: 16 }}>
+        <div>
+          <div style={styles.fieldLabel}>要約</div>
+          <div style={styles.longText}>{theme.summary ?? "概要未登録"}</div>
+        </div>
+        <div>
+          <div style={styles.fieldLabel}>テーマ定義</div>
+          <div style={styles.longText}>{theme.definition ?? "テーマ定義未登録"}</div>
+        </div>
+        <Provenance provenance={theme.provenance} />
+      </div>
+    </Section>
+  );
+}
+
+function ThesisSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const thesis = data.currentThesis;
+  const availability = data.availability.thesis;
+  if (!thesis) {
+    return (
+      <Section title="現在の見立て" availability={availability} description="activeだけでなく、下書き状態も明示して表示します。">
+        <AvailabilityMessage
+          availability={availability}
+          emptyMessage="現在の見立ては登録されていません。"
+          missingMessage="見立て情報はこのViewer契約から提供されていません。"
+        />
+      </Section>
+    );
+  }
+  return (
+    <Section title="現在の見立て" availability={availability} description="見立てのas-ofと確度を、概要とは分けて確認します。">
+      <div style={{ display: "grid", gap: 14, marginTop: 16 }}>
+        <div style={styles.inlineMeta}>
+          <span style={styles.mutedBadge}>{thesis.status}</span>
+          <span style={styles.mutedBadge}>v{thesis.versionNumber ?? "—"}</span>
+          <span>as-of {formatDateTime(thesis.asOf)}</span>
+          <ConfidenceBadge confidence={thesis.confidence} />
+        </div>
+        <TextField label="定義" value={thesis.definition} emptyLabel="定義未登録" />
+        <TextField label="構造仮説" value={thesis.structuralHypothesis} emptyLabel="構造仮説未登録" />
+        <StringListField label="比較・確認レンズ" values={thesis.lenses} emptyLabel="レンズ未登録" />
+        <StringListField label="リスク" values={thesis.risks} emptyLabel="リスク未登録" />
+        <StringListField label="反証条件" values={thesis.falsificationConditions} emptyLabel="反証条件未登録" />
+        <StringListField label="次回確認事項" values={thesis.nextChecks} emptyLabel="次回確認事項未登録" />
+      </div>
+    </Section>
+  );
+}
+
+function TextField({ label, value, emptyLabel }: { label: string; value: string | null; emptyLabel: string }) {
+  return (
+    <div>
+      <div style={styles.fieldLabel}>{label}</div>
+      <div style={styles.longText}>{value ?? emptyLabel}</div>
+    </div>
+  );
+}
+
+function StringListField({ label, values, emptyLabel }: { label: string; values: string[]; emptyLabel: string }) {
+  return (
+    <div>
+      <div style={styles.fieldLabel}>{label}</div>
+      {values.length > 0 ? (
+        <ul style={styles.compactList}>
+          {values.map((value, index) => <li key={`${value}-${index}`}>{value}</li>)}
+        </ul>
+      ) : <div style={styles.longText}>{emptyLabel}</div>}
+    </div>
+  );
+}
+
+function AnalysisHistorySection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const availability = data.availability.analysisHistory;
+  return (
+    <Section title="分析履歴" availability={availability} description="議論・調査の履歴。sourceと分析時点を併記します。">
+      <AvailabilityMessage
+        availability={availability}
+        emptyMessage="分析履歴はまだありません。"
+        missingMessage="分析履歴はこのViewer契約から提供されていません。"
+      />
+      {data.analysisHistory.length > 0 ? (
+        <div style={styles.stack}>
+          {data.analysisHistory.map((analysis) => (
+            <article key={analysis.id} style={styles.subCard}>
+              <div style={styles.itemHeader}>
+                <div>
+                  <div style={styles.itemEyebrow}>{analysis.analysisType}</div>
+                  <h3 style={styles.itemTitle}>{analysis.conclusion ?? "結論未登録"}</h3>
+                </div>
+                <span style={styles.itemDate}>{formatDateTime(analysis.asOf ?? analysis.createdAt)}</span>
+              </div>
+              <Provenance provenance={{ source: analysis.source, asOf: analysis.asOf, confidence: analysis.confidence }} />
+              <TextField label="根拠メモ" value={analysis.evidence} emptyLabel="根拠メモ未登録" />
+              <TextField label="懸念" value={analysis.concerns} emptyLabel="懸念未登録" />
+              {analysis.body ? <TextField label="記録本文" value={analysis.body} emptyLabel="本文未登録" /> : null}
+              {analysis.sourceUrl ? <ExternalLink href={analysis.sourceUrl}>分析の出典</ExternalLink> : null}
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </Section>
+  );
+}
+
+function EvidenceSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const availability = data.availability.evidence;
+  return (
+    <Section title="根拠" availability={availability} description="外部事実・解釈・仮説・判断を、verification statusと確度付きで表示します。">
+      <AvailabilityMessage
+        availability={availability}
+        emptyMessage="根拠レコードはまだありません。"
+        missingMessage="根拠情報はこのViewer契約から提供されていません。"
+      />
+      {data.evidence.length > 0 ? (
+        <div style={styles.stack}>
+          {data.evidence.map((item) => (
+            <article key={item.id} style={styles.subCard}>
+              <div style={styles.itemHeader}>
+                <div style={styles.tagRow}>
+                  <span style={styles.mutedBadge}>{item.stance}</span>
+                  <span style={styles.mutedBadge}>{item.claimKind}</span>
+                  <span style={styles.mutedBadge}>{item.verificationStatus ?? "状態未登録"}</span>
+                </div>
+                <ConfidenceBadge confidence={item.confidence} />
+              </div>
+              <div style={styles.longText}>{item.claim ?? "主張未登録"}</div>
+              <div style={styles.metaGrid}>
+                <span>種別: {item.evidenceType}</span>
+                <span>source: {item.sourceType ?? "未登録"}</span>
+                <span>source as-of: {formatDate(item.sourceAsOf)}</span>
+                <span>確認: {formatDateTime(item.checkedAt)}</span>
+              </div>
+              <div style={styles.sourceRow}>
+                <span>{item.sourceTitle ?? "出典タイトル未登録"}</span>
+                {item.sourceUrl ? <ExternalLink href={item.sourceUrl}>出典を開く</ExternalLink> : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </Section>
+  );
+}
+
+function DirectLinksSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const availability = data.availability.directLinks;
+  return (
+    <Section title="直接リンク" availability={availability} description="関連対象へのリンクです。テーマとの接点を投資判断と混同しません。">
+      <AvailabilityMessage
+        availability={availability}
+        emptyMessage="直接リンクはまだありません。"
+        missingMessage="直接リンク情報はこのViewer契約から提供されていません。"
+      />
+      {data.directLinks.length > 0 ? (
+        <div style={styles.stack}>
+          {data.directLinks.map((item) => (
+            <article key={item.id} style={styles.subCard}>
+              <div style={styles.itemHeader}>
+                <div>
+                  <div style={styles.itemEyebrow}>{item.targetType} / {item.relationType}</div>
+                  <h3 style={styles.itemTitle}>{item.displayName}</h3>
+                </div>
+                <span style={styles.mutedBadge}>{item.status}</span>
+              </div>
+              <div style={styles.longText}>{item.relationNote ?? "関連メモ未登録"}</div>
+              <div style={styles.metaGrid}>
+                <span>対象ID: {item.targetId ?? "未登録"}</span>
+                <span>寄与段階: {item.contributionStage ?? "未登録"}</span>
+                <span>source: {item.sourceTitle ?? "未登録"}</span>
+                <span>source as-of: {formatDate(item.sourceAsOf)}</span>
+                <ConfidenceBadge confidence={item.confidence} />
+              </div>
+              <div style={styles.sourceRow}>
+                {item.url ? <ExternalLink href={item.url}>対象リンクを開く</ExternalLink> : <span>対象URL未提供</span>}
+                {item.sourceUrl ? <ExternalLink href={item.sourceUrl}>確認元を開く</ExternalLink> : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </Section>
+  );
+}
+
+function TaxonomySection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const availability = data.availability.taxonomyMap;
+  const nodesById = new Map(data.taxonomyMap.nodes.map((node) => [node.id, node]));
+  return (
+    <Section title="Taxonomy map" availability={availability} description="テーマ・企業/銘柄・製品/技術などの分類関係を表示します。未分類は未分類のまま扱います。">
+      <AvailabilityMessage
+        availability={availability}
+        emptyMessage="taxonomy mapはまだありません。"
+        missingMessage="taxonomy mapはこのViewer契約から提供されていません。"
+      />
+      {availability.state === "present" ? (
+        <div style={styles.taxonomyGrid}>
+          <div>
+            <h3 style={styles.subheading}>ノード</h3>
+            {data.taxonomyMap.nodes.length > 0 ? (
+              <div style={styles.stack}>
+                {data.taxonomyMap.nodes.map((node) => (
+                  <div key={node.id} style={styles.subCard}>
+                    <div style={styles.itemEyebrow}>{node.domain} / {node.kind}</div>
+                    <strong>{node.displayName}</strong>
+                    <div style={mutedStyle}>{node.description ?? "説明未登録"}</div>
+                    <span style={styles.mutedBadge}>{node.status ?? "状態未登録"}</span>
+                  </div>
+                ))}
+              </div>
+            ) : <p style={mutedStyle}>ノードはありません。</p>}
+          </div>
+          <div>
+            <h3 style={styles.subheading}>テーマとの接点</h3>
+            {data.taxonomyMap.themeLinks.length > 0 ? (
+              <ul style={styles.relationList}>
+                {data.taxonomyMap.themeLinks.map((link) => (
+                  <li key={link.id}>
+                    <strong>{nodesById.get(link.nodeId)?.displayName ?? link.nodeId}</strong>
+                    <span>{link.relationType}</span>
+                    <span>{link.relationNote ?? "メモ未登録"}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : <p style={mutedStyle}>テーマとの接点はありません。</p>}
+            <h3 style={{ ...styles.subheading, marginTop: 18 }}>ノード間の関係</h3>
+            {data.taxonomyMap.edges.length > 0 ? (
+              <ul style={styles.relationList}>
+                {data.taxonomyMap.edges.map((edge) => (
+                  <li key={edge.id}>
+                    <strong>{nodesById.get(edge.sourceNodeId)?.displayName ?? edge.sourceNodeId}</strong>
+                    <span>{edge.relationType}</span>
+                    <strong>{nodesById.get(edge.targetNodeId)?.displayName ?? edge.targetNodeId}</strong>
+                    <span>{edge.relationNote ?? "メモ未登録"}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : <p style={mutedStyle}>ノード間の関係はありません。</p>}
+            {data.taxonomyMap.stockLinks.length > 0 ? (
+              <>
+                <h3 style={{ ...styles.subheading, marginTop: 18 }}>銘柄との分類リンク</h3>
+                <ul style={styles.relationList}>
+                  {data.taxonomyMap.stockLinks.map((link) => (
+                    <li key={link.id}>
+                      <strong>{link.stockId}</strong>
+                      <span>{nodesById.get(link.nodeId)?.displayName ?? link.nodeId}</span>
+                      <span>{link.strategicRole ?? "役割未登録"}</span>
+                      <ConfidenceBadge confidence={link.confidence} />
+                      <span>as-of {formatDate(link.asOf)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </Section>
+  );
+}
+
+function MetricDefinitionCard({ definition }: { definition: ThemeMetricDefinition }) {
+  return (
+    <div style={styles.subCard}>
+      <div style={styles.itemHeader}>
+        <div>
+          <div style={styles.itemEyebrow}>{definition.metricKey}</div>
+          <h3 style={styles.itemTitle}>{definition.displayName}</h3>
+        </div>
+        <span style={styles.mutedBadge}>{definition.scope}</span>
+      </div>
+      <div style={styles.longText}>{definition.definition ?? "定義未登録"}</div>
+      <div style={styles.metaGrid}>
+        <span>単位: {definition.unit ?? "未登録"}</span>
+        <span>版: {definition.versionNumber ?? "—"}</span>
+        <span>{definition.isActive === null ? "有効状態未提供" : definition.isActive ? "active" : "inactive"}</span>
+        {definition.appliesToStockId ? <span>対象銘柄: {definition.appliesToStockId}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+function MetricsSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const availability = data.availability.metrics;
+  const definitions = new Map(data.metrics.definitions.map((definition) => [definition.id, definition]));
+  const snapshots = new Map(data.metrics.snapshots.map((snapshot) => [snapshot.id, snapshot]));
+  return (
+    <Section title="Metrics" availability={availability} description="指標の定義と値を分け、単位・対象・基準日を確認します。">
+      <AvailabilityMessage
+        availability={availability}
+        emptyMessage="指標定義・値はまだありません。"
+        missingMessage="metrics情報はこのViewer契約から提供されていません。"
+      />
+      {data.metrics.definitions.length > 0 ? (
+        <div style={{ ...styles.stack, marginTop: 16 }}>
+          <h3 style={styles.subheading}>指標定義</h3>
+          {data.metrics.definitions.map((definition) => <MetricDefinitionCard key={definition.id} definition={definition} />)}
+        </div>
+      ) : null}
+      {data.metrics.values.length > 0 ? (
+        <div style={{ ...styles.stack, marginTop: 18 }}>
+          <h3 style={styles.subheading}>指標値</h3>
+          <div style={styles.tableScroll}>
+            <table style={styles.table}>
+              <thead>
+                <tr>
+                  <th style={styles.th}>指標</th>
+                  <th style={styles.th}>対象</th>
+                  <th style={styles.th}>値</th>
+                  <th style={styles.th}>基準日 / 期間</th>
+                  <th style={styles.th}>根拠</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.metrics.values.map((value) => {
+                  const definition = definitions.get(value.metricId);
+                  const snapshot = snapshots.get(value.snapshotId);
+                  return (
+                    <tr key={value.id}>
+                      <td style={styles.td}>{definition?.displayName ?? value.metricId}<br /><span style={styles.tableMuted}>{definition?.unit ?? "単位未提供"}</span></td>
+                      <td style={styles.td}>{value.stockId}</td>
+                      <td style={{ ...styles.td, fontWeight: 900 }}>{value.value === null ? "値未取得" : formatNumber(value.value)}</td>
+                      <td style={styles.td}>{formatDate(snapshot?.asOf)}<br /><span style={styles.tableMuted}>{snapshot?.periodLabel ?? "期間未提供"}</span></td>
+                      <td style={styles.td}>{value.evidenceId ?? "根拠ID未提供"}<br /><span style={styles.tableMuted}>{value.calculationNote ?? "計算メモ未登録"}</span></td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : data.metrics.definitions.length > 0 ? (
+        <p style={{ ...mutedStyle, marginTop: 14 }}>指標定義はありますが、値はまだありません。</p>
+      ) : null}
+    </Section>
+  );
+}
+
+function OpenActionsSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResult, { status: "ok" }>["data"]> }) {
+  const availability = data.availability.openActions;
+  return (
+    <Section title="Open actions" availability={availability} description="テーマの追加調査・確認・再評価の作業キューです。売買注文や数量指定ではありません。">
+      <AvailabilityMessage
+        availability={availability}
+        emptyMessage="open actionはありません。"
+        missingMessage="action情報はこのViewer契約から提供されていません。"
+      />
+      {data.openActions.length > 0 ? (
+        <div style={styles.stack}>
+          {data.openActions.map((action) => (
+            <article key={action.id} style={styles.subCard}>
+              <div style={styles.itemHeader}>
+                <div>
+                  <div style={styles.itemEyebrow}>{action.actionType}</div>
+                  <h3 style={styles.itemTitle}>{action.title}</h3>
+                </div>
+                <span style={styles.mutedBadge}>{action.status}</span>
+              </div>
+              <TextField label="詳細" value={action.detail} emptyLabel="詳細未登録" />
+              <TextField label="実行条件" value={action.triggerCondition} emptyLabel="実行条件未登録" />
+              <div style={styles.metaGrid}>
+                <span>期限: {formatDate(action.dueDate)}</span>
+                <span>登録: {formatDateTime(action.createdAt)}</span>
+                <span>更新: {formatDateTime(action.updatedAt)}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      ) : null}
+    </Section>
+  );
+}
+
+export function ThemeDetailView({ result }: { result: ThemeDetailLoadResult }) {
+  return (
+    <main style={styles.page}>
+      <div style={styles.shellWide}>
+        <nav style={styles.topNav}>
+          <div style={styles.navGroup}>
+            <Link href="/premium/themes" style={styles.backLink}>← テーマ一覧</Link>
+            <Link href="/premium" style={styles.backLink}>Premium ホーム</Link>
+          </div>
+          <span style={styles.readOnlyChip}>読み取り専用</span>
+        </nav>
+
+        <ViewerState result={result} emptyMessage="指定されたテーマには表示対象のデータがありません。" />
+
+        {result.status === "ok" ? (
+          <>
+            <ViewerHero
+              eyebrow="theme detail / theme-viewer.v1"
+              title={result.data.theme.displayName}
+              description={`slug: ${result.data.theme.slug}`}
+            >
+              <div style={styles.heroMetaRow}>
+                <StatusBadge status={result.data.theme.status} />
+                <span style={styles.mutedBadge}>ID: {result.data.theme.id}</span>
+              </div>
+              <Provenance provenance={{
+                source: result.data.source ?? result.data.theme.provenance.source,
+                asOf: result.data.asOf ?? result.data.theme.provenance.asOf,
+                confidence: result.data.theme.provenance.confidence,
+              }} />
+            </ViewerHero>
+
+            <div style={styles.detailGrid}>
+              <OverviewSection data={result.data} />
+              <ThesisSection data={result.data} />
+              <AnalysisHistorySection data={result.data} />
+              <EvidenceSection data={result.data} />
+              <DirectLinksSection data={result.data} />
+              <TaxonomySection data={result.data} />
+              <MetricsSection data={result.data} />
+              <OpenActionsSection data={result.data} />
+            </div>
+
+            <section style={styles.guardrail}>
+              <strong>表示上の境界</strong>
+              <p style={{ ...mutedStyle, marginTop: 6 }}>
+                この画面は保存済みThemeの確認専用です。Themeとの関連、根拠、指標、open actionは売買判断・資金配分・発注を自動確定しません。編集や確定が必要な場合はChatGPT + Supabaseの編集チャネルを使います。
+              </p>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  page: {
+    minHeight: "100vh",
+    padding: "24px 16px 72px",
+    background: "#f8fafc",
+  },
+  shell: {
+    maxWidth: 1120,
+    margin: "0 auto",
+  },
+  shellWide: {
+    maxWidth: 1240,
+    margin: "0 auto",
+  },
+  topNav: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
+    flexWrap: "wrap",
+    marginBottom: 18,
+  },
+  navGroup: {
+    display: "flex",
+    gap: 14,
+    flexWrap: "wrap",
+  },
+  backLink: {
+    color: "#64748b",
+    textDecoration: "none",
+    fontSize: 13,
+    fontWeight: 800,
+  },
+  readOnlyChip: {
+    display: "inline-flex",
+    padding: "5px 10px",
+    borderRadius: 999,
+    background: "#fff",
+    border: "1px solid #cbd5e1",
+    color: "#475569",
+    fontSize: 11,
+    fontWeight: 800,
+  },
+  hero: {
+    marginBottom: 22,
+  },
+  eyebrow: {
+    display: "inline-flex",
+    padding: "6px 10px",
+    borderRadius: 999,
+    background: "#eef2ff",
+    border: "1px solid #c7d2fe",
+    color: "#4338ca",
+    fontSize: 11,
+    fontWeight: 900,
+    letterSpacing: 0.3,
+  },
+  title: {
+    margin: "12px 0 8px",
+    color: "#0f172a",
+    fontSize: "clamp(30px, 6vw, 46px)",
+    lineHeight: 1.12,
+    letterSpacing: -1,
+    fontWeight: 900,
+  },
+  heroDescription: {
+    maxWidth: 820,
+    margin: 0,
+    color: "#475569",
+    fontSize: 14,
+    lineHeight: 1.8,
+  },
+  heroMetaRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: 8,
+    marginTop: 14,
+  },
+  provenance: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 8,
+    alignItems: "center",
+    marginTop: 14,
+    color: "#64748b",
+    fontSize: 11,
+    lineHeight: 1.5,
+  },
+  badge: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "4px 9px",
+    borderRadius: 999,
+    border: "1px solid",
+    fontSize: 11,
+    fontWeight: 900,
+    whiteSpace: "nowrap",
+  },
+  mutedBadge: {
+    display: "inline-flex",
+    alignItems: "center",
+    padding: "4px 8px",
+    borderRadius: 999,
+    background: "#f1f5f9",
+    border: "1px solid #e2e8f0",
+    color: "#475569",
+    fontSize: 11,
+    fontWeight: 800,
+    whiteSpace: "nowrap",
+  },
+  listGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(270px, 1fr))",
+    gap: 14,
+  },
+  themeCard: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+    minHeight: 210,
+    padding: 18,
+    borderRadius: 18,
+    background: "#fff",
+    border: "1px solid rgba(15,23,42,0.08)",
+    color: "var(--color-text)",
+    textDecoration: "none",
+    boxShadow: "0 10px 30px rgba(15,23,42,0.05)",
+  },
+  themeCardTop: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 8,
+  },
+  themeSlug: {
+    overflow: "hidden",
+    color: "#94a3b8",
+    fontSize: 11,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  themeTitle: {
+    margin: "4px 0 0",
+    color: "#0f172a",
+    fontSize: 19,
+    lineHeight: 1.35,
+    fontWeight: 900,
+  },
+  themeCardMeta: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 8,
+    alignItems: "center",
+    color: "#64748b",
+    fontSize: 11,
+  },
+  openLabel: {
+    marginTop: "auto",
+    color: "#1d4ed8",
+    fontSize: 13,
+    fontWeight: 900,
+  },
+  detailGrid: {
+    display: "grid",
+    gap: 16,
+  },
+  sectionHeading: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 12,
+    flexWrap: "wrap",
+  },
+  sectionTitle: {
+    margin: 0,
+    color: "#0f172a",
+    fontSize: 20,
+    lineHeight: 1.3,
+    fontWeight: 900,
+  },
+  fieldLabel: {
+    marginBottom: 5,
+    color: "#64748b",
+    fontSize: 11,
+    fontWeight: 900,
+  },
+  longText: {
+    color: "#334155",
+    fontSize: 13,
+    lineHeight: 1.8,
+    whiteSpace: "pre-wrap",
+  },
+  compactList: {
+    margin: 0,
+    paddingLeft: 20,
+    color: "#334155",
+    fontSize: 13,
+    lineHeight: 1.75,
+  },
+  inlineMeta: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: 8,
+    color: "#64748b",
+    fontSize: 12,
+  },
+  stack: {
+    display: "grid",
+    gap: 10,
+    marginTop: 14,
+  },
+  subCard: {
+    display: "grid",
+    gap: 10,
+    padding: 14,
+    borderRadius: 14,
+    background: "#f8fafc",
+    border: "1px solid #e2e8f0",
+  },
+  itemHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 10,
+    flexWrap: "wrap",
+  },
+  itemEyebrow: {
+    color: "#6366f1",
+    fontSize: 11,
+    fontWeight: 900,
+  },
+  itemTitle: {
+    margin: "4px 0 0",
+    color: "#0f172a",
+    fontSize: 15,
+    lineHeight: 1.45,
+    fontWeight: 900,
+  },
+  itemDate: {
+    color: "#64748b",
+    fontSize: 11,
+    whiteSpace: "nowrap",
+  },
+  tagRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+  metaGrid: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "5px 12px",
+    color: "#64748b",
+    fontSize: 11,
+    lineHeight: 1.6,
+  },
+  sourceRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 10,
+    alignItems: "center",
+    color: "#64748b",
+    fontSize: 12,
+  },
+  externalLink: {
+    color: "#1d4ed8",
+    textDecoration: "none",
+    fontWeight: 800,
+  },
+  taxonomyGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+    gap: 18,
+    marginTop: 16,
+  },
+  subheading: {
+    margin: 0,
+    color: "#0f172a",
+    fontSize: 14,
+    fontWeight: 900,
+  },
+  relationList: {
+    display: "grid",
+    gap: 8,
+    margin: "10px 0 0",
+    padding: 0,
+    listStyle: "none",
+    color: "#334155",
+    fontSize: 12,
+    lineHeight: 1.6,
+  },
+  tableScroll: {
+    overflowX: "auto",
+  },
+  table: {
+    width: "100%",
+    minWidth: 720,
+    borderCollapse: "collapse",
+    color: "#334155",
+    fontSize: 12,
+  },
+  th: {
+    padding: "8px 7px",
+    borderBottom: "1px solid #cbd5e1",
+    color: "#64748b",
+    textAlign: "left",
+    fontSize: 11,
+    whiteSpace: "nowrap",
+  },
+  td: {
+    padding: "10px 7px",
+    borderBottom: "1px solid #e2e8f0",
+    verticalAlign: "top",
+    lineHeight: 1.6,
+  },
+  tableMuted: {
+    color: "#94a3b8",
+    fontSize: 11,
+  },
+  guardrail: {
+    marginTop: 16,
+    padding: 16,
+    borderRadius: 16,
+    background: "#eff6ff",
+    border: "1px solid #bfdbfe",
+    color: "#1e3a8a",
+    fontSize: 13,
+    lineHeight: 1.7,
+  },
+  stateTitle: {
+    margin: "0 0 8px",
+    fontSize: 17,
+    fontWeight: 900,
+  },
+  footnote: {
+    margin: "18px 0 0",
+    color: "#94a3b8",
+    fontSize: 11,
+    lineHeight: 1.7,
+  },
+};

--- a/app/premium/themes/ThemeViewer.tsx
+++ b/app/premium/themes/ThemeViewer.tsx
@@ -94,6 +94,10 @@ function ConfidenceBadge({ confidence }: { confidence: ThemeConfidence | null | 
   return <span style={styles.mutedBadge}>{CONFIDENCE_LABELS[confidence]}</span>;
 }
 
+function formatThesisStatus(status: string) {
+  return status === "draft" ? "下書き" : status;
+}
+
 function AvailabilityBadge({ availability }: { availability: ThemeSectionAvailability }) {
   const color = DATA_STATE_COLORS[availability.state];
   return (
@@ -335,7 +339,7 @@ function ThesisSection({ data }: { data: NonNullable<Extract<ThemeDetailLoadResu
     <Section title="現在の見立て" availability={availability} description="見立てのas-ofと確度を、概要とは分けて確認します。">
       <div style={{ display: "grid", gap: 14, marginTop: 16 }}>
         <div style={styles.inlineMeta}>
-          <span style={styles.mutedBadge}>{thesis.status}</span>
+          <span style={styles.mutedBadge}>{formatThesisStatus(thesis.status)}</span>
           <span style={styles.mutedBadge}>v{thesis.versionNumber ?? "—"}</span>
           <span>as-of {formatDateTime(thesis.asOf)}</span>
           <ConfidenceBadge confidence={thesis.confidence} />

--- a/app/premium/themes/[themeId]/page.tsx
+++ b/app/premium/themes/[themeId]/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+import { loadThemeDetail } from "../data-loader";
+import { ThemeDetailView } from "../ThemeViewer";
+
+export const metadata: Metadata = {
+  title: "テーマ詳細 | mini-tools premium",
+  description: "stock-notesに保存したテーマの見立て・根拠・taxonomy・metrics・actionを読み取り専用で確認します。",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default async function PremiumThemeDetailPage({
+  params,
+}: {
+  params: Promise<{ themeId: string }>;
+}) {
+  const { themeId } = await params;
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+
+  if (!verifyPremiumSession(session)) {
+    redirect(`/premium/login?next=${encodeURIComponent(`/premium/themes/${themeId}`)}`);
+  }
+
+  const result = await loadThemeDetail(themeId);
+  return <ThemeDetailView result={result} />;
+}

--- a/app/premium/themes/data-loader.test.ts
+++ b/app/premium/themes/data-loader.test.ts
@@ -51,8 +51,11 @@ function fullDetailResponse() {
       risks: ["capex slowdown"],
       falsificationConditions: ["orders decline for two quarters"],
       nextChecks: ["check quarterly bookings"],
-      asOf: "2026-08-26",
-      source: "chatgpt-supabase",
+      provenance: {
+        source: "chatgpt-supabase",
+        asOf: "2026-08-26",
+        confidence: "medium",
+      },
       basedOnAnalysisId: "analysis-1",
     },
     analysisHistory: [
@@ -282,7 +285,11 @@ describe("Theme Viewer data loader", () => {
       asOf: "2026-08-26",
       confidence: "medium",
     });
-    expect(result.data.currentThesis?.status).toBe("draft");
+    expect(result.data.currentThesis).toMatchObject({
+      status: "draft",
+      source: "chatgpt-supabase",
+      asOf: "2026-08-26",
+    });
     expect(result.data.analysisHistory[0]).toMatchObject({ asOf: "2026-08-25", confidence: "medium" });
     expect(result.data.directLinks[0]?.url).toBe("https://example.com/stocks/stock-1");
     expect(result.data.taxonomyMap.stockLinks[0]?.stockId).toBe("stock-1");
@@ -410,8 +417,10 @@ describe("Theme Viewer data loader", () => {
       .mockResolvedValueOnce(jsonResponse({ schemaVersion: "theme-viewer.v1", themes: [{ id: "missing-fields" }] }))
       .mockResolvedValueOnce(
         jsonResponse({ schemaVersion: "theme-viewer.v2", themes: [] }),
-      );
+      )
+      .mockResolvedValueOnce(jsonResponse({ themes: [] }));
 
+    await expect(loadThemeList()).resolves.toMatchObject({ status: "invalid_response" });
     await expect(loadThemeList()).resolves.toMatchObject({ status: "invalid_response" });
     await expect(loadThemeList()).resolves.toMatchObject({ status: "invalid_response" });
   });

--- a/app/premium/themes/data-loader.test.ts
+++ b/app/premium/themes/data-loader.test.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadThemeDetail, loadThemeList, parseThemeDetailResponse } from "./data-loader";
+
+const API_BASE_ENV = "STOCK_NOTES_API_BASE_URL";
+const API_TOKEN_ENV = "STOCK_NOTES_API_TOKEN";
+const API_BASE = "https://stock-notes.example.test/api/";
+const API_TOKEN = "theme-viewer-test-token";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function setApiConfig() {
+  process.env[API_BASE_ENV] = API_BASE;
+  process.env[API_TOKEN_ENV] = API_TOKEN;
+}
+
+function fullDetailResponse() {
+  return {
+    schemaVersion: "theme-viewer.v1",
+    source: "stock-notes",
+    asOf: "2026-08-27T00:00:00Z",
+    theme: {
+      id: "theme-1",
+      slug: "ai-infrastructure",
+      displayName: "AI infrastructure",
+      status: "draft",
+      summary: "AI infrastructure investment theme",
+      definition: "A theme about the infrastructure supporting AI workloads.",
+      createdAt: "2026-08-01T00:00:00Z",
+      updatedAt: "2026-08-27T00:00:00Z",
+      archivedAt: null,
+      provenance: {
+        source: "chatgpt-supabase",
+        asOf: "2026-08-26",
+        confidence: "medium",
+      },
+    },
+    currentThesis: {
+      id: "thesis-1",
+      versionNumber: 2,
+      status: "draft",
+      definition: "Demand for compute and power may expand together.",
+      structuralHypothesis: "Capacity constraints can persist through the build-out.",
+      confidence: "medium",
+      lenses: ["demand", "capacity"],
+      risks: ["capex slowdown"],
+      falsificationConditions: ["orders decline for two quarters"],
+      nextChecks: ["check quarterly bookings"],
+      asOf: "2026-08-26",
+      source: "chatgpt-supabase",
+      basedOnAnalysisId: "analysis-1",
+    },
+    analysisHistory: [
+      {
+        id: "analysis-1",
+        analysisType: "quarterly_review",
+        conclusion: "The hypothesis remains open.",
+        evidence: "Bookings were resilient.",
+        concerns: "Power availability is a constraint.",
+        body: "Review notes",
+        source: "chatgpt-supabase",
+        sourceUrl: "https://example.com/analysis",
+        asOf: "2026-08-25",
+        confidence: "medium",
+        createdAt: "2026-08-25T00:00:00Z",
+      },
+    ],
+    evidence: [
+      {
+        id: "evidence-1",
+        analysisId: "analysis-1",
+        thesisId: "thesis-1",
+        evidenceType: "source",
+        claimKind: "supporting",
+        stance: "supports",
+        claim: "Bookings remained resilient.",
+        sourceTitle: "Example filing",
+        sourceUrl: "https://example.com/filing",
+        sourceType: "filing",
+        sourceAsOf: "2026-08-24",
+        checkedAt: "2026-08-25",
+        confidence: "high",
+        verificationStatus: "checked",
+      },
+    ],
+    directLinks: [
+      {
+        id: "link-1",
+        targetType: "stock",
+        targetId: "stock-1",
+        displayName: "Example stock",
+        relationType: "exposure",
+        relationNote: "Illustrative direct link",
+        url: "https://example.com/stocks/stock-1",
+        status: "proposed",
+        contributionStage: "enabler",
+        sourceTitle: "Internal mapping",
+        sourceUrl: "https://example.com/mapping",
+        sourceAsOf: "2026-08-20",
+        checkedAt: "2026-08-21",
+        confidence: "medium",
+      },
+    ],
+    taxonomyMap: {
+      nodes: [
+        {
+          id: "node-1",
+          domain: "technology",
+          kind: "category",
+          slug: "compute",
+          displayName: "Compute",
+          description: "Compute infrastructure",
+          status: "active",
+        },
+      ],
+      edges: [
+        {
+          id: "edge-1",
+          sourceNodeId: "node-1",
+          targetNodeId: "node-2",
+          relationType: "related_to",
+          relationNote: null,
+        },
+      ],
+      themeLinks: [
+        {
+          id: "theme-link-1",
+          nodeId: "node-1",
+          relationType: "includes",
+          relationNote: null,
+        },
+      ],
+      stockLinks: [
+        {
+          id: "stock-link-1",
+          stockId: "stock-1",
+          nodeId: "node-1",
+          strategicRole: "enabler",
+          controlType: "supply",
+          relationNote: null,
+          source: "chatgpt-supabase",
+          confidence: "medium",
+          asOf: "2026-08-20",
+          validFrom: "2026-01-01",
+          validTo: null,
+        },
+      ],
+    },
+    metrics: {
+      definitions: [
+        {
+          id: "metric-1",
+          metricKey: "capacity_growth",
+          displayName: "Capacity growth",
+          scope: "theme",
+          appliesToStockId: null,
+          unit: "%",
+          definition: "Year-on-year capacity growth.",
+          versionNumber: 1,
+          isActive: true,
+        },
+      ],
+      snapshots: [
+        {
+          id: "snapshot-1",
+          asOf: "2026-08-26",
+          periodLabel: "2026 Q2",
+          snapshotKind: "quarterly",
+          note: null,
+        },
+      ],
+      values: [
+        {
+          id: "value-1",
+          snapshotId: "snapshot-1",
+          metricId: "metric-1",
+          stockId: "stock-1",
+          value: 0,
+          evidenceId: "evidence-1",
+          calculationNote: "Zero is a reported value, not missing.",
+        },
+      ],
+    },
+    openActions: [
+      {
+        id: "action-1",
+        actionType: "check",
+        title: "Check next bookings release",
+        detail: "Compare bookings with the thesis threshold.",
+        triggerCondition: "Next quarterly filing",
+        dueDate: "2026-11-01",
+        status: "open",
+        basedOnAnalysisId: "analysis-1",
+        basedOnThesisId: "thesis-1",
+        createdAt: "2026-08-26T00:00:00Z",
+        updatedAt: "2026-08-26T00:00:00Z",
+      },
+    ],
+  };
+}
+
+describe("Theme Viewer data loader", () => {
+  beforeEach(() => {
+    vi.stubEnv(API_BASE_ENV, "");
+    vi.stubEnv(API_TOKEN_ENV, "");
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("正常な一覧をcamelCase read modelへ変換し、tokenを結果へ含めない", async () => {
+    setApiConfig();
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        schemaVersion: "theme-viewer.v1",
+        source: "stock-notes",
+        asOf: "2026-08-27",
+        themes: [
+          {
+            id: "theme-1",
+            slug: "ai-infrastructure",
+            displayName: "AI infrastructure",
+            status: "draft",
+            summary: "Summary",
+            source: "chatgpt-supabase",
+            asOf: "2026-08-26",
+            confidence: "medium",
+            updatedAt: "2026-08-27",
+            analysisCount: 0,
+            openActionCount: 2,
+          },
+        ],
+      }),
+    );
+
+    const result = await loadThemeList();
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.data.themes[0]).toMatchObject({
+        id: "theme-1",
+        displayName: "AI infrastructure",
+        analysisCount: 0,
+        openActionCount: 2,
+      });
+    }
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://stock-notes.example.test/api/viewer/themes",
+      expect.objectContaining({
+        method: "GET",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${API_TOKEN}`,
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain(API_TOKEN);
+  });
+
+  it("正常な詳細で各セクション、provenance、0のmetric値を保持する", async () => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse(fullDetailResponse()));
+
+    const result = await loadThemeDetail("theme-1");
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.data.theme.provenance).toEqual({
+      source: "chatgpt-supabase",
+      asOf: "2026-08-26",
+      confidence: "medium",
+    });
+    expect(result.data.currentThesis?.status).toBe("draft");
+    expect(result.data.analysisHistory[0]).toMatchObject({ asOf: "2026-08-25", confidence: "medium" });
+    expect(result.data.directLinks[0]?.url).toBe("https://example.com/stocks/stock-1");
+    expect(result.data.taxonomyMap.stockLinks[0]?.stockId).toBe("stock-1");
+    expect(result.data.metrics.values[0]?.value).toBe(0);
+    expect(result.data.openActions[0]?.title).toBe("Check next bookings release");
+    expect(result.data.availability.metrics).toEqual({ state: "present", count: 3 });
+  });
+
+  it.each([
+    ["base URLがない", undefined, API_TOKEN],
+    ["tokenがない", API_BASE, undefined],
+    ["base URLのschemeが不正", "ftp://stock-notes.example.test", API_TOKEN],
+  ])("%sとき、not_configuredを返してfetchしない", async (_label, baseUrl, token) => {
+    if (baseUrl) process.env[API_BASE_ENV] = baseUrl;
+    if (token) process.env[API_TOKEN_ENV] = token;
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    const result = await loadThemeList();
+
+    expect(result).toMatchObject({ status: "not_configured", httpStatus: null });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("401をunauthorizedとして返し、tokenや上流エラー本文を露出しない", async () => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse({ secret: API_TOKEN }, 401));
+
+    const result = await loadThemeList();
+
+    expect(result).toMatchObject({ status: "unauthorized", httpStatus: 401 });
+    expect(JSON.stringify(result)).not.toContain(API_TOKEN);
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  it.each([500, 503])("HTTP %sをupstream_errorとして空状態と区別する", async (status) => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockResolvedValue(jsonResponse({ themes: [] }, status));
+
+    const result = await loadThemeList();
+
+    expect(result).toMatchObject({ status: "upstream_error", httpStatus: status });
+  });
+
+  it("一覧の空配列をemptyとして返す", async () => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({ schemaVersion: "theme-viewer.v1", source: "stock-notes", themes: [] }),
+    );
+
+    const result = await loadThemeList();
+
+    expect(result).toMatchObject({ status: "empty", data: { themes: [] } });
+  });
+
+  it("詳細404をnot_foundとして返す", async () => {
+    setApiConfig();
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(jsonResponse({ message: "not found" }, 404));
+
+    const result = await loadThemeDetail("theme/日本語");
+
+    expect(result).toMatchObject({ status: "not_found", httpStatus: 404 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://stock-notes.example.test/api/viewer/themes/theme%2F%E6%97%A5%E6%9C%AC%E8%AA%9E",
+      expect.any(Object),
+    );
+  });
+
+  it("詳細のtheme=nullをemptyとして返す", async () => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({ schemaVersion: "theme-viewer.v1", theme: null }),
+    );
+
+    const result = await loadThemeDetail("theme-1");
+
+    expect(result).toEqual({ status: "empty" });
+  });
+
+  it("接続失敗をupstream_errorとして返す", async () => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error("network failure"));
+
+    const result = await loadThemeList();
+
+    expect(result).toMatchObject({ status: "upstream_error", httpStatus: null });
+    expect(JSON.stringify(result)).not.toContain("network failure");
+  });
+
+  it("詳細の明示的nullと未提供セクションをそれぞれempty/missingで表す", async () => {
+    setApiConfig();
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({
+        schemaVersion: "theme-viewer.v1",
+        theme: {
+          id: "theme-1",
+          slug: "minimal",
+          displayName: "Minimal theme",
+          status: "active",
+        },
+        currentThesis: null,
+      }),
+    );
+
+    const result = await loadThemeDetail("theme-1");
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.data.availability).toMatchObject({
+      overview: { state: "missing", count: 0 },
+      thesis: { state: "empty", count: 0 },
+      analysisHistory: { state: "missing", count: 0 },
+      evidence: { state: "missing", count: 0 },
+      directLinks: { state: "missing", count: 0 },
+      taxonomyMap: { state: "missing", count: 0 },
+      metrics: { state: "missing", count: 0 },
+      openActions: { state: "missing", count: 0 },
+    });
+  });
+
+  it("レスポンスの必須項目欠損や未知の契約versionをinvalid_responseとする", async () => {
+    setApiConfig();
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ schemaVersion: "theme-viewer.v1", themes: [{ id: "missing-fields" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ schemaVersion: "theme-viewer.v2", themes: [] }),
+      );
+
+    await expect(loadThemeList()).resolves.toMatchObject({ status: "invalid_response" });
+    await expect(loadThemeList()).resolves.toMatchObject({ status: "invalid_response" });
+  });
+
+  it("既存snake_caseの移行レスポンスもcamelCase read modelへ正規化する", () => {
+    const data = parseThemeDetailResponse({
+      schema_version: "theme-viewer.v1",
+      source_system: "stock-notes",
+      generated_at: "2026-08-27",
+      theme: {
+        id: "theme-1",
+        slug: "snake-case",
+        display_name: "Snake case",
+        status: "active",
+        theme_definition: "Definition",
+      },
+      active_thesis: {
+        id: "thesis-1",
+        version_number: 1,
+        status: "draft",
+        structural_hypothesis: "Hypothesis",
+        falsification_conditions: [],
+        next_checks: [],
+      },
+      analysis_history: [],
+      direct_links: [],
+      open_actions: [],
+    });
+
+    expect(data.theme.displayName).toBe("Snake case");
+    expect(data.theme.definition).toBe("Definition");
+    expect(data.currentThesis?.structuralHypothesis).toBe("Hypothesis");
+    expect(data.availability.analysisHistory).toEqual({ state: "empty", count: 0 });
+  });
+});

--- a/app/premium/themes/data-loader.ts
+++ b/app/premium/themes/data-loader.ts
@@ -1,0 +1,713 @@
+import type {
+  ThemeAnalysis,
+  ThemeConfidence,
+  ThemeDetailData,
+  ThemeDetailLoadResult,
+  ThemeDirectLink,
+  ThemeEvidence,
+  ThemeListData,
+  ThemeListItem,
+  ThemeListLoadResult,
+  ThemeMetricDefinition,
+  ThemeMetricSnapshot,
+  ThemeMetricValue,
+  ThemeMetrics,
+  ThemeOpenAction,
+  ThemeProvenance,
+  ThemeRecord,
+  ThemeSectionAvailability,
+  ThemeSectionKey,
+  ThemeStatus,
+  ThemeStockTaxonomyLink,
+  ThemeTaxonomyEdge,
+  ThemeTaxonomyLink,
+  ThemeTaxonomyMap,
+  ThemeTaxonomyNode,
+  ThemeThesis,
+  ThemeViewerError,
+  ThemeViewerErrorStatus,
+} from "./types";
+import { THEME_VIEWER_CONTRACT_VERSION } from "./types";
+
+/**
+ * Theme Viewerはstock-notesのDBや編集APIを直接読まない。
+ * このloaderはServer Componentからだけ呼び出し、tokenをprops・URL・レスポンスへ
+ * 渡さない。ブラウザで使うコンポーネントからimportしないこと。
+ */
+
+const API_BASE_ENV = "STOCK_NOTES_API_BASE_URL";
+const API_TOKEN_ENV = "STOCK_NOTES_API_TOKEN";
+const REQUEST_TIMEOUT_MS = 5_000;
+
+type RawObject = Record<string, unknown>;
+type Fetcher = typeof fetch;
+
+type RequestResult =
+  | { ok: true; body: unknown }
+  | RequestFailure;
+
+type RequestFailure = {
+  ok: false;
+  status: ThemeViewerErrorStatus;
+  message: string;
+  httpStatus: number | null;
+};
+
+type Field = {
+  found: boolean;
+  value: unknown;
+};
+
+class ThemeViewerResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ThemeViewerResponseError";
+  }
+}
+
+function isObject(value: unknown): value is RawObject {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(record: RawObject, key: string) {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function readField(record: RawObject, keys: string[]): Field {
+  for (const key of keys) {
+    if (hasOwn(record, key)) return { found: true, value: record[key] };
+  }
+  return { found: false, value: undefined };
+}
+
+function requiredObject(value: unknown, label: string): RawObject {
+  if (!isObject(value)) throw new ThemeViewerResponseError(`${label} is not an object`);
+  return value;
+}
+
+function requiredString(record: RawObject, keys: string[], label: string): string {
+  const field = readField(record, keys);
+  if (typeof field.value !== "string" || field.value.trim().length === 0) {
+    throw new ThemeViewerResponseError(`${label} is missing`);
+  }
+  return field.value;
+}
+
+function optionalString(record: RawObject, keys: string[]): string | null {
+  const field = readField(record, keys);
+  if (field.value === undefined || field.value === null) return null;
+  if (typeof field.value !== "string") {
+    throw new ThemeViewerResponseError(`${keys[0]} is not a string`);
+  }
+  return field.value.trim().length > 0 ? field.value : null;
+}
+
+function optionalNumber(record: RawObject, keys: string[]): number | null {
+  const field = readField(record, keys);
+  if (field.value === undefined || field.value === null || field.value === "") return null;
+  if (typeof field.value === "number") {
+    if (Number.isFinite(field.value)) return field.value;
+    throw new ThemeViewerResponseError(`${keys[0]} is not finite`);
+  }
+  if (typeof field.value === "string" && field.value.trim().length > 0) {
+    const parsed = Number(field.value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  throw new ThemeViewerResponseError(`${keys[0]} is not a number`);
+}
+
+function optionalBoolean(record: RawObject, keys: string[]): boolean | null {
+  const field = readField(record, keys);
+  if (field.value === undefined || field.value === null) return null;
+  if (typeof field.value === "boolean") return field.value;
+  if (field.value === "true") return true;
+  if (field.value === "false") return false;
+  throw new ThemeViewerResponseError(`${keys[0]} is not a boolean`);
+}
+
+function stringArray(record: RawObject, keys: string[]): string[] {
+  const field = readField(record, keys);
+  if (field.value === undefined || field.value === null) return [];
+  if (!Array.isArray(field.value)) {
+    throw new ThemeViewerResponseError(`${keys[0]} is not an array`);
+  }
+  return field.value.filter((value): value is string => typeof value === "string");
+}
+
+function objectArray(record: RawObject, keys: string[]): { found: boolean; values: unknown[] } {
+  const field = readField(record, keys);
+  if (!field.found || field.value === null) return { found: field.found, values: [] };
+  if (!Array.isArray(field.value)) {
+    throw new ThemeViewerResponseError(`${keys[0]} is not an array`);
+  }
+  return { found: true, values: field.value };
+}
+
+function optionalHttpUrl(record: RawObject, keys: string[]): string | null {
+  const value = optionalString(record, keys);
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function optionalConfidence(record: RawObject, keys: string[]): ThemeConfidence | null {
+  const value = optionalString(record, keys);
+  if (value === null) return null;
+  return value === "high" || value === "medium" || value === "low" ? value : null;
+}
+
+function requiredThemeStatus(record: RawObject): ThemeStatus {
+  const value = requiredString(record, ["status"], "status");
+  if (value === "draft" || value === "active" || value === "archived") return value;
+  throw new ThemeViewerResponseError("status is invalid");
+}
+
+function contractVersion(record: RawObject): typeof THEME_VIEWER_CONTRACT_VERSION {
+  const field = readField(record, ["schemaVersion", "schema_version", "contractVersion", "contract_version"]);
+  if (field.value !== undefined && field.value !== THEME_VIEWER_CONTRACT_VERSION) {
+    throw new ThemeViewerResponseError("unsupported viewer contract version");
+  }
+  return THEME_VIEWER_CONTRACT_VERSION;
+}
+
+function topLevelProvenance(record: RawObject): ThemeProvenance {
+  return {
+    source: optionalString(record, ["source", "sourceSystem", "source_system"]),
+    asOf: optionalString(record, ["asOf", "as_of", "generatedAt", "generated_at"]),
+    confidence: optionalConfidence(record, ["confidence"]),
+  };
+}
+
+function provenance(record: RawObject, fallback: ThemeProvenance): ThemeProvenance {
+  const nested = readField(record, ["provenance"]);
+  const sourceRecord = isObject(nested.value) ? nested.value : record;
+  return {
+    source: optionalString(sourceRecord, ["source", "sourceSystem", "source_system"]) ?? fallback.source,
+    asOf:
+      optionalString(sourceRecord, ["asOf", "as_of", "generatedAt", "generated_at"]) ?? fallback.asOf,
+    confidence: optionalConfidence(sourceRecord, ["confidence"]) ?? fallback.confidence,
+  };
+}
+
+function parseListItem(value: unknown, fallback: ThemeProvenance): ThemeListItem {
+  const record = requiredObject(value, "theme");
+  const itemProvenance = provenance(record, fallback);
+  return {
+    id: requiredString(record, ["id"], "theme.id"),
+    slug: requiredString(record, ["slug"], "theme.slug"),
+    displayName: requiredString(record, ["displayName", "display_name"], "theme.displayName"),
+    status: requiredThemeStatus(record),
+    summary: optionalString(record, ["summary", "overview"]),
+    asOf: itemProvenance.asOf,
+    source: itemProvenance.source,
+    confidence: itemProvenance.confidence,
+    updatedAt: optionalString(record, ["updatedAt", "updated_at"]),
+    analysisCount: optionalNumber(record, ["analysisCount", "analysis_count"]),
+    openActionCount: optionalNumber(record, ["openActionCount", "open_action_count"]),
+  };
+}
+
+/** Viewer一覧レスポンスをcamelCaseのread modelへ変換する。 */
+export function parseThemeListResponse(input: unknown): ThemeListData {
+  const root = isObject(input) ? input : {};
+  const fallback = topLevelProvenance(root);
+  const field = Array.isArray(input)
+    ? { found: true, values: input }
+    : objectArray(root, ["themes"]);
+  if (!field.found) throw new ThemeViewerResponseError("themes is missing");
+
+  return {
+    contractVersion: contractVersion(root),
+    source: fallback.source,
+    asOf: fallback.asOf,
+    themes: field.values.map((item) => parseListItem(item, fallback)),
+  };
+}
+
+function parseThemeRecord(value: unknown, fallback: ThemeProvenance): ThemeRecord {
+  const record = requiredObject(value, "theme");
+  return {
+    id: requiredString(record, ["id"], "theme.id"),
+    slug: requiredString(record, ["slug"], "theme.slug"),
+    displayName: requiredString(record, ["displayName", "display_name"], "theme.displayName"),
+    status: requiredThemeStatus(record),
+    summary: optionalString(record, ["summary", "overview"]),
+    definition: optionalString(record, ["definition", "themeDefinition", "theme_definition"]),
+    createdAt: optionalString(record, ["createdAt", "created_at"]),
+    updatedAt: optionalString(record, ["updatedAt", "updated_at"]),
+    archivedAt: optionalString(record, ["archivedAt", "archived_at"]),
+    provenance: provenance(record, fallback),
+  };
+}
+
+function parseThesis(value: unknown, fallback: ThemeProvenance): ThemeThesis {
+  const record = requiredObject(value, "currentThesis");
+  return {
+    id: requiredString(record, ["id"], "currentThesis.id"),
+    versionNumber: optionalNumber(record, ["versionNumber", "version_number"]),
+    status: optionalString(record, ["status"]) ?? "draft",
+    definition: optionalString(record, ["definition"]),
+    structuralHypothesis: optionalString(record, ["structuralHypothesis", "structural_hypothesis"]),
+    confidence:
+      optionalConfidence(record, ["confidence"]) ??
+      provenance(record, fallback).confidence,
+    lenses: stringArray(record, ["lenses"]),
+    risks: stringArray(record, ["risks"]),
+    falsificationConditions: stringArray(record, ["falsificationConditions", "falsification_conditions"]),
+    nextChecks: stringArray(record, ["nextChecks", "next_checks"]),
+    asOf: optionalString(record, ["asOf", "as_of"]),
+    source: provenance(record, fallback).source,
+    basedOnAnalysisId: optionalString(record, ["basedOnAnalysisId", "based_on_analysis_id"]),
+  };
+}
+
+function parseAnalysis(value: unknown, fallback: ThemeProvenance): ThemeAnalysis {
+  const record = requiredObject(value, "analysis");
+  const analysisProvenance = provenance(record, fallback);
+  return {
+    id: requiredString(record, ["id"], "analysis.id"),
+    analysisType: optionalString(record, ["analysisType", "analysis_type"]) ?? "other",
+    conclusion: optionalString(record, ["conclusion"]),
+    evidence: optionalString(record, ["evidence"]),
+    concerns: optionalString(record, ["concerns"]),
+    body: optionalString(record, ["body", "bodySummary", "body_summary"]),
+    source: analysisProvenance.source,
+    sourceUrl: optionalHttpUrl(record, ["sourceUrl", "source_url"]),
+    asOf:
+      optionalString(record, ["asOf", "as_of", "analyzedAt", "analyzed_at"]) ?? analysisProvenance.asOf,
+    confidence: optionalConfidence(record, ["confidence"]) ?? fallback.confidence,
+    createdAt: optionalString(record, ["createdAt", "created_at"]),
+  };
+}
+
+function parseEvidence(value: unknown, fallback: ThemeProvenance): ThemeEvidence {
+  const record = requiredObject(value, "evidence");
+  return {
+    id: requiredString(record, ["id"], "evidence.id"),
+    analysisId: optionalString(record, ["analysisId", "analysis_id"]),
+    thesisId: optionalString(record, ["thesisId", "thesis_id"]),
+    evidenceType: optionalString(record, ["evidenceType", "evidence_type"]) ?? "other",
+    claimKind: optionalString(record, ["claimKind", "claim_kind"]) ?? "other",
+    stance: optionalString(record, ["stance"]) ?? "context",
+    claim: optionalString(record, ["claim", "claimSummary", "claim_summary"]),
+    sourceTitle: optionalString(record, ["sourceTitle", "source_title"]),
+    sourceUrl: optionalHttpUrl(record, ["sourceUrl", "source_url"]),
+    sourceType: optionalString(record, ["sourceType", "source_type"]),
+    sourceAsOf: optionalString(record, ["sourceAsOf", "source_as_of"]),
+    checkedAt: optionalString(record, ["checkedAt", "checked_at"]),
+    confidence: optionalConfidence(record, ["confidence"]) ?? fallback.confidence,
+    verificationStatus: optionalString(record, ["verificationStatus", "verification_status"]),
+  };
+}
+
+function parseDirectLink(value: unknown, fallback: ThemeProvenance): ThemeDirectLink {
+  const record = requiredObject(value, "directLink");
+  return {
+    id: requiredString(record, ["id"], "directLink.id"),
+    targetType: optionalString(record, ["targetType", "target_type"]) ?? "other",
+    targetId: optionalString(record, ["targetId", "target_id", "stockId", "stock_id"]),
+    displayName: requiredString(record, ["displayName", "display_name", "label"], "directLink.displayName"),
+    relationType: optionalString(record, ["relationType", "relation_type"]) ?? "related",
+    relationNote: optionalString(record, ["relationNote", "relation_note"]),
+    url: optionalHttpUrl(record, ["url", "targetUrl", "target_url", "href"]),
+    status: optionalString(record, ["status"]) ?? "proposed",
+    contributionStage: optionalString(record, ["contributionStage", "contribution_stage"]),
+    sourceTitle: optionalString(record, ["sourceTitle", "source_title"]),
+    sourceUrl: optionalHttpUrl(record, ["sourceUrl", "source_url"]),
+    sourceAsOf: optionalString(record, ["sourceAsOf", "source_as_of"]) ?? fallback.asOf,
+    checkedAt: optionalString(record, ["checkedAt", "checked_at"]),
+    confidence: optionalConfidence(record, ["confidence"]) ?? fallback.confidence,
+  };
+}
+
+function parseTaxonomyNode(value: unknown): ThemeTaxonomyNode {
+  const record = requiredObject(value, "taxonomy node");
+  return {
+    id: requiredString(record, ["id"], "taxonomyNode.id"),
+    domain: optionalString(record, ["domain"]) ?? "unknown",
+    kind: optionalString(record, ["kind"]) ?? "unknown",
+    slug: requiredString(record, ["slug"], "taxonomyNode.slug"),
+    displayName: requiredString(record, ["displayName", "display_name"], "taxonomyNode.displayName"),
+    description: optionalString(record, ["description"]),
+    status: optionalString(record, ["status"]),
+  };
+}
+
+function parseTaxonomyEdge(value: unknown): ThemeTaxonomyEdge {
+  const record = requiredObject(value, "taxonomy edge");
+  return {
+    id: requiredString(record, ["id"], "taxonomyEdge.id"),
+    sourceNodeId: requiredString(record, ["sourceNodeId", "source_node_id"], "taxonomyEdge.sourceNodeId"),
+    targetNodeId: requiredString(record, ["targetNodeId", "target_node_id"], "taxonomyEdge.targetNodeId"),
+    relationType: optionalString(record, ["relationType", "relation_type"]) ?? "related_to",
+    relationNote: optionalString(record, ["relationNote", "relation_note"]),
+  };
+}
+
+function parseTaxonomyLink(value: unknown): ThemeTaxonomyLink {
+  const record = requiredObject(value, "theme taxonomy link");
+  return {
+    id: requiredString(record, ["id"], "themeTaxonomyLink.id"),
+    nodeId: requiredString(record, ["nodeId", "node_id"], "themeTaxonomyLink.nodeId"),
+    relationType: optionalString(record, ["relationType", "relation_type"]) ?? "related",
+    relationNote: optionalString(record, ["relationNote", "relation_note"]),
+  };
+}
+
+function parseStockTaxonomyLink(value: unknown, fallback: ThemeProvenance): ThemeStockTaxonomyLink {
+  const record = requiredObject(value, "stock taxonomy link");
+  return {
+    id: requiredString(record, ["id"], "stockTaxonomyLink.id"),
+    stockId: requiredString(record, ["stockId", "stock_id"], "stockTaxonomyLink.stockId"),
+    nodeId: requiredString(record, ["nodeId", "node_id"], "stockTaxonomyLink.nodeId"),
+    strategicRole: optionalString(record, ["strategicRole", "strategic_role"]),
+    controlType: optionalString(record, ["controlType", "control_type"]),
+    relationNote: optionalString(record, ["relationNote", "relation_note"]),
+    source: optionalString(record, ["source", "sourceType", "source_type"]) ?? fallback.source,
+    confidence: optionalConfidence(record, ["confidence"]) ?? fallback.confidence,
+    asOf: optionalString(record, ["asOf", "as_of"]) ?? fallback.asOf,
+    validFrom: optionalString(record, ["validFrom", "valid_from"]),
+    validTo: optionalString(record, ["validTo", "valid_to"]),
+  };
+}
+
+function parseTaxonomyMap(value: unknown, fallback: ThemeProvenance): ThemeTaxonomyMap {
+  if (value === null || value === undefined) {
+    return { nodes: [], edges: [], themeLinks: [], stockLinks: [] };
+  }
+  const record = requiredObject(value, "taxonomyMap");
+  const nodes = objectArray(record, ["nodes"]).values.map(parseTaxonomyNode);
+  const edges = objectArray(record, ["edges"]).values.map(parseTaxonomyEdge);
+  const themeLinks = objectArray(record, ["themeLinks", "theme_links"]).values.map(parseTaxonomyLink);
+  const stockLinks = objectArray(record, ["stockLinks", "stock_links"]).values.map((item) =>
+    parseStockTaxonomyLink(item, fallback),
+  );
+  return { nodes, edges, themeLinks, stockLinks };
+}
+
+function parseMetricDefinition(value: unknown): ThemeMetricDefinition {
+  const record = requiredObject(value, "metric definition");
+  return {
+    id: requiredString(record, ["id"], "metricDefinition.id"),
+    metricKey: requiredString(record, ["metricKey", "metric_key"], "metricDefinition.metricKey"),
+    displayName: requiredString(record, ["displayName", "display_name"], "metricDefinition.displayName"),
+    scope: optionalString(record, ["scope", "metricScope", "metric_scope"]) ?? "common",
+    appliesToStockId: optionalString(record, ["appliesToStockId", "applies_to_stock_id"]),
+    unit: optionalString(record, ["unit"]),
+    definition: optionalString(record, ["definition"]),
+    versionNumber: optionalNumber(record, ["versionNumber", "version_number"]),
+    isActive: optionalBoolean(record, ["isActive", "is_active"]),
+  };
+}
+
+function parseMetricSnapshot(value: unknown): ThemeMetricSnapshot {
+  const record = requiredObject(value, "metric snapshot");
+  return {
+    id: requiredString(record, ["id"], "metricSnapshot.id"),
+    asOf: optionalString(record, ["asOf", "as_of"]),
+    periodLabel: optionalString(record, ["periodLabel", "period_label"]),
+    snapshotKind: optionalString(record, ["snapshotKind", "snapshot_kind"]),
+    note: optionalString(record, ["note"]),
+  };
+}
+
+function parseMetricValue(value: unknown): ThemeMetricValue {
+  const record = requiredObject(value, "metric value");
+  return {
+    id: requiredString(record, ["id"], "metricValue.id"),
+    snapshotId: requiredString(record, ["snapshotId", "snapshot_id"], "metricValue.snapshotId"),
+    metricId: requiredString(record, ["metricId", "metric_id"], "metricValue.metricId"),
+    stockId: requiredString(record, ["stockId", "stock_id"], "metricValue.stockId"),
+    value: optionalNumber(record, ["value"]),
+    evidenceId: optionalString(record, ["evidenceId", "evidence_id"]),
+    calculationNote: optionalString(record, ["calculationNote", "calculation_note"]),
+  };
+}
+
+function parseMetrics(value: unknown): ThemeMetrics {
+  if (value === null || value === undefined) {
+    return { definitions: [], snapshots: [], values: [] };
+  }
+  const record = requiredObject(value, "metrics");
+  return {
+    definitions: objectArray(record, ["definitions", "metricDefinitions", "metric_definitions"]).values.map(
+      parseMetricDefinition,
+    ),
+    snapshots: objectArray(record, ["snapshots", "metricSnapshots", "metric_snapshots"]).values.map(
+      parseMetricSnapshot,
+    ),
+    values: objectArray(record, ["values", "metricValues", "metric_values"]).values.map(parseMetricValue),
+  };
+}
+
+function parseOpenAction(value: unknown): ThemeOpenAction {
+  const record = requiredObject(value, "open action");
+  return {
+    id: requiredString(record, ["id"], "openAction.id"),
+    actionType: optionalString(record, ["actionType", "action_type"]) ?? "other",
+    title: requiredString(record, ["title"], "openAction.title"),
+    detail: optionalString(record, ["detail", "detailSummary", "detail_summary"]),
+    triggerCondition: optionalString(record, ["triggerCondition", "trigger_condition", "triggerConditionSummary"]),
+    dueDate: optionalString(record, ["dueDate", "due_date"]),
+    status: optionalString(record, ["status"]) ?? "open",
+    basedOnAnalysisId: optionalString(record, ["basedOnAnalysisId", "based_on_analysis_id"]),
+    basedOnThesisId: optionalString(record, ["basedOnThesisId", "based_on_thesis_id"]),
+    createdAt: optionalString(record, ["createdAt", "created_at"]),
+    updatedAt: optionalString(record, ["updatedAt", "updated_at"]),
+  };
+}
+
+function section(state: ThemeSectionAvailability["state"], count: number): ThemeSectionAvailability {
+  return { state, count };
+}
+
+function collectionSection(record: RawObject, keys: string[], count: number): ThemeSectionAvailability {
+  const field = readField(record, keys);
+  if (!field.found) return section("missing", 0);
+  return section(count > 0 ? "present" : "empty", count);
+}
+
+function buildAvailability(
+  root: RawObject,
+  themeRecord: RawObject,
+  thesisField: Field,
+  analysisHistory: ThemeAnalysis[],
+  evidence: ThemeEvidence[],
+  directLinks: ThemeDirectLink[],
+  taxonomyMap: ThemeTaxonomyMap,
+  metrics: ThemeMetrics,
+  openActions: ThemeOpenAction[],
+): Record<ThemeSectionKey, ThemeSectionAvailability> {
+  const overviewFields = [
+    readField(themeRecord, ["summary", "overview"]),
+    readField(themeRecord, ["definition", "themeDefinition", "theme_definition"]),
+  ];
+  const overviewCount = overviewFields.filter((field) => typeof field.value === "string" && field.value.trim()).length;
+  const taxonomyCount =
+    taxonomyMap.nodes.length +
+    taxonomyMap.edges.length +
+    taxonomyMap.themeLinks.length +
+    taxonomyMap.stockLinks.length;
+  const metricsCount = metrics.definitions.length + metrics.snapshots.length + metrics.values.length;
+
+  return {
+    overview: section(
+      overviewFields.some((field) => field.found)
+        ? overviewCount > 0
+          ? "present"
+          : "empty"
+        : "missing",
+      overviewCount,
+    ),
+    thesis: !thesisField.found
+      ? section("missing", 0)
+      : thesisField.value === null
+        ? section("empty", 0)
+        : section("present", 1),
+    analysisHistory: collectionSection(root, ["analysisHistory", "analysis_history", "analyses"], analysisHistory.length),
+    evidence: collectionSection(root, ["evidence", "evidenceRecords", "evidence_records"], evidence.length),
+    directLinks: collectionSection(root, ["directLinks", "direct_links", "links"], directLinks.length),
+    taxonomyMap: collectionSection(root, ["taxonomyMap", "taxonomy_map", "taxonomy"], taxonomyCount),
+    metrics: collectionSection(root, ["metrics", "metricData", "metric_data"], metricsCount),
+    openActions: collectionSection(root, ["openActions", "open_actions", "actions"], openActions.length),
+  };
+}
+
+/** Viewer詳細レスポンスをcamelCaseのread modelへ変換する。nullは「対象なし」を表す。 */
+export function parseThemeDetailResponse(input: unknown): ThemeDetailData | null {
+  const root = requiredObject(input, "viewer detail");
+  const viewerContractVersion = contractVersion(root);
+  const themeField = readField(root, ["theme"]);
+  if (themeField.found && themeField.value === null) return null;
+  const themeValue = themeField.found ? themeField.value : root;
+  const topProvenance = topLevelProvenance(root);
+  const themeRecord = requiredObject(themeValue, "theme");
+  const theme = parseThemeRecord(themeRecord, topProvenance);
+
+  const thesisField = readField(root, ["currentThesis", "current_thesis", "activeThesis", "active_thesis", "thesis"]);
+  const currentThesis =
+    thesisField.found && thesisField.value !== null
+      ? parseThesis(thesisField.value, theme.provenance)
+      : null;
+
+  const analysisField = objectArray(root, ["analysisHistory", "analysis_history", "analyses"]);
+  const evidenceField = objectArray(root, ["evidence", "evidenceRecords", "evidence_records"]);
+  const linksField = objectArray(root, ["directLinks", "direct_links", "links"]);
+  const taxonomyField = readField(root, ["taxonomyMap", "taxonomy_map", "taxonomy"]);
+  const metricsField = readField(root, ["metrics", "metricData", "metric_data"]);
+  const actionsField = objectArray(root, ["openActions", "open_actions", "actions"]);
+
+  const analysisHistory = analysisField.values.map((item) => parseAnalysis(item, theme.provenance));
+  const evidence = evidenceField.values.map((item) => parseEvidence(item, theme.provenance));
+  const directLinks = linksField.values.map((item) => parseDirectLink(item, theme.provenance));
+  const taxonomyMap = parseTaxonomyMap(taxonomyField.value, theme.provenance);
+  const metrics = parseMetrics(metricsField.value);
+  const openActions = actionsField.values.map(parseOpenAction);
+
+  return {
+    contractVersion: viewerContractVersion,
+    source: topProvenance.source ?? theme.provenance.source,
+    asOf: topProvenance.asOf ?? theme.provenance.asOf,
+    theme,
+    currentThesis,
+    analysisHistory,
+    evidence,
+    directLinks,
+    taxonomyMap,
+    metrics,
+    openActions,
+    availability: buildAvailability(
+      root,
+      themeRecord,
+      thesisField,
+      analysisHistory,
+      evidence,
+      directLinks,
+      taxonomyMap,
+      metrics,
+      openActions,
+    ),
+  };
+}
+
+function configuredApi(): { baseUrl: string; token: string } | null {
+  const baseUrl = process.env[API_BASE_ENV]?.trim().replace(/\/+$/, "") ?? "";
+  const token = process.env[API_TOKEN_ENV]?.trim() ?? "";
+  if (!baseUrl || !token) return null;
+  try {
+    const parsed = new URL(baseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  } catch {
+    return null;
+  }
+  return { baseUrl, token };
+}
+
+function errorResult(
+  status: ThemeViewerErrorStatus,
+  message: string,
+  httpStatus: number | null = null,
+): RequestFailure {
+  return { ok: false, status, message, httpStatus };
+}
+
+function viewerError(failure: RequestFailure): ThemeViewerError {
+  return {
+    status: failure.status,
+    message: failure.message,
+    httpStatus: failure.httpStatus,
+  };
+}
+
+async function requestViewerJson(
+  path: string,
+  kind: "list" | "detail",
+  fetcher: Fetcher,
+): Promise<RequestResult> {
+  const config = configuredApi();
+  if (!config) {
+    return errorResult(
+      "not_configured",
+      `stock-notes Theme Viewer APIの設定がありません（${API_BASE_ENV} / ${API_TOKEN_ENV}）。`,
+    );
+  }
+
+  let url: string;
+  try {
+    // API_BASE_URLに `/api` などのprefixが含まれる環境でもprefixを維持する。
+    url = new URL(path.replace(/^\/+/, ""), `${config.baseUrl}/`).toString();
+  } catch {
+    return errorResult("not_configured", `${API_BASE_ENV} のURLが不正です。`);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetcher(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${config.token}`,
+      },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+
+    if (response.status === 401) {
+      return errorResult("unauthorized", "stock-notes APIの認証に失敗しました。", response.status);
+    }
+    if (kind === "detail" && response.status === 404) {
+      return errorResult("not_found", "指定されたテーマは見つかりません。", response.status);
+    }
+    if (response.status >= 500) {
+      return errorResult(
+        "upstream_error",
+        `stock-notes APIで一時的なエラーが発生しました（HTTP ${response.status}）。`,
+        response.status,
+      );
+    }
+    if (!response.ok) {
+      return errorResult(
+        "upstream_error",
+        `stock-notes APIからデータを取得できませんでした（HTTP ${response.status}）。`,
+        response.status,
+      );
+    }
+
+    try {
+      return { ok: true, body: await response.json() };
+    } catch {
+      return errorResult("invalid_response", "stock-notes APIのレスポンスを読み取れませんでした。");
+    }
+  } catch {
+    return errorResult("upstream_error", "stock-notes APIへ接続できませんでした。");
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function invalidResponseResult(message = "stock-notes APIのレスポンス形式が契約と異なります。"): ThemeViewerError {
+  return {
+    status: "invalid_response" as const,
+    message,
+    httpStatus: null,
+  };
+}
+
+export async function loadThemeList(fetcher: Fetcher = fetch): Promise<ThemeListLoadResult> {
+  const response = await requestViewerJson("/viewer/themes", "list", fetcher);
+  if (response.ok === false) return viewerError(response);
+
+  try {
+    const data = parseThemeListResponse(response.body);
+    return data.themes.length === 0 ? { status: "empty", data } : { status: "ok", data };
+  } catch {
+    return invalidResponseResult();
+  }
+}
+
+export async function loadThemeDetail(
+  themeId: string,
+  fetcher: Fetcher = fetch,
+): Promise<ThemeDetailLoadResult> {
+  if (!themeId.trim()) return invalidResponseResult("テーマIDが空です。");
+  const response = await requestViewerJson(`/viewer/themes/${encodeURIComponent(themeId)}`, "detail", fetcher);
+  if (response.ok === false) return viewerError(response);
+
+  try {
+    const data = parseThemeDetailResponse(response.body);
+    return data === null ? { status: "empty" } : { status: "ok", data };
+  } catch {
+    return invalidResponseResult();
+  }
+}
+
+export const themeViewerConfig = {
+  baseEnv: API_BASE_ENV,
+  tokenEnv: API_TOKEN_ENV,
+};

--- a/app/premium/themes/data-loader.ts
+++ b/app/premium/themes/data-loader.ts
@@ -168,7 +168,7 @@ function requiredThemeStatus(record: RawObject): ThemeStatus {
 
 function contractVersion(record: RawObject): typeof THEME_VIEWER_CONTRACT_VERSION {
   const field = readField(record, ["schemaVersion", "schema_version", "contractVersion", "contract_version"]);
-  if (field.value !== undefined && field.value !== THEME_VIEWER_CONTRACT_VERSION) {
+  if (field.value !== THEME_VIEWER_CONTRACT_VERSION) {
     throw new ThemeViewerResponseError("unsupported viewer contract version");
   }
   return THEME_VIEWER_CONTRACT_VERSION;
@@ -246,6 +246,7 @@ function parseThemeRecord(value: unknown, fallback: ThemeProvenance): ThemeRecor
 
 function parseThesis(value: unknown, fallback: ThemeProvenance): ThemeThesis {
   const record = requiredObject(value, "currentThesis");
+  const thesisProvenance = provenance(record, fallback);
   return {
     id: requiredString(record, ["id"], "currentThesis.id"),
     versionNumber: optionalNumber(record, ["versionNumber", "version_number"]),
@@ -254,13 +255,13 @@ function parseThesis(value: unknown, fallback: ThemeProvenance): ThemeThesis {
     structuralHypothesis: optionalString(record, ["structuralHypothesis", "structural_hypothesis"]),
     confidence:
       optionalConfidence(record, ["confidence"]) ??
-      provenance(record, fallback).confidence,
+      thesisProvenance.confidence,
     lenses: stringArray(record, ["lenses"]),
     risks: stringArray(record, ["risks"]),
     falsificationConditions: stringArray(record, ["falsificationConditions", "falsification_conditions"]),
     nextChecks: stringArray(record, ["nextChecks", "next_checks"]),
-    asOf: optionalString(record, ["asOf", "as_of"]),
-    source: provenance(record, fallback).source,
+    asOf: optionalString(record, ["asOf", "as_of"]) ?? thesisProvenance.asOf,
+    source: thesisProvenance.source,
     basedOnAnalysisId: optionalString(record, ["basedOnAnalysisId", "based_on_analysis_id"]),
   };
 }

--- a/app/premium/themes/page.tsx
+++ b/app/premium/themes/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+import { loadThemeList } from "./data-loader";
+import { ThemeListView } from "./ThemeViewer";
+
+export const metadata: Metadata = {
+  title: "テーマViewer | mini-tools premium",
+  description: "stock-notesに保存したテーマの概要・履歴・根拠・関連を読み取り専用で確認します。",
+  alternates: {
+    canonical: "/premium/themes",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default async function PremiumThemesPage() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+
+  if (!verifyPremiumSession(session)) {
+    redirect(`/premium/login?next=${encodeURIComponent("/premium/themes")}`);
+  }
+
+  const result = await loadThemeList();
+  return <ThemeListView result={result} />;
+}

--- a/app/premium/themes/types.ts
+++ b/app/premium/themes/types.ts
@@ -1,0 +1,267 @@
+/**
+ * MiniToolsが依存するTheme Viewerの安定した読み取りモデル。
+ *
+ * stock-notesのDB行や編集APIの型をこの画面へ持ち込まない。Viewer APIの
+ * versioned read modelだけを境界にし、snake_caseの既存APIから移行しやすいように
+ * loader側でcamelCaseへ正規化する。
+ */
+
+export const THEME_VIEWER_CONTRACT_VERSION = "theme-viewer.v1" as const;
+
+export type ThemeViewerContractVersion = typeof THEME_VIEWER_CONTRACT_VERSION;
+export type ThemeStatus = "draft" | "active" | "archived";
+export type ThemeConfidence = "high" | "medium" | "low";
+export type ThemeDataState = "present" | "empty" | "missing";
+
+export type ThemeProvenance = {
+  source: string | null;
+  asOf: string | null;
+  confidence: ThemeConfidence | null;
+};
+
+export type ThemeSectionKey =
+  | "overview"
+  | "thesis"
+  | "analysisHistory"
+  | "evidence"
+  | "directLinks"
+  | "taxonomyMap"
+  | "metrics"
+  | "openActions";
+
+export type ThemeSectionAvailability = {
+  state: ThemeDataState;
+  count: number;
+};
+
+export type ThemeListItem = {
+  id: string;
+  slug: string;
+  displayName: string;
+  status: ThemeStatus;
+  summary: string | null;
+  asOf: string | null;
+  source: string | null;
+  confidence: ThemeConfidence | null;
+  updatedAt: string | null;
+  analysisCount: number | null;
+  openActionCount: number | null;
+};
+
+export type ThemeListData = {
+  contractVersion: ThemeViewerContractVersion;
+  source: string | null;
+  asOf: string | null;
+  themes: ThemeListItem[];
+};
+
+export type ThemeRecord = {
+  id: string;
+  slug: string;
+  displayName: string;
+  status: ThemeStatus;
+  summary: string | null;
+  definition: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  archivedAt: string | null;
+  provenance: ThemeProvenance;
+};
+
+export type ThemeThesis = {
+  id: string;
+  versionNumber: number | null;
+  status: string;
+  definition: string | null;
+  structuralHypothesis: string | null;
+  confidence: ThemeConfidence | null;
+  lenses: string[];
+  risks: string[];
+  falsificationConditions: string[];
+  nextChecks: string[];
+  asOf: string | null;
+  source: string | null;
+  basedOnAnalysisId: string | null;
+};
+
+export type ThemeAnalysis = {
+  id: string;
+  analysisType: string;
+  conclusion: string | null;
+  evidence: string | null;
+  concerns: string | null;
+  body: string | null;
+  source: string | null;
+  sourceUrl: string | null;
+  asOf: string | null;
+  confidence: ThemeConfidence | null;
+  createdAt: string | null;
+};
+
+export type ThemeEvidence = {
+  id: string;
+  analysisId: string | null;
+  thesisId: string | null;
+  evidenceType: string;
+  claimKind: string;
+  stance: string;
+  claim: string | null;
+  sourceTitle: string | null;
+  sourceUrl: string | null;
+  sourceType: string | null;
+  sourceAsOf: string | null;
+  checkedAt: string | null;
+  confidence: ThemeConfidence | null;
+  verificationStatus: string | null;
+};
+
+export type ThemeDirectLink = {
+  id: string;
+  targetType: string;
+  targetId: string | null;
+  displayName: string;
+  relationType: string;
+  relationNote: string | null;
+  url: string | null;
+  status: string;
+  contributionStage: string | null;
+  sourceTitle: string | null;
+  sourceUrl: string | null;
+  sourceAsOf: string | null;
+  checkedAt: string | null;
+  confidence: ThemeConfidence | null;
+};
+
+export type ThemeTaxonomyNode = {
+  id: string;
+  domain: string;
+  kind: string;
+  slug: string;
+  displayName: string;
+  description: string | null;
+  status: string | null;
+};
+
+export type ThemeTaxonomyEdge = {
+  id: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  relationType: string;
+  relationNote: string | null;
+};
+
+export type ThemeTaxonomyLink = {
+  id: string;
+  nodeId: string;
+  relationType: string;
+  relationNote: string | null;
+};
+
+export type ThemeStockTaxonomyLink = {
+  id: string;
+  stockId: string;
+  nodeId: string;
+  strategicRole: string | null;
+  controlType: string | null;
+  relationNote: string | null;
+  source: string | null;
+  confidence: ThemeConfidence | null;
+  asOf: string | null;
+  validFrom: string | null;
+  validTo: string | null;
+};
+
+export type ThemeTaxonomyMap = {
+  nodes: ThemeTaxonomyNode[];
+  edges: ThemeTaxonomyEdge[];
+  themeLinks: ThemeTaxonomyLink[];
+  stockLinks: ThemeStockTaxonomyLink[];
+};
+
+export type ThemeMetricDefinition = {
+  id: string;
+  metricKey: string;
+  displayName: string;
+  scope: string;
+  appliesToStockId: string | null;
+  unit: string | null;
+  definition: string | null;
+  versionNumber: number | null;
+  isActive: boolean | null;
+};
+
+export type ThemeMetricSnapshot = {
+  id: string;
+  asOf: string | null;
+  periodLabel: string | null;
+  snapshotKind: string | null;
+  note: string | null;
+};
+
+export type ThemeMetricValue = {
+  id: string;
+  snapshotId: string;
+  metricId: string;
+  stockId: string;
+  value: number | null;
+  evidenceId: string | null;
+  calculationNote: string | null;
+};
+
+export type ThemeMetrics = {
+  definitions: ThemeMetricDefinition[];
+  snapshots: ThemeMetricSnapshot[];
+  values: ThemeMetricValue[];
+};
+
+export type ThemeOpenAction = {
+  id: string;
+  actionType: string;
+  title: string;
+  detail: string | null;
+  triggerCondition: string | null;
+  dueDate: string | null;
+  status: string;
+  basedOnAnalysisId: string | null;
+  basedOnThesisId: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type ThemeDetailData = {
+  contractVersion: ThemeViewerContractVersion;
+  source: string | null;
+  asOf: string | null;
+  theme: ThemeRecord;
+  currentThesis: ThemeThesis | null;
+  analysisHistory: ThemeAnalysis[];
+  evidence: ThemeEvidence[];
+  directLinks: ThemeDirectLink[];
+  taxonomyMap: ThemeTaxonomyMap;
+  metrics: ThemeMetrics;
+  openActions: ThemeOpenAction[];
+  availability: Record<ThemeSectionKey, ThemeSectionAvailability>;
+};
+
+export type ThemeViewerErrorStatus =
+  | "not_configured"
+  | "unauthorized"
+  | "upstream_error"
+  | "not_found"
+  | "invalid_response";
+
+export type ThemeViewerError = {
+  status: ThemeViewerErrorStatus;
+  message: string;
+  httpStatus: number | null;
+};
+
+export type ThemeListLoadResult =
+  | { status: "ok"; data: ThemeListData }
+  | { status: "empty"; data: ThemeListData }
+  | ThemeViewerError;
+
+export type ThemeDetailLoadResult =
+  | { status: "ok"; data: ThemeDetailData }
+  | { status: "empty" }
+  | ThemeViewerError;

--- a/docs/decision-log/2026-08-27-theme-viewer-read-model.md
+++ b/docs/decision-log/2026-08-27-theme-viewer-read-model.md
@@ -1,0 +1,39 @@
+# テーマViewerの読み取り契約と責任境界
+
+## 結論
+
+MiniToolsの`/premium/themes`は、ChatGPT + Supabaseで整備されたテーマをstock-notesの専用Viewer APIから読み取り、閲覧だけを担当する。API tokenはサーバー側に閉じ、UIへ渡す型は`theme-viewer.v1`のcamelCase read modelに固定する。
+
+## 背景
+
+テーマはChatGPTとの対話で仮説、根拠、分析履歴、taxonomy、metrics、open actionsを更新する前提である。MiniToolsへ編集機能やSupabase書き込みを持ち込むと、編集チャネルと閲覧チャネルの責任が混ざり、draftや未確定の情報を売買判断へ誤って昇格させるおそれがある。
+
+## 決めたこと
+
+- MiniToolsはstock-notesのDBを直接参照せず、`GET /viewer/themes` と `GET /viewer/themes/{theme_id}`だけを呼ぶ
+- `STOCK_NOTES_API_BASE_URL` と `STOCK_NOTES_API_TOKEN`はServer Componentのloaderだけで使用する
+- UI境界は明示的な`theme-viewer.v1` camelCase read modelとし、snake_case互換は移行用parserに閉じ込める
+- 詳細は概要、現行thesis、分析履歴、evidence、direct links、taxonomy map、metrics、open actionsを同一payloadで受け取る
+- source、as-of、confidence、draft、missing、emptyを表示上の状態として保持する
+- テーマから買う／売る／保有する結論を生成せず、open actionも読み取り専用で表示する
+- 未設定、401、404、5xx、契約不正、空データを別状態として扱う
+
+## 理由
+
+- 編集経路をChatGPT + Supabaseに集約すると、相談・確認・保存の正本が一つになる
+- stock-notesの専用read modelを境界にすると、MiniToolsがDBスキーマや編集APIの変更に引きずられにくい
+- 詳細を集約すると、画面が複数endpointの部分成功を勝手に解釈せず、テーマ単位の基準日と状態を一貫して表示できる
+- missingとemptyを分けると、「未提供」と「確認したがデータなし」を区別できる
+- 0をnull／欠損と混同しないことで、metricsの表示を監査しやすくできる
+
+## 影響と残課題
+
+現時点のstock-notesには既存テーマAPIはあるが、`/viewer/*`のversioned aggregate contractはまだ確定していない。MiniTools側はUI、型、parser、状態表示を先に実装した。stock-notes側では、envelope、camelCase必須フィールド、詳細aggregate、provenance、direct link URL、taxonomy／metrics、401/404/5xxとemptyの意味を契約化する必要がある。
+
+この差分はUIの空実装で隠さず、設定未完了・契約不一致として表示する。Viewer APIが整うまでは、本番のテーマ一覧が空または未設定になり得るが、サンプルデータや推測値へのfallbackは行わない。
+
+## 関連
+
+- 仕様: [テーマViewer仕様](../specs/tools/theme-viewer.md)
+- UAT: [テーマViewer UAT](../uat/theme-viewer.md)
+- 実装計画: [ポートフォリオ意思決定ワークスペース計画](../plans/portfolio-decision-workspace-plan.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
 - [2026-08-15 ポートフォリオはChatGPT起点の意思決定ワークスペースとする](./decision-log/2026-08-15-portfolio-chat-first-operating-model.md)
 - [2026-08-18 ポートフォリオDB確認ビュー](./decision-log/2026-08-18-portfolio-db-check-view.md)
 - [2026-08-21 ポートフォリオ意思決定画面の初回実装](./decision-log/2026-08-21-portfolio-decision-view.md)
+- [2026-08-27 テーマViewerの読み取り契約と責任境界](./decision-log/2026-08-27-theme-viewer-read-model.md)
 - [2026-08-07 優待取得時に次回権利月を固定する](./decision-log/2026-08-07-yutai-acquired-entitlement-lock.md)
 
 設計・方針・トレードオフの判断理由を記録します。
@@ -134,6 +135,7 @@ docs の置き場所と相互リンクのルールは [Docs Writing Workflow](./
   - [ペンギンシューター 仕様](./specs/tools/penguin-shooter.md)
   - [ルーティン一覧 仕様](./specs/tools/routines.md)
   - [ポートフォリオ 仕様](./specs/tools/portfolio.md)
+  - [テーマViewer 仕様](./specs/tools/theme-viewer.md)
 - [横断仕様インデックス](./specs/cross-cutting/index.md)
   - [mini-tools システム構成概要](./specs/cross-cutting/system-architecture-overview.md)
   - [React Server / Client 責任境界](./specs/cross-cutting/react-server-client-boundaries.md)
@@ -181,6 +183,7 @@ PR マージ後・リリース前の確認観点をツールごとにまとめ�
   - [株主優待期限帳](./uat/yutai-expiry.md)
   - [優待銘柄メモ帳](./uat/yutai-memo.md)
   - [ペンギンシューター](./uat/penguin-shooter.md)
+  - [テーマViewer](./uat/theme-viewer.md)
 
 ---
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -29,6 +29,7 @@
 | ペンギンシューター | `/tools/penguin-shooter` | [penguin-shooter.md](./tools/penguin-shooter.md) |
 | ルーティン一覧 | `/premium/routines` | [routines.md](./tools/routines.md) |
 | ポートフォリオ | `/premium/portfolio` | [portfolio.md](./tools/portfolio.md) |
+| テーマViewer | `/premium/themes` | [theme-viewer.md](./tools/theme-viewer.md) |
 
 ## テンプレート
 

--- a/docs/specs/tools/theme-viewer.md
+++ b/docs/specs/tools/theme-viewer.md
@@ -1,0 +1,142 @@
+# テーマViewer 仕様
+
+> **実装状態:** 2026-08-27時点の初回版。`/premium/themes` とテーマ詳細を、stock-notesのViewer APIから読み取り専用で表示する。テーマ編集、Supabaseへの書き込み、売買判断の確定はこの画面の責務ではない。
+
+## 結論
+
+ChatGPT + Supabaseを編集チャネル、stock-notesをバージョン付き読み取り契約の提供元、MiniToolsを閲覧チャネルとする。MiniToolsはstock-notesのDBや編集APIを直接読まず、サーバー側loaderを経由して `theme-viewer.v1` のcamelCase read modelだけをUIへ渡す。
+
+## 概要
+
+- 一覧URL: `/premium/themes`
+- 詳細URL: `/premium/themes/[themeId]`
+- 分類: Premium / テーマViewer
+- 主な用途: テーマの概要、仮説、分析履歴、根拠、関連リンク、taxonomy map、metrics、open actionsを、基準日と信頼度付きで確認する
+
+## 画面仕様
+
+### 一覧
+
+- テーマ名、slug、status（`draft` / `active` / `archived`）、概要を表示する
+- source、as-of、confidenceを表示する。値がない場合は「未提供」と表示する
+- 分析件数とopen action件数は、APIが値を返した場合だけ表示する
+- 各カードから `/premium/themes/[themeId]` へ遷移する
+- 対象が0件のときは「テーマなし」と表示し、取得失敗とは区別する
+
+### 詳細
+
+次のセクションを表示する。セクションの状態は `present`（値あり）、`empty`（APIが明示的に空またはnull）、`missing`（フィールド自体が未提供）を区別する。
+
+- Overview: テーマ定義と概要
+- Current thesis: 現行仮説の版、status、構造仮説、confidence、risk、falsification condition、next check
+- Analysis history: 分析種別、結論、懸念、基準日、出典、confidence
+- Evidence: claim、stance、verification status、source、source-as-of、checked-at、confidence
+- Direct links: 関連対象、関係、status、直接URL、出典
+- Taxonomy map: nodes、edges、theme links、stock linksと、それぞれの関係・基準日・confidence
+- Metrics: metric definition、snapshot、value、単位、計算メモ、根拠ID
+- Open actions: 未完了確認事項、実行条件、期限、関連分析・仮説
+
+詳細画面の上部にテーマ自身のsource、as-of、confidenceとstatusを表示する。`draft` は「下書き」、欠損データは「未提供」と明示し、空配列やnullは「データなし」と表示する。
+
+### 読み取り専用の境界
+
+- 画面に編集フォーム、保存、更新、完了、削除操作を置かない
+- テーマから「買う／売る／保有する」などの売買判断を確定しない
+- open actionは確認事項として表示するだけで、この画面から状態を変更しない
+- 詳細に直接URLがある場合だけ外部リンクを表示する。URLは `http` / `https` に限定し、不正な値はリンク化しない
+
+## データ契約
+
+### 取得元と認証
+
+Server Componentから次のstock-notes endpointへGETする。
+
+- `GET /viewer/themes`
+- `GET /viewer/themes/{theme_id}`
+
+環境変数は `STOCK_NOTES_API_BASE_URL` と `STOCK_NOTES_API_TOKEN`。どちらもserver-onlyで扱い、`Authorization: Bearer ...` はサーバーからstock-notesへだけ送る。ブラウザーのprops、HTML、URL、クライアントfetchへtokenを渡さない。レスポンスは `no-store`、timeoutは5秒とする。
+
+### versioned camelCase read model
+
+Viewer APIの正本契約は `schemaVersion: "theme-viewer.v1"` とする。代表的な形は次のとおり。
+
+```json
+{
+  "schemaVersion": "theme-viewer.v1",
+  "source": "stock-notes",
+  "asOf": "2026-08-27T00:00:00Z",
+  "themes": [
+    {
+      "id": "theme-1",
+      "slug": "ai-infrastructure",
+      "displayName": "AI infrastructure",
+      "status": "draft",
+      "summary": "...",
+      "asOf": "2026-08-26",
+      "source": "chatgpt-supabase",
+      "confidence": "medium",
+      "updatedAt": "2026-08-27T00:00:00Z",
+      "analysisCount": 0,
+      "openActionCount": 2
+    }
+  ]
+}
+```
+
+詳細は同じ `schemaVersion` とトップレベルのsource/as-ofを持ち、`theme`、`currentThesis`、`analysisHistory`、`evidence`、`directLinks`、`taxonomyMap`、`metrics`、`openActions`を含む。各配列・オブジェクトのフィールドもcamelCaseとする。`directLinks` の対象URLは `url`、taxonomyは `nodes` / `edges` / `themeLinks` / `stockLinks`、metricsは `definitions` / `snapshots` / `values` とする。
+
+アプリ内部の型は [テーマViewer types](../../../app/premium/themes/types.ts) に定義する。移行期間の互換性としてloaderは既存snake_case名も受け付けるが、UIへ渡すread modelは常にcamelCaseである。
+
+### source / as-of / confidence
+
+- `source`: 値を生成・確認したシステムまたは資料の識別子
+- `asOf`: 判断・データの基準日時。取得日時とは区別する
+- `confidence`: `high` / `medium` / `low`。未提供は空欄ではなく「未提供」
+- 上位メタデータがない場合、レコード固有のprovenanceを優先する
+
+## API契約の不足と変更候補
+
+現時点のstock-notesにはテーマ単位の既存読み取りendpointはあるが、MiniToolsが想定する `/viewer/themes` と `/viewer/themes/{theme_id}` のversioned aggregate endpoint、camelCase envelopeはまだ正本化されていない。したがって、このPRではUI側の境界と互換parserを先に実装し、stock-notes側のAPI変更をこのPRへ混在させない。
+
+stock-notes側で次に確定すべき変更候補は以下のとおり。
+
+1. `theme-viewer.v1` の一覧／詳細 envelopeと必須フィールドをAPI契約として公開する
+2. 詳細endpointで、thesis、analysis history、evidence、direct links、taxonomy map、metrics、open actionsを1つの読み取りpayloadに集約する
+3. source、asOf、confidence、draft、未提供、明示的な空を各セクションで表現する
+4. direct linksの表示名・関係・対象ID・安全なtarget URLを返す
+5. taxonomy／metricsの定義、snapshot、value、根拠IDを同じread modelで返す
+6. 401、404、5xxと空データの意味を明文化する。テーマが存在しない場合は404、存在するが未登録のセクションはmissingまたはemptyとする
+
+## 状態・エラー表示
+
+| 状態 | 表示・挙動 |
+|---|---|
+| Premium未認証 | `/premium/login?next=...` へ遷移 |
+| env未設定／URL不正 | `not_configured`。設定不足として表示し、空データにしない |
+| stock-notes 401 | `unauthorized`。認証設定を確認する案内を表示 |
+| stock-notes 404（詳細） | `not_found`。指定テーマなしとして表示 |
+| stock-notes 5xx／接続失敗／timeout | `upstream_error`。一時的な取得失敗として表示 |
+| JSON／version／必須項目不正 | `invalid_response`。契約不一致として表示 |
+| 一覧が空 | `empty`。テーマなしとして表示 |
+| 詳細のセクションが未提供 | `missing`。APIが返していないことを表示 |
+| 詳細のセクションが明示的に空 | `empty`。値がないことを表示 |
+
+## Premium / 権限制御
+
+- Premium Cookie認証を必須とする
+- 認証前にstock-notes APIへリクエストしない
+- stock-notes tokenはserver-only envから取得し、クライアントへ出さない
+
+## 関連実装
+
+- [テーマViewer一覧 page](../../../app/premium/themes/page.tsx)
+- [テーマViewer詳細 page](../../../app/premium/themes/%5BthemeId%5D/page.tsx)
+- [テーマViewer loader](../../../app/premium/themes/data-loader.ts)
+- [テーマViewer UI](../../../app/premium/themes/ThemeViewer.tsx)
+- [テーマViewer tests](../../../app/premium/themes/data-loader.test.ts)
+
+## 関連 docs
+
+- UAT: [テーマViewer UAT](../../uat/theme-viewer.md)
+- Decision Log: [テーマViewerの読み取り契約と責任境界](../../decision-log/2026-08-27-theme-viewer-read-model.md)
+- Docs Writing Workflow: [docs作成ルール](../../docs-writing-workflow.md)

--- a/docs/uat/index.md
+++ b/docs/uat/index.md
@@ -24,6 +24,7 @@ PR マージ後・リリース前に「何を確認すれば OK か」をツー�
 | アカウント（パスワードのリセット・変更） | `/account`, `/account/reset-password` | Supabase Auth | [password-reset.md](./password-reset.md) |
 | ペンギンシューター | `/tools/penguin-shooter` | なし（初期版はメモリ上のゲーム状態のみ） | [penguin-shooter.md](./penguin-shooter.md) |
 | ポートフォリオ | `/premium/portfolio` | Supabase（RLS付き読み取り）、Premium + Supabase Auth | [portfolio.md](./portfolio.md) |
+| テーマViewer | `/premium/themes` | stock-notes Viewer API（server-only token）、Premium | [theme-viewer.md](./theme-viewer.md) |
 
 ## 確認環境
 

--- a/docs/uat/theme-viewer.md
+++ b/docs/uat/theme-viewer.md
@@ -1,0 +1,54 @@
+# テーマViewer UAT
+
+## 前提
+
+- Premium仮ログインで `/premium` に入れる
+- stock-notesのViewer APIに対して、設定済み環境と未設定環境を確認できる
+- テスト用テーマに、`draft`、分析履歴、根拠、直接リンク、taxonomy、metrics、open actionsの有無を用意する
+
+## 正常系
+
+- [ ] Premiumホームに「テーマViewer」カードが表示される
+- [ ] `/premium/themes` がログイン後に表示される
+- [ ] 一覧にテーマ名、slug、status、概要、source、as-of、confidenceが表示される
+- [ ] 一覧カードから `/premium/themes/[themeId]` へ遷移できる
+- [ ] 詳細に概要・テーマ定義とsource/as-of/confidenceが表示される
+- [ ] `draft` が「下書き」と明示される
+- [ ] 現行thesisの版、構造仮説、risk、falsification condition、next checkが表示される
+- [ ] analysis historyが基準日・出典付きで表示される
+- [ ] evidenceがclaim、stance、検証状態、source、source-as-of、confidence付きで表示される
+- [ ] direct linksが関係・status・出典付きで表示され、`http` / `https` のURLだけリンクとして開ける
+- [ ] taxonomy mapでnodes、edges、theme links、stock linksの関係が確認できる
+- [ ] metricsで定義、単位、snapshot、value、計算メモが確認できる
+- [ ] metric valueが0の場合、欠損ではなく`0`と表示される
+- [ ] open actionsが確認事項、条件、期限、関連分析／仮説付きで表示される
+- [ ] 画面に保存・編集・更新・完了・削除の操作がなく、「読み取り専用」と表示される
+- [ ] テーマの表示から売買判断（買う／売る／保有する）が確定されない
+
+## 空・欠損・下書き
+
+- [ ] 一覧の空配列が「テーマなし」と表示され、取得失敗と混同されない
+- [ ] 詳細の明示的なnull／空配列が「データなし」と表示される
+- [ ] 詳細で未提供のセクションが「未提供」と表示され、空データと区別される
+- [ ] source、as-of、confidenceの未提供が「未提供」と表示される
+- [ ] thesisがないテーマでも、テーマ概要と他の提供済みセクションは表示される
+
+## 異常系
+
+- [ ] `STOCK_NOTES_API_BASE_URL` または `STOCK_NOTES_API_TOKEN` 未設定時に設定不足画面が表示される
+- [ ] APIの401時に認証エラー画面が表示される
+- [ ] APIの5xx、接続失敗、timeout時に一時的な取得失敗画面が表示される
+- [ ] 詳細の404時に指定テーマなし画面が表示される
+- [ ] JSON、必須項目、schema versionが契約外のときにレスポンス不正画面が表示される
+- [ ] Premium未認証で一覧／詳細へ直接アクセスすると、元URLを保ったままPremiumログインへ遷移する
+
+## server-only確認
+
+- [ ] ブラウザーのHTML、リンク、ページpropsに `STOCK_NOTES_API_TOKEN` の値が含まれない
+- [ ] ブラウザーのNetworkログにstock-notes token付きリクエストが出ず、Viewer API呼び出しはサーバー側で完了する
+- [ ] 開発者ツールで確認する場合も、実tokenをチケットやスクリーンショットへ残さない
+
+## 関連
+
+- 仕様: [テーマViewer仕様](../specs/tools/theme-viewer.md)
+- Decision Log: [テーマViewerの読み取り契約と責任境界](../decision-log/2026-08-27-theme-viewer-read-model.md)

--- a/lib/__tests__/premium-navigation.test.ts
+++ b/lib/__tests__/premium-navigation.test.ts
@@ -8,6 +8,8 @@ describe("getSafePremiumNextPath", () => {
   it.each([
     ["/premium", "/premium"],
     ["/premium/portfolio?tab=stocks", "/premium/portfolio?tab=stocks"],
+    ["/premium/themes", "/premium/themes"],
+    ["/premium/themes/theme-1", "/premium/themes/theme-1"],
     ["/admin", "/admin"],
     ["/tools/yutai-dashboard", "/tools/yutai-dashboard"],
     ["/tools/yutai-dashboard?month=all", "/tools/yutai-dashboard?month=all"],

--- a/lib/premium-navigation.ts
+++ b/lib/premium-navigation.ts
@@ -1,6 +1,7 @@
 const DEFAULT_PREMIUM_NEXT_PATH = "/premium";
 const ALLOWED_PREMIUM_NEXT_PATHS = [
   "/premium",
+  "/premium/themes",
   "/admin",
   "/tools/yutai-dashboard",
 ] as const;


### PR DESCRIPTION
## 概要

ChatGPT + Supabaseで登録・更新したThemeを、stock-notesの読み取り専用 `theme-viewer.v1` API経由で確認するPremium Theme Viewerを追加します。

## 変更内容

- `/premium/themes` の一覧と `/premium/themes/[themeId]` の詳細を追加
- `STOCK_NOTES_API_BASE_URL` / `STOCK_NOTES_API_TOKEN` をserver-sideだけで利用
- 未設定、401、404、5xx、接続失敗、空データ、契約不一致を区別
- 見立て、分析履歴、根拠、直接リンク、taxonomy map、metrics、open actionsを読み取り専用表示
- source / as-of / confidence、draft、欠損状態を明示
- Premiumホーム導線、Tool Spec、Decision Log、UATを追加

## 責任境界

- ChatGPT + Supabaseの直接編集経路は維持
- MiniToolsはDB tableへ直接依存せず、versioned read modelだけを読む
- tokenをブラウザへ露出しない
- ViewerからDB更新や売買判断確定を行わない

## 確認項目

- `npm test`: 51 files / 569 tests passed
- `npm run lint`: passed
- `npx tsc --noEmit`: passed
- `npm run build`: passed（`/premium/themes`、`/premium/themes/[themeId]`生成確認）
- Lunaによるレビュー指摘対応済み: `8a08ad0`
- 実画面UATはAPI接続環境で別途実施

Closes #483
