### PR TITLE
feat(portfolio): 企業グループexposureを追加

### DIFF
--- a/app/premium/portfolio/CompanyGroupExposureCard.tsx
+++ b/app/premium/portfolio/CompanyGroupExposureCard.tsx
@@ -1,0 +1,102 @@
+import Link from "next/link";
+import type { CompanyGroupExposure } from "./company-group-exposure";
+
+function formatYen(value: number | null) {
+  if (value === null) return "—";
+  return new Intl.NumberFormat("ja-JP", {
+    style: "currency",
+    currency: "JPY",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatPct(value: number | null) {
+  if (value === null) return "—";
+  return `${new Intl.NumberFormat("ja-JP", { maximumFractionDigits: 1, minimumFractionDigits: 1 }).format(value)}%`;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(0, 10);
+  return new Intl.DateTimeFormat("ja-JP", { dateStyle: "medium", timeZone: "Asia/Tokyo" }).format(date);
+}
+
+export default function CompanyGroupExposureCard({ exposure, asOf }: { exposure: CompanyGroupExposure; asOf: string | null }) {
+  const hasGroups = exposure.groups.length > 0;
+
+  return (
+    <section style={{ background: "var(--color-bg-card)", border: "1px solid var(--color-border)", borderRadius: 12, padding: 18 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 14, alignItems: "flex-start", flexWrap: "wrap" }}>
+        <div>
+          <div style={{ color: "var(--color-text-muted)", fontSize: 12, fontWeight: 800 }}>企業関係ネットワーク × ポートフォリオ</div>
+          <h2 style={{ margin: "4px 0 0", fontSize: 20 }}>企業グループ集中（事実ベース）</h2>
+          <p style={{ margin: "8px 0 0", color: "var(--color-text-sub)", fontSize: 13, lineHeight: 1.7 }}>
+            最新の公式保有を、確認済みの企業グループ所属で横断します。同じグループへの所属は表示しますが、業績連動や受益関係までは推論しません。
+          </p>
+        </div>
+        <Link href="/premium/company-network" style={{ color: "var(--color-accent)", fontWeight: 800, fontSize: 13, textDecoration: "none" }}>
+          企業関係マップを開く →
+        </Link>
+      </div>
+
+      <div style={{ marginTop: 16, display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 10 }}>
+        <div style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: 13 }}>
+          <div style={{ color: "var(--color-text-muted)", fontSize: 11, fontWeight: 800 }}>グループ所属を確認できた評価額</div>
+          <div style={{ marginTop: 6, fontSize: 21, fontWeight: 900 }}>{formatYen(exposure.groupResolvedMarketValue)}</div>
+          <div style={{ marginTop: 4, color: "var(--color-text-muted)", fontSize: 11 }}>公式保有全体の {formatPct(exposure.coveragePct)}</div>
+        </div>
+        <div style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: 13 }}>
+          <div style={{ color: "var(--color-text-muted)", fontSize: 11, fontWeight: 800 }}>グループ所属まで解決</div>
+          <div style={{ marginTop: 6, fontSize: 21, fontWeight: 900 }}>{exposure.groupResolvedInstrumentCount} / {exposure.eligibleInstrumentCount} 銘柄</div>
+          <div style={{ marginTop: 4, color: "var(--color-text-muted)", fontSize: 11 }}>対象: stock_id付き国内株</div>
+        </div>
+        <div style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: 13 }}>
+          <div style={{ color: "var(--color-text-muted)", fontSize: 11, fontWeight: 800 }}>company identityまで解決</div>
+          <div style={{ marginTop: 6, fontSize: 21, fontWeight: 900 }}>{exposure.companyResolvedInstrumentCount} / {exposure.eligibleInstrumentCount} 銘柄</div>
+          <div style={{ marginTop: 4, color: "var(--color-text-muted)", fontSize: 11 }}>未解決を「所属なし」とみなしません</div>
+        </div>
+        <div style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: 13 }}>
+          <div style={{ color: "var(--color-text-muted)", fontSize: 11, fontWeight: 800 }}>基準日</div>
+          <div style={{ marginTop: 6, fontSize: 18, fontWeight: 900 }}>{formatDate(asOf)}</div>
+          <div style={{ marginTop: 4, color: "var(--color-text-muted)", fontSize: 11 }}>最新ready公式snapshot</div>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 16, display: "grid", gap: 10 }}>
+        {hasGroups ? exposure.groups.map((group) => (
+          <article key={group.groupId} style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: 14 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "baseline" }}>
+              <div>
+                <strong style={{ fontSize: 16 }}>{group.groupName}</strong>
+                <span style={{ marginLeft: 8, color: "var(--color-text-muted)", fontSize: 11 }}>{group.groupType}</span>
+              </div>
+              <div style={{ textAlign: "right" }}>
+                <strong>{formatYen(group.marketValue)}</strong>
+                <span style={{ marginLeft: 8, color: "var(--color-text-sub)", fontSize: 12 }}>公式保有の {formatPct(group.portfolioSharePct)}</span>
+              </div>
+            </div>
+            <div style={{ marginTop: 10, display: "grid", gap: 7 }}>
+              {group.members.map((member) => (
+                <div key={`${group.groupId}:${member.instrumentId}`} style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", borderTop: "1px solid var(--color-border)", paddingTop: 7 }}>
+                  <span><strong>{member.identifier}</strong> {member.name}</span>
+                  <span style={{ color: "var(--color-text-sub)", fontSize: 12 }}>
+                    {formatYen(member.marketValue)} / 根拠 {member.membershipBasis} / source {formatDate(member.sourceAsOf)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </article>
+        )) : (
+          <div style={{ border: "1px dashed var(--color-border)", borderRadius: 10, padding: 14, color: "var(--color-text-sub)", fontSize: 13, lineHeight: 1.7 }}>
+            現在の確認済みデータでは、最新保有に結び付く企業グループ所属を表示できません。これは「企業グループへの集中がない」という意味ではなく、company identity / group membership のデータ整備が未完了である可能性を含みます。
+          </div>
+        )}
+      </div>
+
+      <p style={{ margin: "14px 0 0", color: "var(--color-text-muted)", fontSize: 11, lineHeight: 1.7 }}>
+        集計対象は current・verified の corporate_group / capital_group / keiretsu / presidents_club です。旧財閥などの歴史的系譜は現代の資本集中と同一視しないため除外しています。複数グループに正式所属する企業は各グループへ表示されるため、グループ別金額の単純合計はポートフォリオ評価額と一致しない場合があります。
+      </p>
+    </section>
+  );
+}

--- a/app/premium/portfolio/company-group-exposure.ts
+++ b/app/premium/portfolio/company-group-exposure.ts
@@ -1,0 +1,191 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type CompanyGroupExposureMember = {
+  instrumentId: string;
+  identifier: string;
+  name: string;
+  marketValue: number;
+  companyEntityId: string;
+  companyName: string;
+  membershipBasis: string;
+  sourceAsOf: string | null;
+};
+
+export type CompanyGroupExposureRow = {
+  groupId: string;
+  groupName: string;
+  groupType: string;
+  marketValue: number;
+  portfolioSharePct: number | null;
+  members: CompanyGroupExposureMember[];
+};
+
+export type CompanyGroupExposure = {
+  snapshotId: string | null;
+  totalMarketValue: number | null;
+  eligibleInstrumentCount: number;
+  companyResolvedInstrumentCount: number;
+  groupResolvedInstrumentCount: number;
+  groupResolvedMarketValue: number;
+  coveragePct: number | null;
+  groups: CompanyGroupExposureRow[];
+};
+
+type PositionRow = { instrument_id: string; market_value: number | string | null };
+type InstrumentRow = { id: string; stock_id: string | null; asset_type: string; identifier: string; name: string };
+type CompanyStockLinkRow = { stock_id: string; company_entity_id: string };
+type MembershipRow = {
+  company_entity_id: string;
+  company_name: string;
+  group_id: string;
+  group_name: string;
+  group_type: string;
+  membership_basis: string;
+  source_as_of: string | null;
+};
+
+const ELIGIBLE_GROUP_TYPES = new Set(["corporate_group", "capital_group", "keiretsu", "presidents_club"]);
+
+function toNumber(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function emptyCompanyGroupExposure(snapshotId: string | null = null): CompanyGroupExposure {
+  return {
+    snapshotId,
+    totalMarketValue: null,
+    eligibleInstrumentCount: 0,
+    companyResolvedInstrumentCount: 0,
+    groupResolvedInstrumentCount: 0,
+    groupResolvedMarketValue: 0,
+    coveragePct: null,
+    groups: [],
+  };
+}
+
+export async function loadCompanyGroupExposure(supabase: SupabaseClient, snapshotId: string | null): Promise<CompanyGroupExposure> {
+  if (!snapshotId) return emptyCompanyGroupExposure();
+
+  const { data: positionData, error: positionError } = await supabase
+    .from("stock_notes_portfolio_positions")
+    .select("instrument_id, market_value")
+    .eq("snapshot_id", snapshotId)
+    .returns<PositionRow[]>();
+  if (positionError) throw positionError;
+
+  const valueByInstrument = new Map<string, number>();
+  for (const row of positionData ?? []) {
+    const marketValue = toNumber(row.market_value);
+    if (marketValue === null) continue;
+    valueByInstrument.set(row.instrument_id, (valueByInstrument.get(row.instrument_id) ?? 0) + marketValue);
+  }
+
+  const instrumentIds = [...valueByInstrument.keys()];
+  if (instrumentIds.length === 0) return { ...emptyCompanyGroupExposure(snapshotId), totalMarketValue: 0 };
+
+  const { data: instrumentData, error: instrumentError } = await supabase
+    .from("stock_notes_portfolio_instruments")
+    .select("id, stock_id, asset_type, identifier, name")
+    .in("id", instrumentIds)
+    .returns<InstrumentRow[]>();
+  if (instrumentError) throw instrumentError;
+
+  const instruments = (instrumentData ?? []).filter((row) => row.stock_id && row.asset_type === "domestic_stock");
+  const totalMarketValue = [...valueByInstrument.values()].reduce((sum, value) => sum + value, 0);
+  const stockIds = [...new Set(instruments.map((row) => row.stock_id).filter((id): id is string => Boolean(id)))];
+  if (stockIds.length === 0) {
+    return { ...emptyCompanyGroupExposure(snapshotId), totalMarketValue, eligibleInstrumentCount: instruments.length, coveragePct: totalMarketValue > 0 ? 0 : null };
+  }
+
+  const { data: linkData, error: linkError } = await supabase
+    .from("stock_notes_company_stock_links")
+    .select("stock_id, company_entity_id")
+    .in("stock_id", stockIds)
+    .is("valid_to", null)
+    .returns<CompanyStockLinkRow[]>();
+  if (linkError) throw linkError;
+
+  const companyByStock = new Map<string, string>();
+  for (const row of linkData ?? []) companyByStock.set(row.stock_id, row.company_entity_id);
+  const companyIds = [...new Set(companyByStock.values())];
+
+  const { data: membershipData, error: membershipError } = companyIds.length > 0
+    ? await supabase
+      .from("stock_notes_company_group_memberships_v")
+      .select("company_entity_id, company_name, group_id, group_name, group_type, membership_basis, source_as_of")
+      .in("company_entity_id", companyIds)
+      .eq("verification_status", "verified")
+      .eq("is_current", true)
+      .returns<MembershipRow[]>()
+    : { data: [], error: null };
+  if (membershipError) throw membershipError;
+
+  const membershipsByCompany = new Map<string, MembershipRow[]>();
+  for (const membership of membershipData ?? []) {
+    if (!ELIGIBLE_GROUP_TYPES.has(membership.group_type)) continue;
+    const rows = membershipsByCompany.get(membership.company_entity_id) ?? [];
+    rows.push(membership);
+    membershipsByCompany.set(membership.company_entity_id, rows);
+  }
+
+  const companyResolved = new Set<string>();
+  const groupResolved = new Set<string>();
+  const groups = new Map<string, CompanyGroupExposureRow>();
+
+  for (const instrument of instruments) {
+    if (!instrument.stock_id) continue;
+    const companyEntityId = companyByStock.get(instrument.stock_id);
+    if (!companyEntityId) continue;
+    companyResolved.add(instrument.id);
+
+    const memberships = membershipsByCompany.get(companyEntityId) ?? [];
+    if (memberships.length === 0) continue;
+    groupResolved.add(instrument.id);
+    const marketValue = valueByInstrument.get(instrument.id) ?? 0;
+
+    for (const membership of memberships) {
+      const current = groups.get(membership.group_id) ?? {
+        groupId: membership.group_id,
+        groupName: membership.group_name,
+        groupType: membership.group_type,
+        marketValue: 0,
+        portfolioSharePct: null,
+        members: [],
+      };
+      current.marketValue += marketValue;
+      current.members.push({
+        instrumentId: instrument.id,
+        identifier: instrument.identifier,
+        name: instrument.name,
+        marketValue,
+        companyEntityId,
+        companyName: membership.company_name,
+        membershipBasis: membership.membership_basis,
+        sourceAsOf: membership.source_as_of,
+      });
+      groups.set(membership.group_id, current);
+    }
+  }
+
+  const groupResolvedMarketValue = [...groupResolved].reduce((sum, instrumentId) => sum + (valueByInstrument.get(instrumentId) ?? 0), 0);
+  const groupRows = [...groups.values()]
+    .map((group) => ({
+      ...group,
+      portfolioSharePct: totalMarketValue > 0 ? (group.marketValue / totalMarketValue) * 100 : null,
+      members: group.members.sort((a, b) => b.marketValue - a.marketValue || a.identifier.localeCompare(b.identifier)),
+    }))
+    .sort((a, b) => b.marketValue - a.marketValue || a.groupName.localeCompare(b.groupName, "ja"));
+
+  return {
+    snapshotId,
+    totalMarketValue,
+    eligibleInstrumentCount: instruments.length,
+    companyResolvedInstrumentCount: companyResolved.size,
+    groupResolvedInstrumentCount: groupResolved.size,
+    groupResolvedMarketValue,
+    coveragePct: totalMarketValue > 0 ? (groupResolvedMarketValue / totalMarketValue) * 100 : null,
+    groups: groupRows,
+  };
+}

--- a/app/premium/portfolio/page.tsx
+++ b/app/premium/portfolio/page.tsx
@@ -76,11 +76,14 @@ export default async function PremiumPortfolioPage() {
         </nav>
 
         {portfolio.authState === "authenticated" && portfolio.currentSnapshot ? (
-          <CompanyGroupExposureCard
-            exposure={companyGroupExposure}
-            asOf={portfolio.currentSnapshot.asOf}
-            errorMessage={companyGroupExposureError}
-          />
+          companyGroupExposureError ? (
+            <section style={{ background: "var(--color-bg-card)", border: "1px solid var(--color-border)", borderRadius: 12, padding: 18 }}>
+              <h2 style={{ margin: 0, fontSize: 20 }}>企業グループ集中（事実ベース）</h2>
+              <p style={{ margin: "8px 0 0", color: "var(--color-text-sub)", lineHeight: 1.7 }}>{companyGroupExposureError}</p>
+            </section>
+          ) : (
+            <CompanyGroupExposureCard exposure={companyGroupExposure} asOf={portfolio.currentSnapshot.asOf} />
+          )
         ) : null}
 
         <PortfolioWorkspace data={portfolio} />

--- a/app/premium/portfolio/page.tsx
+++ b/app/premium/portfolio/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import CompanyGroupExposureCard from "./CompanyGroupExposureCard";
 import PortfolioWorkspace from "./PortfolioWorkspace";
+import { emptyCompanyGroupExposure, loadCompanyGroupExposure } from "./company-group-exposure";
 import { loadPortfolio, portfolioAuthRequired } from "./data";
 import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 import { isSyncConfigured } from "@/lib/supabase/config";
@@ -25,12 +27,24 @@ export default async function PremiumPortfolioPage() {
   }
 
   let portfolio = portfolioAuthRequired();
+  let companyGroupExposure = emptyCompanyGroupExposure();
+  let companyGroupExposureError: string | null = null;
+
   if (isSyncConfigured()) {
     const supabase = await createSupabaseServerClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    portfolio = user ? await loadPortfolio(supabase) : portfolioAuthRequired();
+
+    if (user) {
+      portfolio = await loadPortfolio(supabase);
+      try {
+        companyGroupExposure = await loadCompanyGroupExposure(supabase, portfolio.currentSnapshot?.id ?? null);
+      } catch (error) {
+        console.error("Failed to load company group exposure", error);
+        companyGroupExposureError = "企業関係データの取得に失敗しました。ポートフォリオ本体の表示は継続しています。";
+      }
+    }
   }
 
   return (
@@ -60,6 +74,14 @@ export default async function PremiumPortfolioPage() {
             優待銘柄メモ
           </Link>
         </nav>
+
+        {portfolio.authState === "authenticated" && portfolio.currentSnapshot ? (
+          <CompanyGroupExposureCard
+            exposure={companyGroupExposure}
+            asOf={portfolio.currentSnapshot.asOf}
+            errorMessage={companyGroupExposureError}
+          />
+        ) : null}
 
         <PortfolioWorkspace data={portfolio} />
       </section>

--- a/docs/decision-log/2026-08-28-portfolio-company-group-exposure.md
+++ b/docs/decision-log/2026-08-28-portfolio-company-group-exposure.md
@@ -1,0 +1,49 @@
+# ポートフォリオへ企業グループexposureを追加する
+
+日付: 2026-08-28
+
+## 背景
+
+企業関係ネットワーク Phase 1〜4 で、company identity、企業間関係、企業グループ所属、1-hop/2-hop探索、企業関係マップを追加した。Phase 5では、この事実層を投資分析へ接続する。
+
+ポートフォリオV2の正本では、active policy → exposure → gap の順序を維持し、個別銘柄情報を主入力へ戻さないことが重要である。企業グループは33業種・cycle・income・roleを置き換える分類ではなく、セクター横断の集中を補助的に見る独立軸として扱う。
+
+## 決定
+
+1. 最新readyのofficial snapshotを対象にする。
+2. 同一instrumentの複数口座positionはmarket_valueを商品単位へ集約してから判定する。
+3. portfolio instrumentのstock_idからcompany identityへ解決し、currentなcompany-stock linkだけを使う。
+4. corporate group membershipはcurrentかつverifiedのみを既定の集計対象にする。
+5. 現代の集中度には `corporate_group` / `capital_group` / `keiretsu` / `presidents_club` を使う。
+6. `zaibatsu_lineage` / `historical_group` は歴史的系譜であり、現代の資本集中と同一視しないため集計から除外する。
+7. company identity未解決、group membership未整備は「グループ所属なし」に変換せずcoverageとして表示する。
+8. 同じグループへの所属は事実として表示するが、業績連動・受益・売買判断を自動推論しない。
+9. 企業関係データ取得失敗はポートフォリオ本体の取得失敗と分離し、本体表示を継続する。
+10. 一社が複数グループに正式所属する場合は各グループへ表示する。そのためグループ別金額の単純合計はポートフォリオ総額と一致しない場合がある。coverageはinstrumentを重複計上せず算出する。
+
+## V1の表示
+
+`/premium/portfolio` に「企業グループ集中（事実ベース）」カードを追加する。
+
+表示するもの:
+- group membershipまで解決できた評価額と公式保有全体に対するcoverage
+- group membershipまで解決できた銘柄数
+- company identityまで解決できた銘柄数
+- group別の評価額・公式保有比率・構成銘柄
+- membership basisとsource_as_of
+- `/premium/company-network` への導線
+
+## 現時点のデータ品質
+
+実装開始時点の最新official snapshotは41商品・52position、評価額12,480,043円だった。stock_idは多くの国内株に存在する一方、company identity / verified group membershipのcoverageは低かった。
+
+Phase 2で公式情報により作成済みだったトヨタ自動車entity・TSE 7203 listing・トヨタグループmembershipを、既存stock masterの7203へ `primary_listing` として接続した。これにより実保有のトヨタ自動車を、推測なしでトヨタグループexposureとして解決できる。
+
+今後coverageを上げる場合も、企業名の似た文字列から自動でgroup membershipを推定せず、company identity linkと公式根拠を順次整備する。
+
+## 非対象
+
+- group concentrationから売買actionを自動生成すること
+- 旧財閥系譜を現代group exposureへ自動合算すること
+- 外部参照資産のgroup exposure統合
+- theme → company → related company の二次探索（Phase 5B）


### PR DESCRIPTION
## 概要

Issue #501 の Phase 5A として、企業関係ネットワークをポートフォリオへ接続し、current / verified な企業グループ所属だけを事実ベースのexposureとして表示します。

## 変更内容

- `/premium/portfolio` に「企業グループ集中（事実ベース）」カードを追加
- 最新ready official snapshotのpositionをinstrument単位へ集約
- `stock_id → company identity → verified/current group membership` を解決
- corporate_group / capital_group / keiretsu / presidents_club のみ現代group exposureへ集計
- zaibatsu_lineage / historical_group は現代の集中度から除外
- group別の評価額・公式保有比率・構成銘柄・membership basis・source_as_ofを表示
- company identity / group membership の未整備を「所属なし」と扱わずcoverageとして表示
- 企業関係取得失敗をポートフォリオ本体から障害分離
- `/premium/company-network` への導線を追加
- 集計ルールをdecision logへ記録

## 実データ確認

最新official snapshot:
- 41商品 / 52position
- 評価額 12,480,043円
- stock_id付き国内株 37銘柄
- company identity解決 4銘柄
- verified group membership解決 1銘柄
- トヨタグループ: 7203 トヨタ自動車 372,317円 / 公式保有の2.98%
- membership basis: official_group_member
- source_as_of: 2026-04-01

Phase 2で公式情報に基づき作成済みだったトヨタ自動車entity / TSE 7203 listing / トヨタグループmembershipを、既存stock master 7203へprimary_listingで接続して検証しました。推測によるgroup membershipは追加していません。

## 設計上の境界

- group exposureは33業種 / cycle / income / roleを置き換えず、追加の集中軸として扱う
- 同一グループ所属から業績連動・受益・売買判断を自動推論しない
- 複数グループ所属は各groupへ表示するためgroup別金額の単純合計は総額と一致しない場合がある
- coverageはinstrumentを重複計上せず算出
- 外部参照資産は今回の対象外
- theme → company → related company は #502 で実装

## 確認項目

- [x] Supabase実データで集計結果を確認
- [x] authenticated roleでcompany-stock link / verified membershipのRLS読み取りを確認
- [x] `npm run lint` — CI run #970 success
- [x] `npm run test` — CI run #970 success
- [x] `npm run build` — CI run #970 success
- [ ] Codex CLI review — この実行環境にcodexコマンドがないため未実施
- [ ] Premium認証付き実ブラウザ表示確認

Closes #501