### PR TITLE
feat(theme-network): テーマ→企業→関係企業の横断探索を追加

### DIFF
--- a/app/premium/page.tsx
+++ b/app/premium/page.tsx
@@ -61,6 +61,14 @@ const FEATURE_CARDS: FeatureCard[] = [
     tone: "violet",
   },
   {
+    href: "/premium/theme-company-network",
+    icon: "🔗",
+    title: "テーマ × 企業関係",
+    description:
+      "テーマへの直接企業と、出資・支配などの企業関係で見つかる企業を分けて横断探索します。",
+    tone: "violet",
+  },
+  {
     href: "/premium/routines",
     icon: "🗓",
     title: "ルーティン一覧",

--- a/app/premium/theme-company-network/ThemeCompanyNetworkClient.tsx
+++ b/app/premium/theme-company-network/ThemeCompanyNetworkClient.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { ThemeCompanyNetworkLoadResult, ThemeCompanyRelationship, ThemeDirectCompany } from "./data-loader";
+
+function formatPct(value: number | null) {
+  if (value === null) return "";
+  return `${new Intl.NumberFormat("ja-JP", { maximumFractionDigits: 2 }).format(value)}%`;
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(0, 10);
+  return new Intl.DateTimeFormat("ja-JP", { dateStyle: "medium", timeZone: "Asia/Tokyo" }).format(date);
+}
+
+function relationLabel(relation: ThemeCompanyRelationship) {
+  const labels: Record<string, string> = {
+    equity_ownership: "出資",
+    parent_of: "親会社",
+    controls: "支配",
+    equity_method_investment: "持分法",
+    spun_off: "分社",
+    predecessor_of: "前身",
+    merged_into: "統合",
+  };
+  const base = labels[relation.relationType] ?? relation.relationType;
+  const pct = formatPct(relation.ownershipPct);
+  return pct ? `${base} ${pct}` : base;
+}
+
+type RelatedRow = {
+  direct: ThemeDirectCompany;
+  relatedCompanyId: string;
+  relatedCompanyName: string;
+  relatedIsAlsoDirect: boolean;
+  relationship: ThemeCompanyRelationship;
+};
+
+export default function ThemeCompanyNetworkClient({ result }: { result: ThemeCompanyNetworkLoadResult }) {
+  const data = result.data;
+  const defaultThemeId = useMemo(() => {
+    if (!data) return "";
+    const verifiedDirect = data.directCompanies.filter((link) => link.sourceStatus === "verified");
+    const withRelationship = data.themes.find((theme) =>
+      verifiedDirect.some((link) =>
+        link.themeId === theme.id &&
+        data.relationships.some(
+          (relationship) =>
+            relationship.verificationStatus === "verified" &&
+            (relationship.sourceCompanyId === link.companyId || relationship.targetCompanyId === link.companyId),
+        ),
+      ),
+    );
+    return withRelationship?.id ?? data.themes[0]?.id ?? "";
+  }, [data]);
+
+  const [selectedThemeId, setSelectedThemeId] = useState(defaultThemeId);
+  const [includeProposed, setIncludeProposed] = useState(false);
+
+  const directCompanies = useMemo(() => {
+    if (!data || !selectedThemeId) return [];
+    return data.directCompanies
+      .filter((link) => link.themeId === selectedThemeId)
+      .filter((link) => link.sourceStatus === "verified" || (includeProposed && link.sourceStatus === "proposed"))
+      .sort((a, b) => a.companyName.localeCompare(b.companyName, "ja"));
+  }, [data, selectedThemeId, includeProposed]);
+
+  const relatedRows = useMemo<RelatedRow[]>(() => {
+    if (!data) return [];
+    const directIds = new Set(directCompanies.map((company) => company.companyId));
+    const seen = new Set<string>();
+    const rows: RelatedRow[] = [];
+
+    for (const direct of directCompanies) {
+      for (const relationship of data.relationships) {
+        if (relationship.verificationStatus !== "verified" && !(includeProposed && relationship.verificationStatus === "proposed")) continue;
+        const directIsSource = relationship.sourceCompanyId === direct.companyId;
+        const directIsTarget = relationship.targetCompanyId === direct.companyId;
+        if (!directIsSource && !directIsTarget) continue;
+
+        const relatedCompanyId = directIsSource ? relationship.targetCompanyId : relationship.sourceCompanyId;
+        const relatedCompanyName = directIsSource ? relationship.targetCompanyName : relationship.sourceCompanyName;
+        const key = `${direct.companyId}:${relationship.relationId}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        rows.push({
+          direct,
+          relatedCompanyId,
+          relatedCompanyName,
+          relatedIsAlsoDirect: directIds.has(relatedCompanyId),
+          relationship,
+        });
+      }
+    }
+
+    return rows.sort((a, b) => a.relatedCompanyName.localeCompare(b.relatedCompanyName, "ja"));
+  }, [data, directCompanies, includeProposed]);
+
+  if (!data) {
+    return (
+      <main style={{ padding: "28px 16px 72px" }}>
+        <section style={{ maxWidth: 1100, margin: "0 auto", display: "grid", gap: 16 }}>
+          <Link href="/premium" style={{ color: "var(--color-text-sub)", textDecoration: "none", fontWeight: 800 }}>← Premium ホーム</Link>
+          <div style={{ background: "var(--color-bg-card)", border: "1px solid var(--color-border)", borderRadius: 16, padding: 20 }}>
+            <h1 style={{ margin: 0 }}>テーマ × 企業関係</h1>
+            <p style={{ color: "var(--color-text-sub)", lineHeight: 1.8 }}>{result.message}</p>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  const selectedTheme = data.themes.find((theme) => theme.id === selectedThemeId) ?? data.themes[0] ?? null;
+
+  return (
+    <main style={{ padding: "28px 16px 72px" }}>
+      <section style={{ maxWidth: 1180, margin: "0 auto", display: "grid", gap: 16 }}>
+        <nav style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <Link href="/premium" style={{ color: "var(--color-text-sub)", textDecoration: "none", fontWeight: 800 }}>← Premium ホーム</Link>
+          <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+            <Link href="/premium/industry-map" style={{ color: "var(--color-text-sub)", textDecoration: "none", fontWeight: 800 }}>業界マップ</Link>
+            <Link href="/premium/company-network" style={{ color: "var(--color-text-sub)", textDecoration: "none", fontWeight: 800 }}>企業関係マップ</Link>
+          </div>
+        </nav>
+
+        <header style={{ background: "linear-gradient(135deg, #172554 0%, #312e81 52%, #5b21b6 100%)", color: "white", borderRadius: 22, padding: "24px 22px" }}>
+          <div style={{ fontSize: 12, fontWeight: 900, letterSpacing: 0.5, opacity: 0.8 }}>FACT LAYER CROSS EXPLORER</div>
+          <h1 style={{ margin: "7px 0 8px", fontSize: 30 }}>テーマ → 企業 → 関係企業</h1>
+          <p style={{ margin: 0, maxWidth: 800, lineHeight: 1.8, color: "rgba(255,255,255,0.82)" }}>
+            テーマへ直接つながる企業と、その企業から資本・支配・歴史的関係で見つかる企業を分けて表示します。間接企業をテーマ受益企業とは自動判定しません。
+          </p>
+        </header>
+
+        <section style={{ background: "var(--color-bg-card)", border: "1px solid var(--color-border)", borderRadius: 14, padding: 16, display: "flex", gap: 18, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 6, minWidth: 280, flex: "1 1 360px" }}>
+            <span style={{ fontSize: 12, fontWeight: 900, color: "var(--color-text-muted)" }}>テーマ</span>
+            <select value={selectedThemeId} onChange={(event) => setSelectedThemeId(event.target.value)} style={{ minHeight: 42, borderRadius: 9, border: "1px solid var(--color-border)", background: "var(--color-bg-input)", color: "var(--color-text)", padding: "0 10px" }}>
+              {data.themes.map((theme) => <option key={theme.id} value={theme.id}>{theme.name}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "inline-flex", alignItems: "center", gap: 8, minHeight: 42, fontSize: 13, fontWeight: 800 }}>
+            <input type="checkbox" checked={includeProposed} onChange={(event) => setIncludeProposed(event.target.checked)} />
+            proposedも表示
+          </label>
+        </section>
+
+        <section style={{ display: "grid", gridTemplateColumns: "minmax(220px, 0.8fr) minmax(280px, 1fr) minmax(320px, 1.25fr)", gap: 14, alignItems: "start" }}>
+          <div style={{ background: "#eef2ff", border: "1px solid #c7d2fe", borderRadius: 14, padding: 16 }}>
+            <div style={{ fontSize: 11, fontWeight: 900, color: "#4338ca" }}>THEME</div>
+            <h2 style={{ margin: "6px 0 4px", fontSize: 19 }}>{selectedTheme?.name ?? "—"}</h2>
+            <div style={{ color: "var(--color-text-muted)", fontSize: 12 }}>{directCompanies.length} 直接企業</div>
+          </div>
+
+          <div style={{ display: "grid", gap: 10 }}>
+            <div style={{ fontSize: 12, fontWeight: 900, color: "var(--color-text-muted)" }}>直接テーマ企業</div>
+            {directCompanies.length > 0 ? directCompanies.map((company) => (
+              <article key={company.linkId} style={{ background: "var(--color-bg-card)", border: "2px solid #818cf8", borderRadius: 14, padding: 15 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                  <strong>{company.companyName}</strong>
+                  <span style={{ fontSize: 11, fontWeight: 900 }}>{company.sourceStatus}</span>
+                </div>
+                <div style={{ marginTop: 7, color: "var(--color-text-sub)", fontSize: 12 }}>theme relation: {company.relationType ?? "—"}</div>
+                <div style={{ marginTop: 5, color: "var(--color-text-muted)", fontSize: 11 }}>source {formatDate(company.sourceAsOf)} / confidence {company.confidence ?? "—"}</div>
+                {company.sourceUrl ? <a href={company.sourceUrl} target="_blank" rel="noreferrer" style={{ display: "inline-block", marginTop: 8, color: "var(--color-accent)", fontSize: 12, fontWeight: 800 }}>テーマ根拠を見る ↗</a> : null}
+              </article>
+            )) : (
+              <div style={{ border: "1px dashed var(--color-border)", borderRadius: 12, padding: 14, color: "var(--color-text-sub)", lineHeight: 1.7 }}>この条件で根拠確認済みの直接企業はありません。</div>
+            )}
+          </div>
+
+          <div style={{ display: "grid", gap: 10 }}>
+            <div style={{ fontSize: 12, fontWeight: 900, color: "var(--color-text-muted)" }}>企業関係で見つかった企業</div>
+            {relatedRows.length > 0 ? relatedRows.map((row) => {
+              const relationship = row.relationship;
+              const directionText = relationship.sourceCompanyId === row.direct.companyId
+                ? `${row.direct.companyName} → ${row.relatedCompanyName}`
+                : `${row.relatedCompanyName} → ${row.direct.companyName}`;
+              return (
+                <article key={`${row.direct.companyId}:${relationship.relationId}`} style={{ background: "var(--color-bg-card)", border: relationship.verificationStatus === "verified" ? "1px solid var(--color-border)" : "1px dashed #a78bfa", borderRadius: 14, padding: 15 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                    <strong>{row.relatedCompanyName}</strong>
+                    <span style={{ fontSize: 11, fontWeight: 900 }}>{relationship.verificationStatus}</span>
+                  </div>
+                  {row.relatedIsAlsoDirect ? <div style={{ marginTop: 5, fontSize: 11, fontWeight: 800, color: "#4338ca" }}>この企業は直接テーマ企業でもあります</div> : null}
+                  <div style={{ marginTop: 8, fontSize: 13, fontWeight: 800 }}>{directionText}</div>
+                  <div style={{ marginTop: 5, color: "var(--color-text-sub)", fontSize: 12 }}>{relationLabel(relationship)} / {relationship.relationCategory}</div>
+                  <div style={{ marginTop: 5, color: "var(--color-text-muted)", fontSize: 11 }}>source {formatDate(relationship.sourceAsOf)} / confidence {relationship.confidence}</div>
+                  <div style={{ marginTop: 8, padding: "8px 10px", borderRadius: 8, background: "var(--color-bg-input)", color: "var(--color-text-sub)", fontSize: 11, lineHeight: 1.6 }}>
+                    これは企業関係の事実です。{row.relatedCompanyName}が「{selectedTheme?.name ?? "このテーマ"}」の受益企業であることを意味しません。
+                  </div>
+                  {relationship.sourceUrl ? <a href={relationship.sourceUrl} target="_blank" rel="noreferrer" style={{ display: "inline-block", marginTop: 8, color: "var(--color-accent)", fontSize: 12, fontWeight: 800 }}>企業関係の根拠を見る ↗</a> : null}
+                </article>
+              );
+            }) : (
+              <div style={{ border: "1px dashed var(--color-border)", borderRadius: 12, padding: 14, color: "var(--color-text-sub)", lineHeight: 1.7 }}>直接企業に接続する確認済み企業関係はありません。関係がないとは限らず、企業関係DBのcoverageにも依存します。</div>
+            )}
+          </div>
+        </section>
+
+        <p style={{ margin: 0, color: "var(--color-text-muted)", fontSize: 11, lineHeight: 1.7 }}>
+          既定ではverifiedのみ表示します。テーマへの直接接続と企業間関係は別の根拠を持つ別エッジです。表示対象はcurrentな企業関係で、関連企業へのテーマ適合性は別途リサーチが必要です。
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/premium/theme-company-network/ThemeCompanyNetworkClient.tsx
+++ b/app/premium/theme-company-network/ThemeCompanyNetworkClient.tsx
@@ -135,9 +135,9 @@ export default function ThemeCompanyNetworkClient({ result }: { result: ThemeCom
         </header>
 
         <section style={{ background: "var(--color-bg-card)", border: "1px solid var(--color-border)", borderRadius: 14, padding: 16, display: "flex", gap: 18, flexWrap: "wrap", alignItems: "end" }}>
-          <label style={{ display: "grid", gap: 6, minWidth: 280, flex: "1 1 360px" }}>
+          <label style={{ display: "grid", gap: 6, minWidth: 260, flex: "1 1 360px" }}>
             <span style={{ fontSize: 12, fontWeight: 900, color: "var(--color-text-muted)" }}>テーマ</span>
-            <select value={selectedThemeId} onChange={(event) => setSelectedThemeId(event.target.value)} style={{ minHeight: 42, borderRadius: 9, border: "1px solid var(--color-border)", background: "var(--color-bg-input)", color: "var(--color-text)", padding: "0 10px" }}>
+            <select value={selectedThemeId} onChange={(event) => setSelectedThemeId(event.target.value)} style={{ minHeight: 42, borderRadius: 9, border: "1px solid var(--color-border)", background: "var(--color-bg-input)", color: "var(--color-text)", padding: "0 10px", maxWidth: "100%" }}>
               {data.themes.map((theme) => <option key={theme.id} value={theme.id}>{theme.name}</option>)}
             </select>
           </label>
@@ -147,31 +147,31 @@ export default function ThemeCompanyNetworkClient({ result }: { result: ThemeCom
           </label>
         </section>
 
-        <section style={{ display: "grid", gridTemplateColumns: "minmax(220px, 0.8fr) minmax(280px, 1fr) minmax(320px, 1.25fr)", gap: 14, alignItems: "start" }}>
-          <div style={{ background: "#eef2ff", border: "1px solid #c7d2fe", borderRadius: 14, padding: 16 }}>
+        <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 14, alignItems: "start" }}>
+          <div style={{ background: "#eef2ff", border: "1px solid #c7d2fe", borderRadius: 14, padding: 16, minWidth: 0 }}>
             <div style={{ fontSize: 11, fontWeight: 900, color: "#4338ca" }}>THEME</div>
             <h2 style={{ margin: "6px 0 4px", fontSize: 19 }}>{selectedTheme?.name ?? "—"}</h2>
             <div style={{ color: "var(--color-text-muted)", fontSize: 12 }}>{directCompanies.length} 直接企業</div>
           </div>
 
-          <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ display: "grid", gap: 10, minWidth: 0 }}>
             <div style={{ fontSize: 12, fontWeight: 900, color: "var(--color-text-muted)" }}>直接テーマ企業</div>
             {directCompanies.length > 0 ? directCompanies.map((company) => (
-              <article key={company.linkId} style={{ background: "var(--color-bg-card)", border: "2px solid #818cf8", borderRadius: 14, padding: 15 }}>
+              <article key={company.linkId} style={{ background: "var(--color-bg-card)", border: "2px solid #818cf8", borderRadius: 14, padding: 15, minWidth: 0 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
                   <strong>{company.companyName}</strong>
                   <span style={{ fontSize: 11, fontWeight: 900 }}>{company.sourceStatus}</span>
                 </div>
                 <div style={{ marginTop: 7, color: "var(--color-text-sub)", fontSize: 12 }}>theme relation: {company.relationType ?? "—"}</div>
                 <div style={{ marginTop: 5, color: "var(--color-text-muted)", fontSize: 11 }}>source {formatDate(company.sourceAsOf)} / confidence {company.confidence ?? "—"}</div>
-                {company.sourceUrl ? <a href={company.sourceUrl} target="_blank" rel="noreferrer" style={{ display: "inline-block", marginTop: 8, color: "var(--color-accent)", fontSize: 12, fontWeight: 800 }}>テーマ根拠を見る ↗</a> : null}
+                {company.sourceUrl ? <a href={company.sourceUrl} target="_blank" rel="noreferrer" style={{ display: "inline-block", marginTop: 8, color: "var(--color-accent)", fontSize: 12, fontWeight: 800, overflowWrap: "anywhere" }}>テーマ根拠を見る ↗</a> : null}
               </article>
             )) : (
               <div style={{ border: "1px dashed var(--color-border)", borderRadius: 12, padding: 14, color: "var(--color-text-sub)", lineHeight: 1.7 }}>この条件で根拠確認済みの直接企業はありません。</div>
             )}
           </div>
 
-          <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ display: "grid", gap: 10, minWidth: 0 }}>
             <div style={{ fontSize: 12, fontWeight: 900, color: "var(--color-text-muted)" }}>企業関係で見つかった企業</div>
             {relatedRows.length > 0 ? relatedRows.map((row) => {
               const relationship = row.relationship;
@@ -179,7 +179,7 @@ export default function ThemeCompanyNetworkClient({ result }: { result: ThemeCom
                 ? `${row.direct.companyName} → ${row.relatedCompanyName}`
                 : `${row.relatedCompanyName} → ${row.direct.companyName}`;
               return (
-                <article key={`${row.direct.companyId}:${relationship.relationId}`} style={{ background: "var(--color-bg-card)", border: relationship.verificationStatus === "verified" ? "1px solid var(--color-border)" : "1px dashed #a78bfa", borderRadius: 14, padding: 15 }}>
+                <article key={`${row.direct.companyId}:${relationship.relationId}`} style={{ background: "var(--color-bg-card)", border: relationship.verificationStatus === "verified" ? "1px solid var(--color-border)" : "1px dashed #a78bfa", borderRadius: 14, padding: 15, minWidth: 0 }}>
                   <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
                     <strong>{row.relatedCompanyName}</strong>
                     <span style={{ fontSize: 11, fontWeight: 900 }}>{relationship.verificationStatus}</span>
@@ -191,7 +191,7 @@ export default function ThemeCompanyNetworkClient({ result }: { result: ThemeCom
                   <div style={{ marginTop: 8, padding: "8px 10px", borderRadius: 8, background: "var(--color-bg-input)", color: "var(--color-text-sub)", fontSize: 11, lineHeight: 1.6 }}>
                     これは企業関係の事実です。{row.relatedCompanyName}が「{selectedTheme?.name ?? "このテーマ"}」の受益企業であることを意味しません。
                   </div>
-                  {relationship.sourceUrl ? <a href={relationship.sourceUrl} target="_blank" rel="noreferrer" style={{ display: "inline-block", marginTop: 8, color: "var(--color-accent)", fontSize: 12, fontWeight: 800 }}>企業関係の根拠を見る ↗</a> : null}
+                  {relationship.sourceUrl ? <a href={relationship.sourceUrl} target="_blank" rel="noreferrer" style={{ display: "inline-block", marginTop: 8, color: "var(--color-accent)", fontSize: 12, fontWeight: 800, overflowWrap: "anywhere" }}>企業関係の根拠を見る ↗</a> : null}
                 </article>
               );
             }) : (

--- a/app/premium/theme-company-network/data-loader.ts
+++ b/app/premium/theme-company-network/data-loader.ts
@@ -1,0 +1,201 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const ROW_LIMIT = 2000;
+
+export type ThemeNetworkTheme = {
+  id: string;
+  slug: string;
+  name: string;
+};
+
+export type ThemeDirectCompany = {
+  linkId: string;
+  themeId: string;
+  companyId: string;
+  companyName: string;
+  note: string;
+  sourceLinkId: string | null;
+  sourceStatus: string | null;
+  relationType: string | null;
+  sourceTitle: string | null;
+  sourceUrl: string | null;
+  sourceAsOf: string | null;
+  confidence: string | null;
+};
+
+export type ThemeCompanyRelationship = {
+  relationId: string;
+  sourceCompanyId: string;
+  sourceCompanyName: string;
+  targetCompanyId: string;
+  targetCompanyName: string;
+  relationCategory: string;
+  relationType: string;
+  ownershipPct: number | null;
+  votingRightsPct: number | null;
+  verificationStatus: string;
+  confidence: string;
+  sourceTitle: string | null;
+  sourceUrl: string | null;
+  sourceAsOf: string | null;
+  note: string;
+};
+
+export type ThemeCompanyNetworkData = {
+  themes: ThemeNetworkTheme[];
+  directCompanies: ThemeDirectCompany[];
+  relationships: ThemeCompanyRelationship[];
+};
+
+export type ThemeCompanyNetworkLoadResult =
+  | { status: "ok"; data: ThemeCompanyNetworkData; message: null }
+  | { status: "empty" | "error" | "unconfigured" | "unauthenticated"; data: ThemeCompanyNetworkData | null; message: string };
+
+type Row = Record<string, unknown>;
+
+function text(row: Row, key: string): string {
+  const value = row[key];
+  return typeof value === "string" ? value : "";
+}
+
+function nullableText(row: Row, key: string): string | null {
+  const value = text(row, key).trim();
+  return value ? value : null;
+}
+
+function nullableNumber(row: Row, key: string): number | null {
+  const value = row[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function themeCompanyNetworkUnconfigured(): ThemeCompanyNetworkLoadResult {
+  return { status: "unconfigured", data: null, message: "Supabase 連携が未設定のためテーマ企業ネットワークを取得できません。" };
+}
+
+export function themeCompanyNetworkAuthRequired(): ThemeCompanyNetworkLoadResult {
+  return { status: "unauthenticated", data: null, message: "Supabase にログインするとテーマ企業ネットワークを表示します。" };
+}
+
+export async function loadThemeCompanyNetwork(supabase: SupabaseClient): Promise<ThemeCompanyNetworkLoadResult> {
+  const [themesResult, linksResult, sourceLinksResult, companiesResult, relationshipsResult] = await Promise.all([
+    supabase
+      .from("stock_notes_themes")
+      .select("id,slug,display_name,status")
+      .neq("status", "archived")
+      .order("display_name", { ascending: true })
+      .limit(ROW_LIMIT),
+    supabase
+      .from("stock_notes_theme_company_links")
+      .select("id,theme_id,company_entity_id,source_theme_link_id,relation_note")
+      .order("created_at", { ascending: true })
+      .limit(ROW_LIMIT),
+    supabase
+      .from("stock_notes_theme_links")
+      .select("id,status,relation_type,source_title,source_url,source_as_of,confidence")
+      .in("status", ["verified", "proposed"])
+      .limit(ROW_LIMIT),
+    supabase
+      .from("stock_notes_company_entities")
+      .select("id,display_name,status")
+      .neq("status", "archived")
+      .limit(ROW_LIMIT),
+    supabase
+      .from("stock_notes_company_relationship_edges_v")
+      .select(
+        "relation_id,source_company_id,source_company_name,target_company_id,target_company_name," +
+          "relation_category,relation_type,ownership_pct,voting_rights_pct,verification_status,confidence," +
+          "source_title,source_url,source_as_of,relation_note,valid_to",
+      )
+      .is("valid_to", null)
+      .in("verification_status", ["verified", "proposed"])
+      .limit(ROW_LIMIT),
+  ]);
+
+  if (themesResult.error || linksResult.error || sourceLinksResult.error || companiesResult.error || relationshipsResult.error) {
+    return { status: "error", data: null, message: "テーマ企業ネットワークの取得に失敗しました。Supabase のRLS / View設定を確認してください。" };
+  }
+
+  const companies = new Map<string, string>();
+  for (const raw of (companiesResult.data ?? []) as unknown as Row[]) {
+    const id = nullableText(raw, "id");
+    const name = nullableText(raw, "display_name");
+    if (id && name) companies.set(id, name);
+  }
+
+  const sources = new Map<string, Row>();
+  for (const raw of (sourceLinksResult.data ?? []) as unknown as Row[]) {
+    const id = nullableText(raw, "id");
+    if (id) sources.set(id, raw);
+  }
+
+  const directCompanies: ThemeDirectCompany[] = [];
+  for (const raw of (linksResult.data ?? []) as unknown as Row[]) {
+    const linkId = nullableText(raw, "id");
+    const themeId = nullableText(raw, "theme_id");
+    const companyId = nullableText(raw, "company_entity_id");
+    if (!linkId || !themeId || !companyId) continue;
+    const companyName = companies.get(companyId);
+    if (!companyName) continue;
+    const sourceLinkId = nullableText(raw, "source_theme_link_id");
+    const source = sourceLinkId ? sources.get(sourceLinkId) : undefined;
+    directCompanies.push({
+      linkId,
+      themeId,
+      companyId,
+      companyName,
+      note: text(raw, "relation_note"),
+      sourceLinkId,
+      sourceStatus: source ? nullableText(source, "status") : null,
+      relationType: source ? nullableText(source, "relation_type") : null,
+      sourceTitle: source ? nullableText(source, "source_title") : null,
+      sourceUrl: source ? nullableText(source, "source_url") : null,
+      sourceAsOf: source ? nullableText(source, "source_as_of") : null,
+      confidence: source ? nullableText(source, "confidence") : null,
+    });
+  }
+
+  const usedThemeIds = new Set(directCompanies.map((link) => link.themeId));
+  const themes: ThemeNetworkTheme[] = ((themesResult.data ?? []) as unknown as Row[])
+    .map((raw) => ({ id: text(raw, "id"), slug: text(raw, "slug"), name: text(raw, "display_name") }))
+    .filter((theme) => theme.id && theme.name && usedThemeIds.has(theme.id));
+
+  const relationships: ThemeCompanyRelationship[] = [];
+  for (const raw of (relationshipsResult.data ?? []) as unknown as Row[]) {
+    const relationId = nullableText(raw, "relation_id");
+    const sourceCompanyId = nullableText(raw, "source_company_id");
+    const sourceCompanyName = nullableText(raw, "source_company_name");
+    const targetCompanyId = nullableText(raw, "target_company_id");
+    const targetCompanyName = nullableText(raw, "target_company_name");
+    const verificationStatus = nullableText(raw, "verification_status");
+    const confidence = nullableText(raw, "confidence");
+    if (!relationId || !sourceCompanyId || !sourceCompanyName || !targetCompanyId || !targetCompanyName || !verificationStatus || !confidence) continue;
+    relationships.push({
+      relationId,
+      sourceCompanyId,
+      sourceCompanyName,
+      targetCompanyId,
+      targetCompanyName,
+      relationCategory: text(raw, "relation_category"),
+      relationType: text(raw, "relation_type"),
+      ownershipPct: nullableNumber(raw, "ownership_pct"),
+      votingRightsPct: nullableNumber(raw, "voting_rights_pct"),
+      verificationStatus,
+      confidence,
+      sourceTitle: nullableText(raw, "source_title"),
+      sourceUrl: nullableText(raw, "source_url"),
+      sourceAsOf: nullableText(raw, "source_as_of"),
+      note: text(raw, "relation_note"),
+    });
+  }
+
+  const data = { themes, directCompanies, relationships };
+  if (themes.length === 0 || directCompanies.length === 0) {
+    return { status: "empty", data, message: "company identityへ接続済みのテーマ企業がまだありません。" };
+  }
+  return { status: "ok", data, message: null };
+}

--- a/app/premium/theme-company-network/page.tsx
+++ b/app/premium/theme-company-network/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+import { isSyncConfigured } from "@/lib/supabase/config";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import ThemeCompanyNetworkClient from "./ThemeCompanyNetworkClient";
+import {
+  loadThemeCompanyNetwork,
+  themeCompanyNetworkAuthRequired,
+  themeCompanyNetworkUnconfigured,
+  type ThemeCompanyNetworkLoadResult,
+} from "./data-loader";
+
+export const metadata: Metadata = {
+  title: "テーマ × 企業関係 | mini-tools premium",
+  description: "テーマへの直接企業と、資本・支配・歴史的関係で見つかる企業を根拠付きで分離表示します。",
+  alternates: { canonical: "/premium/theme-company-network" },
+  robots: { index: false, follow: false },
+};
+
+export default async function PremiumThemeCompanyNetworkPage() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+
+  if (!verifyPremiumSession(session)) {
+    redirect(`/premium/login?next=${encodeURIComponent("/premium/theme-company-network")}`);
+  }
+
+  let result: ThemeCompanyNetworkLoadResult = themeCompanyNetworkUnconfigured();
+  if (isSyncConfigured()) {
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    result = user ? await loadThemeCompanyNetwork(supabase) : themeCompanyNetworkAuthRequired();
+  }
+
+  return <ThemeCompanyNetworkClient result={result} />;
+}

--- a/docs/decision-log/2026-08-28-theme-company-network.md
+++ b/docs/decision-log/2026-08-28-theme-company-network.md
@@ -1,0 +1,55 @@
+# テーマ → 企業 → 関係企業の横断探索
+
+日付: 2026-08-28
+
+## 背景
+
+企業関係ネットワークをテーマ分析へ接続する際、「テーマに直接関係する企業」と「その企業に資本・支配等の関係がある企業」を同一視すると、企業関係があるだけでテーマ受益企業と誤認する危険がある。
+
+そのため Phase 5B では、テーマエッジと企業関係エッジを別の事実として保持・表示する。
+
+## 決定
+
+1. `stock_notes_theme_company_links` をテーマ→canonical company identityの直接エッジとして使う。
+2. 直接テーマ企業の根拠は `source_theme_link_id` から `stock_notes_theme_links` の検証状態・出典へ戻れるものを優先する。
+3. 既定表示は verified の直接テーマリンクと verified/current の企業関係だけにする。
+4. proposed は利用者が明示的に切り替えた場合のみ表示する。
+5. 関連企業は、直接テーマ企業に接続する企業関係エッジから1-hopで発見する。
+6. 資本関係の方向は探索方向に合わせて反転せず、DBのcanonical directionをそのまま表示する。
+7. 関連企業をテーマ受益企業・投資候補とは自動判定しない。テーマ適合性の追加リサーチが必要であることをUIに明示する。
+8. taxonomy/industry-mapの役割エッジと企業関係エッジは統合せず、別レイヤーとして扱う。
+
+## 代表ケース
+
+`自動運転産業マップ・商業化競争` に Woven by Toyota を直接企業として追加した。
+
+- テーマ直接関係: Woven by Toyota公式企業概要が主な事業内容として自動運転技術を明示
+- theme link: verified / high confidence / enabler
+- company identity: 既存の `ウーブン・バイ・トヨタ`
+- 企業関係: トヨタ自動車 → ウーブン・バイ・トヨタ、equity_ownership 100%、verified
+
+この結果、
+
+`自動運転テーマ → Woven by Toyota [直接] ← 100%出資 ← トヨタ自動車 [企業関係で発見]`
+
+を表示できる。
+
+ここから「トヨタ自動車は自動運転テーマの受益企業」と自動推論はしない。
+
+## UI
+
+新規Premium画面 `/premium/theme-company-network` を追加する。
+
+- テーマ選択
+- verifiedのみ / proposed含む切替
+- 直接テーマ企業の根拠・基準日・confidence
+- 関連企業との企業関係、ownership、verification、根拠
+- 関連企業が直接テーマ企業でもある場合の明示
+- `/premium/industry-map` と `/premium/company-network` への導線
+
+## 非対象
+
+- 間接受益スコア
+- 自動投資判断
+- 2-hop以降のテーマ間接探索
+- supplier/customer/joint research等のPhase 6関係


### PR DESCRIPTION
## 概要

Issue #502 の Phase 5B として、テーマへの直接企業と、その企業から資本・支配・歴史的関係で見つかる企業を別レイヤーとして横断探索するPremium画面を追加します。

## 変更内容

- `/premium/theme-company-network` を追加
- テーマ選択
- verifiedのみを既定表示、proposedを明示切替
- `stock_notes_theme_company_links` から直接テーマ企業を取得
- `source_theme_link_id` 経由でtheme linkのverification / source / confidenceを表示
- 直接企業からcurrent企業関係を1-hop探索
- 関連企業との資本・支配・歴史的関係、ownership、verification、source_as_ofを表示
- 企業関係のcanonical directionを反転せず表示
- 関連企業をテーマ受益企業と自動判定しない旨を各カードに明示
- Premiumホームに独立ツールカードを追加
- Industry Map / Company Networkへの導線を追加
- 3層表示はauto-fitでモバイル時に縦積み
- 設計境界をdecision logへ記録

## 代表データ

自動運転産業マップに Woven by Toyota を公式根拠付きで直接接続しました。

- theme: 自動運転産業マップ・商業化競争
- direct company: ウーブン・バイ・トヨタ
- theme relation: enabler
- theme status: verified / high confidence
- theme source: Woven by Toyota Company Profile
- 公式企業概要で主な事業に「自動運転技術」を明示
- company relationship: トヨタ自動車 → ウーブン・バイ・トヨタ
- relation: equity_ownership 100%
- relationship status: verified

これにより `テーマ → Woven [直接] ← 100%出資 ← トヨタ [企業関係で発見]` を、テーマ根拠と企業関係根拠を混ぜずに表示できます。

## DB運用確認

- theme linkは既存契約どおり proposedで作成し、公式根拠を付けてverifiedへ遷移
- failed INSERTはトランザクション単位で失敗しており残存なし
- authenticated roleで theme_company_links / theme_links / current company relationships のSELECTを確認

## 設計上の境界

- 直接テーマ企業と間接関連企業を別レイヤーにする
- 「資本関係がある = テーマ受益」としない
- taxonomy/industry-map edgeと企業関係edgeを統合しない
- V1は1-hopまで。2-hop以降は対象外
- supplier/customer/joint research等はPhase 6 #497の対象

## 確認項目

- [x] Supabase代表データで theme → direct company → related company のjoinを確認
- [x] authenticated roleでRLS読み取りを確認
- [x] npm run lint — CI run #973 success
- [x] npm run test — CI run #973 success
- [x] npm run build — CI run #973 success
- [ ] Codex CLI review — この実行環境にcodexコマンドがないため未実施
- [ ] Premium認証付き実ブラウザ表示確認

Closes #502