### PR TITLE
feat(company-network): 企業関係マップを4ビューへ刷新

### DIFF
--- a/app/premium/company-network/CompanyNetwork.module.css
+++ b/app/premium/company-network/CompanyNetwork.module.css
@@ -1,341 +1,734 @@
 .page {
-  min-height: 100%;
-  padding: 28px 14px 72px;
-  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
-  color: #0f172a;
-}
+  --network-blue: #2554ff;
+  --network-violet: #7c3aed;
+  --network-slate: #64748b;
+  --network-group: #d97706;
+  --panel-radius: 16px;
 
-.shell {
-  width: min(1280px, 100%);
-  margin: 0 auto;
   display: grid;
-  gap: 18px;
+  gap: 14px;
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 24px 16px calc(72px + var(--bottom-nav-space));
+  color: var(--color-text);
 }
 
-.header {
+.topNav {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
-  gap: 24px;
-  flex-wrap: wrap;
-  padding: 26px;
-  border-radius: 26px;
-  background: linear-gradient(135deg, #0f172a, #1e293b 48%, #312e81);
-  color: white;
-}
-
-.header h1 {
-  margin: 4px 0 10px;
-  font-size: clamp(28px, 5vw, 42px);
-  letter-spacing: -0.04em;
-}
-
-.header p {
-  max-width: 760px;
-  margin: 0;
-  color: rgba(255, 255, 255, 0.78);
-  line-height: 1.8;
-}
-
-.eyebrow {
-  font-size: 12px;
-  font-weight: 900;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #c7d2fe;
-}
-
-.backLink {
-  display: inline-flex;
-  margin-bottom: 10px;
-  color: inherit;
-  text-decoration: none;
-  font-weight: 800;
-}
-
-.stats {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.stats span,
-.badges span {
-  display: inline-flex;
-  align-items: center;
-  min-height: 30px;
-  padding: 0 10px;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 800;
-}
-
-.stats span {
-  background: rgba(255, 255, 255, 0.12);
-}
-
-.controls {
-  display: flex;
-  align-items: end;
-  gap: 14px;
-  flex-wrap: wrap;
-  padding: 16px;
-  border: 1px solid #dbeafe;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.94);
-}
-
-.selectLabel {
-  display: grid;
-  gap: 6px;
-  min-width: min(320px, 100%);
-  font-size: 12px;
-  font-weight: 800;
-  color: #475569;
-}
-
-.selectLabel select {
-  min-height: 44px;
-  padding: 0 12px;
-  border: 1px solid #cbd5e1;
-  border-radius: 12px;
-  background: white;
-  color: #0f172a;
-  font: inherit;
-  font-size: 16px;
-}
-
-.segment {
-  display: inline-flex;
-  padding: 4px;
-  border-radius: 13px;
-  background: #e2e8f0;
-}
-
-.button,
-.activeButton {
-  min-height: 40px;
-  padding: 0 14px;
-  border: 0;
-  border-radius: 10px;
-  font-weight: 900;
-  cursor: pointer;
-}
-
-.button {
-  background: transparent;
-  color: #475569;
-}
-
-.activeButton {
-  background: white;
-  color: #3730a3;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
-}
-
-.checks {
-  display: flex;
   gap: 12px;
   flex-wrap: wrap;
-  align-items: center;
 }
 
-.checks label {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 40px;
+.topNavLink {
+  color: var(--color-text-sub);
+  text-decoration: none;
   font-size: 13px;
+  font-weight: 800;
+}
+
+.topNavLink:hover { color: var(--color-accent); }
+
+.state,
+.hero,
+.toolbar,
+.canvas,
+.detailPanel {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-card);
+  border-radius: var(--panel-radius);
+}
+
+.state {
+  padding: 24px;
+}
+
+.state h1 { margin: 0 0 8px; font-size: 22px; }
+.state p { margin: 0; color: var(--color-text-sub); line-height: 1.8; }
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 20px;
+  display: grid;
+  gap: 14px;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -45% 58% 42% -12%;
+  background: radial-gradient(circle at 30% 40%, rgba(37, 84, 255, 0.14), rgba(37, 84, 255, 0) 70%);
+  pointer-events: none;
+}
+
+.heroHead {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 900;
+  letter-spacing: 0.01em;
+}
+
+.heroLead {
+  margin: 6px 0 0;
+  max-width: 780px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  line-height: 1.7;
+}
+
+.versionBadge {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+.statRow {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.stat {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-bg-input);
+  padding: 10px 12px;
+}
+
+.stat span {
+  display: block;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.stat strong {
+  font-size: 20px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  margin-top: 2px;
+}
+
+.stat small {
+  margin-left: 3px;
+  font-size: 11px;
   font-weight: 700;
-  color: #334155;
+  color: var(--color-text-muted);
 }
 
-.checks input {
-  width: 18px;
-  height: 18px;
+.toolbar {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  position: sticky;
+  top: 8px;
+  z-index: 5;
+  backdrop-filter: saturate(1.4) blur(6px);
 }
 
-.mapPanel,
-.detailCard {
-  border: 1px solid #dbeafe;
-  border-radius: 24px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.06);
-}
-
-.mapPanel {
+.segmented {
+  position: relative;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 2px;
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 3px;
   overflow: hidden;
 }
 
-.legend {
-  display: flex;
-  gap: 14px;
-  flex-wrap: wrap;
-  padding: 14px 18px;
-  border-bottom: 1px solid #e2e8f0;
-  font-size: 12px;
-  font-weight: 700;
-  color: #64748b;
+.segmentedIndicator {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  border-radius: 9px;
+  background: var(--color-bg-card);
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.12);
+  transition: left 260ms cubic-bezier(0.22, 1, 0.36, 1), width 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
 }
 
-.legend span {
+.segmentButton {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
+  min-height: 40px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
 }
 
-.legend i {
-  display: inline-block;
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-}
+.segmentButtonActive { color: var(--color-accent); }
 
-.legendCenter { background: #4f46e5; }
-.legendCompany { background: #dbeafe; border: 1px solid #3b82f6; }
-.legendGroup { background: #fef3c7; border: 1px solid #d97706; }
-
-.svgScroller {
-  width: 100%;
-  overflow-x: auto;
-}
-
-.graph {
-  display: block;
-  width: 100%;
-  min-width: 820px;
-  min-height: 520px;
-}
-
-.edge,
-.proposedEdge,
-.membershipEdge {
-  fill: none;
-  stroke-width: 2.4;
-}
-
-.edge { stroke: #475569; }
-.proposedEdge { stroke: #94a3b8; stroke-dasharray: 8 7; }
-.membershipEdge { stroke: #d97706; stroke-width: 2; stroke-dasharray: 7 7; opacity: 0.7; }
-.arrowHead { fill: #475569; }
-.edgeLabel { font-size: 12px; font-weight: 800; fill: #475569; paint-order: stroke; stroke: white; stroke-width: 5px; stroke-linejoin: round; }
-
-.nodeButton { cursor: pointer; outline: none; }
-.nodeButton:focus-visible circle { stroke-width: 5; stroke: #f59e0b; }
-.centerNode { fill: #4f46e5; stroke: #312e81; stroke-width: 3; }
-.companyNode { fill: #eff6ff; stroke: #3b82f6; stroke-width: 2.5; }
-.nodeLabel { font-size: 13px; font-weight: 900; fill: #0f172a; pointer-events: none; }
-.centerNode + .nodeLabel { fill: white; }
-.depthLabel { font-size: 10px; font-weight: 800; fill: #64748b; pointer-events: none; }
-.centerNode ~ .depthLabel { fill: #c7d2fe; }
-.groupNode { fill: #fffbeb; stroke: #d97706; stroke-width: 2.5; }
-.groupLabel { font-size: 13px; font-weight: 900; fill: #78350f; }
-.groupTypeLabel { font-size: 10px; font-weight: 700; fill: #a16207; }
-
-.detailsGrid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 16px;
-}
-
-.detailCard {
-  padding: 18px;
-  min-width: 0;
-}
-
-.sectionHeading {
+.controlRow,
+.filterRow,
+.viewTools {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 12px;
-}
-
-.sectionHeading h2,
-.evidence h3,
-.membershipList h3 {
-  margin: 0;
-}
-
-.sectionHeading h2 { font-size: 18px; }
-.sectionHeading span { font-size: 12px; color: #64748b; font-weight: 800; }
-
-.relationList {
-  display: grid;
   gap: 8px;
-  max-height: 390px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.companySelect {
+  display: grid;
+  gap: 4px;
+  min-width: min(300px, 100%);
+}
+
+.companySelect span {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--color-text-muted);
+}
+
+.companySelect select,
+.search {
+  min-height: 40px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 14px;
+  padding: 0 11px;
+}
+
+.search {
+  flex: 1 1 230px;
+  min-width: 180px;
+}
+
+.hopControl {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg-input);
+}
+
+.toggle,
+.toggleOn,
+.smallButton {
+  min-height: 34px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg-card);
+  color: var(--color-text-sub);
+  padding: 0 11px;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.toggleOn {
+  border-color: var(--color-accent);
+  background: var(--color-accent-sub);
+  color: var(--color-accent);
+}
+
+.toggleDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  vertical-align: middle;
+}
+
+.hint {
+  margin: 0;
+  padding: 0 3px;
+  color: var(--color-text-muted);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+  gap: 14px;
+  align-items: start;
+}
+
+.canvas {
+  min-width: 0;
+  min-height: 560px;
+  overflow: hidden;
+  padding: 14px;
+}
+
+.detailPanel {
+  min-width: 0;
+  padding: 16px;
+  display: grid;
+  gap: 0;
+  position: sticky;
+  top: 176px;
+  max-height: calc(100vh - 194px);
   overflow: auto;
 }
 
-.relationItem,
-.relationActive {
-  display: grid;
-  gap: 5px;
-  width: 100%;
-  padding: 12px;
-  border-radius: 14px;
-  text-align: left;
-  cursor: pointer;
-  font: inherit;
-}
+.viewFade { animation: viewIn 180ms ease both; }
 
-.relationItem { border: 1px solid #e2e8f0; background: #fff; color: #0f172a; }
-.relationActive { border: 1px solid #818cf8; background: #eef2ff; color: #312e81; }
-.relationItem span,
-.relationActive span { font-size: 12px; color: #64748b; }
-
-.evidence {
-  display: grid;
-  gap: 12px;
-}
-
-.evidence p {
-  margin: 0;
-  line-height: 1.75;
-  color: #475569;
-}
-
-.evidence a,
-.membershipList a {
-  color: #4338ca;
+.viewTools {
+  justify-content: space-between;
+  margin-bottom: 10px;
+  color: var(--color-text-muted);
+  font-size: 11px;
   font-weight: 800;
-  text-decoration: none;
-  overflow-wrap: anywhere;
 }
 
-.badges {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
+.svgWrap {
+  position: relative;
+  min-height: 520px;
+  overflow: hidden;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.75), rgba(238, 242, 255, 0.52));
+  border: 1px solid var(--color-border);
 }
 
-.badges span { background: #eef2ff; color: #4338ca; }
-
-.membershipList {
-  display: grid;
-  gap: 9px;
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px solid #e2e8f0;
+.svg {
+  display: block;
+  width: 100%;
+  min-height: 520px;
+  user-select: none;
 }
 
-.membershipList > div {
-  display: grid;
+.svgGrab { cursor: grab; }
+.svgGrabbing { cursor: grabbing; }
+
+.zoomControls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 2;
+  display: inline-flex;
   gap: 4px;
-  padding: 10px 0;
-  border-bottom: 1px solid #f1f5f9;
+  padding: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: rgba(255,255,255,0.92);
+  box-shadow: 0 6px 18px rgba(15,23,42,0.08);
 }
 
-.membershipList span { font-size: 12px; color: #64748b; }
-.muted,
-.message { color: #64748b; line-height: 1.7; }
-.message { padding: 18px; border-radius: 16px; background: white; }
+.zoomControls button {
+  min-width: 32px;
+  height: 30px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-sub);
+  font-weight: 900;
+  cursor: pointer;
+}
 
-@media (max-width: 780px) {
-  .page { padding: 18px 10px 56px; }
-  .header { padding: 22px 18px; border-radius: 22px; }
-  .controls { align-items: stretch; }
-  .selectLabel { width: 100%; }
-  .detailsGrid { grid-template-columns: 1fr; }
-  .graph { min-width: 760px; }
+.zoomControls button:hover:not(:disabled) { background: var(--color-bg-input); }
+.zoomControls button:disabled { opacity: 0.35; cursor: default; }
+
+.edgeHitTarget { cursor: pointer; }
+
+.svgEdgeLabel {
+  font-size: 10px;
+  font-weight: 800;
+  fill: var(--color-text-sub);
+  paint-order: stroke;
+  stroke: white;
+  stroke-width: 4px;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.membershipLine {
+  stroke: var(--network-group);
+  stroke-width: 1.6;
+  stroke-dasharray: 6 6;
+  fill: none;
+}
+
+.svgNodeDim { opacity: 0.18; }
+
+.svgLabel {
+  fill: var(--color-text);
+  font-size: 11px;
+  font-weight: 800;
+  paint-order: stroke;
+  stroke: white;
+  stroke-width: 4px;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.pulse {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: pulse 1.8s ease-out infinite;
+  pointer-events: none;
+}
+
+.radialRing,
+.radialGroupRing {
+  fill: none;
+  stroke: var(--color-border);
+  stroke-width: 1;
+  stroke-dasharray: 4 7;
+}
+
+.radialGroupRing { stroke: rgba(217, 119, 6, 0.35); }
+
+.radialCenterLabel,
+.radialNodeLabel,
+.radialGroupLabel {
+  font-size: 9px;
+  font-weight: 900;
+  pointer-events: none;
+}
+
+.radialCenterLabel { fill: white; }
+.radialNodeLabel { fill: var(--color-text); }
+.radialCenterMeta,
+.radialNodeMeta,
+.radialGroupMeta {
+  font-size: 7px;
+  font-weight: 700;
+  pointer-events: none;
+}
+.radialCenterMeta { fill: rgba(255,255,255,0.78); }
+.radialNodeMeta { fill: var(--color-text-muted); }
+
+.radialGroupNode {
+  fill: #fff7ed;
+  stroke: var(--network-group);
+  stroke-width: 1.5;
+}
+.radialGroupLabel { fill: #78350f; }
+.radialGroupMeta { fill: #a16207; }
+
+.seriesView { display: grid; gap: 14px; }
+
+.seriesIntro {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: var(--color-bg-input);
+  color: var(--color-text-sub);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.seriesSection {
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.seriesSectionHead,
+.detailSectionHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.seriesSectionHead h3,
+.detailSectionHead h3 { margin: 2px 0 0; font-size: 14px; }
+.seriesSectionHead > span,
+.detailSectionHead > span { color: var(--color-text-muted); font-size: 10px; font-weight: 800; }
+
+.seriesKicker,
+.detailKicker {
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.seriesRows { display: grid; gap: 8px; margin-top: 12px; }
+.seriesRow { display: grid; gap: 5px; transition: opacity 160ms ease; }
+.seriesRowDim { opacity: 0.2; }
+
+.seriesCompany,
+.seriesRelation {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.seriesCompany {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 10px;
+}
+
+.seriesDepth {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 22px;
+  border-radius: 7px;
+  background: var(--color-accent-sub);
+  color: var(--color-accent);
+  font-size: 9px;
+  font-weight: 900;
+}
+
+.warningBadge {
+  margin-left: auto;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: #fff7ed;
+  color: #c2410c;
+  font-size: 9px;
+  font-weight: 900;
+}
+
+.seriesRelation {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 10px;
+  color: var(--color-text-muted);
+  font-size: 10px;
+}
+.seriesRelation span { color: var(--color-text-sub); font-weight: 800; }
+.seriesRelationActive { border-color: var(--color-accent); background: var(--color-accent-sub); }
+
+.seriesCenter {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  padding: 15px;
+  border-radius: 14px;
+  background: var(--color-accent-sub);
+  border: 2px solid var(--color-accent);
+}
+.seriesCenter span { font-size: 9px; color: var(--color-accent); font-weight: 900; }
+.seriesCenter strong { font-size: 17px; }
+.seriesCenter small { color: var(--color-text-muted); }
+
+.empty {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.tableScroll {
+  width: 100%;
+  overflow: auto;
+}
+
+.table {
+  width: 100%;
+  min-width: 900px;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 11px;
+}
+
+.table caption {
+  padding: 0 0 10px;
+  text-align: left;
+  color: var(--color-text-muted);
+}
+
+.table th,
+.table td {
+  padding: 10px 9px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-bg-card);
+  color: var(--color-text-muted);
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.sortable { cursor: pointer; }
+.table tbody tr { cursor: pointer; transition: background 120ms ease; }
+.table tbody tr:hover { background: var(--color-bg-input); }
+.tableRowSelected { background: var(--color-accent-sub) !important; }
+
+.tableCompanyButton {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--color-accent);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+.tableRelation { font-weight: 800; }
+.tableSource { max-width: 220px; color: var(--color-text-sub); }
+
+.detailSection {
+  display: grid;
+  gap: 10px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.detailSection:first-child { padding-top: 0; }
+.detailSection:last-child { border-bottom: 0; padding-bottom: 0; }
+.detailSection h2 { margin: 2px 0 0; font-size: 18px; }
+
+.badges { display: flex; gap: 5px; flex-wrap: wrap; }
+.badges span {
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: var(--color-bg-input);
+  color: var(--color-text-sub);
+  font-size: 9px;
+  font-weight: 800;
+}
+
+.relationDirection {
+  display: grid;
+  grid-template-columns: minmax(0,1fr) auto minmax(0,1fr);
+  gap: 6px;
+  align-items: center;
+}
+.relationDirection button {
+  border: 1px solid var(--color-border);
+  border-radius: 9px;
+  padding: 7px;
+  background: var(--color-bg-card);
+  color: var(--color-accent);
+  font: inherit;
+  font-size: 10px;
+  font-weight: 800;
+  cursor: pointer;
+}
+.relationDirection span { color: var(--color-text-muted); }
+.relationTitle { font-size: 14px; }
+
+.detailList { display: grid; gap: 6px; margin: 0; }
+.detailList div { display: grid; grid-template-columns: 76px 1fr; gap: 8px; }
+.detailList dt { color: var(--color-text-muted); font-size: 9px; font-weight: 800; }
+.detailList dd { margin: 0; font-size: 10px; color: var(--color-text-sub); overflow-wrap: anywhere; }
+.detailNote { margin: 0; color: var(--color-text-sub); font-size: 11px; line-height: 1.7; }
+.sourceLink { color: var(--color-accent); text-decoration: none; font-size: 11px; font-weight: 800; overflow-wrap: anywhere; }
+
+.detailRelations,
+.groupList { display: grid; gap: 7px; }
+
+.detailRelationButton {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 9px;
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+.detailRelationButton span { font-size: 10px; color: var(--color-text-sub); }
+.detailRelationButton strong { font-size: 11px; }
+.detailRelationButton small { color: var(--color-text-muted); font-size: 9px; }
+
+.groupList article {
+  display: grid;
+  gap: 3px;
+  padding: 9px;
+  border: 1px solid #fed7aa;
+  border-radius: 10px;
+  background: #fff7ed;
+}
+.groupList strong { font-size: 11px; color: #7c2d12; }
+.groupList span,
+.groupList small { font-size: 9px; color: #9a3412; }
+.groupList a { color: #c2410c; text-decoration: none; font-size: 9px; font-weight: 800; }
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.note {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 10px;
+  line-height: 1.7;
+}
+
+@keyframes viewIn {
+  from { opacity: 0; transform: translateY(3px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse {
+  0% { opacity: 0.8; transform: scale(0.75); }
+  75%, 100% { opacity: 0; transform: scale(1.35); }
+}
+
+@media (max-width: 980px) {
+  .workspace { grid-template-columns: 1fr; }
+  .detailPanel { position: static; max-height: none; }
+}
+
+@media (max-width: 720px) {
+  .page { padding: 18px 10px calc(60px + var(--bottom-nav-space)); }
+  .hero { padding: 16px; }
+  .statRow { grid-template-columns: repeat(2, minmax(0,1fr)); }
+  .toolbar { top: 4px; }
+  .segmentButton { gap: 3px; font-size: 10px; }
+  .controlRow { align-items: stretch; }
+  .companySelect { width: 100%; }
+  .search { width: 100%; }
+  .canvas { min-height: 430px; padding: 9px; }
+  .svgWrap, .svg { min-height: 430px; }
+  .seriesRelation { display: grid; }
 }

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -1,137 +1,30 @@
 "use client";
 
-import { useMemo, useState } from "react";
 import Link from "next/link";
-import { buildReachableNetwork } from "./graph";
+import { useMemo, useState } from "react";
 import styles from "./CompanyNetwork.module.css";
-import type {
-  CompanyGroupMembership,
-  CompanyNetworkLoadResult,
-  CompanyRelationship,
-  RelationCategory,
-} from "./types";
+import { CATEGORY_LABEL, VIEWS, type CompanyNetworkViewMode } from "./presentation";
+import type { CompanyNetworkLoadResult, RelationCategory } from "./types";
+import DetailPanel from "./views/DetailPanel";
+import HierarchyView from "./views/HierarchyView";
+import NetworkView from "./views/NetworkView";
+import RadialView from "./views/RadialView";
+import TableView from "./views/TableView";
 
-const CATEGORY_LABELS: Record<RelationCategory, string> = {
-  capital: "資本",
-  control: "支配",
-  historical: "歴史",
-};
+const ALL_CATEGORIES: readonly RelationCategory[] = ["capital", "control", "historical"];
 
-const RELATION_LABELS: Record<string, string> = {
-  equity_ownership: "出資",
-  parent_of: "親会社",
-  controls: "支配",
-  equity_method_investment: "持分法",
-  spun_off: "分社",
-  predecessor_of: "前身",
-  merged_into: "統合",
-};
-
-function shortName(name: string, max = 18) {
-  return name.length > max ? `${name.slice(0, max - 1)}…` : name;
-}
-
-function relationLabel(relationship: CompanyRelationship) {
-  const base = RELATION_LABELS[relationship.relationType] ?? relationship.relationType;
-  return relationship.ownershipPct === null ? base : `${base} ${relationship.ownershipPct}%`;
-}
-
-function formatAsOf(value: string | null) {
-  return value ? value.slice(0, 10) : "基準日なし";
-}
-
-function toggleCategory(
-  current: RelationCategory[],
-  category: RelationCategory,
-): RelationCategory[] {
-  return current.includes(category)
-    ? current.filter((item) => item !== category)
-    : [...current, category];
-}
-
-type Point = { x: number; y: number };
-
-type EdgeGeometry = {
-  x1: number;
-  y1: number;
-  x2: number;
-  y2: number;
-  midX: number;
-  midY: number;
-};
-
-function edgeGeometry(
-  source: Point,
-  target: Point,
-  sourceRadius: number,
-  targetRadius: number,
-): EdgeGeometry {
-  const dx = target.x - source.x;
-  const dy = target.y - source.y;
-  const distance = Math.hypot(dx, dy);
-  if (distance === 0) {
-    return {
-      x1: source.x,
-      y1: source.y,
-      x2: target.x,
-      y2: target.y,
-      midX: source.x,
-      midY: source.y,
-    };
-  }
-
-  const unitX = dx / distance;
-  const unitY = dy / distance;
-  const x1 = source.x + unitX * (sourceRadius + 5);
-  const y1 = source.y + unitY * (sourceRadius + 5);
-  const x2 = target.x - unitX * (targetRadius + 8);
-  const y2 = target.y - unitY * (targetRadius + 8);
-  return {
-    x1,
-    y1,
-    x2,
-    y2,
-    midX: (x1 + x2) / 2,
-    midY: (y1 + y2) / 2,
-  };
-}
-
-function companyPositions(depthByCompany: Map<string, number>): Map<string, Point> {
-  const positions = new Map<string, Point>();
-  const center = { x: 450, y: 350 };
-  const byDepth = new Map<number, string[]>();
-
-  for (const [companyId, depth] of depthByCompany) {
-    const bucket = byDepth.get(depth) ?? [];
-    bucket.push(companyId);
-    byDepth.set(depth, bucket);
-  }
-
-  for (const [depth, ids] of byDepth) {
-    if (depth === 0) {
-      positions.set(ids[0], center);
-      continue;
-    }
-    const radius = depth === 1 ? 180 : 305;
-    ids.forEach((companyId, index) => {
-      const angle = -Math.PI / 2 + (Math.PI * 2 * index) / Math.max(ids.length, 1);
-      positions.set(companyId, {
-        x: center.x + Math.cos(angle) * radius,
-        y: center.y + Math.sin(angle) * radius,
-      });
-    });
-  }
-  return positions;
-}
-
-function groupPositions(memberships: CompanyGroupMembership[]): Map<string, Point> {
-  const groups = [...new Map(memberships.map((membership) => [membership.groupId, membership])).values()];
-  const positions = new Map<string, Point>();
-  groups.forEach((group, index) => {
-    const y = groups.length === 1 ? 350 : 110 + (500 * index) / Math.max(groups.length - 1, 1);
-    positions.set(group.groupId, { x: 965, y });
-  });
-  return positions;
+function StateScreen({ title, body }: { title: string; body: string }) {
+  return (
+    <main className={styles.page}>
+      <nav className={styles.topNav}>
+        <Link href="/premium" className={styles.topNavLink}>← Premium ホーム</Link>
+      </nav>
+      <section className={styles.state}>
+        <h1>{title}</h1>
+        <p>{body}</p>
+      </section>
+    </main>
+  );
 }
 
 export default function CompanyNetworkClient({ result }: { result: CompanyNetworkLoadResult }) {
@@ -139,342 +32,243 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const connectedCompanyIds = useMemo(() => {
     if (!data) return new Set<string>();
     return new Set([
-      ...data.relationships.flatMap((relationship) => [
-        relationship.sourceCompanyId,
-        relationship.targetCompanyId,
-      ]),
+      ...data.relationships.flatMap((relationship) => [relationship.sourceCompanyId, relationship.targetCompanyId]),
       ...data.memberships.map((membership) => membership.companyId),
     ]);
   }, [data]);
-  const connectedCompanies = useMemo(
-    () => data?.companies.filter((company) => connectedCompanyIds.has(company.id)) ?? [],
-    [connectedCompanyIds, data],
-  );
-  const selectableCompanies = connectedCompanies.length > 0 ? connectedCompanies : (data?.companies ?? []);
+  const selectableCompanies = useMemo(() => {
+    if (!data) return [];
+    const connected = data.companies.filter((company) => connectedCompanyIds.has(company.id));
+    return connected.length > 0 ? connected : data.companies;
+  }, [connectedCompanyIds, data]);
   const defaultCompanyId =
     selectableCompanies.find((company) => company.name === "トヨタ自動車")?.id ??
     selectableCompanies[0]?.id ??
     "";
 
+  const [view, setView] = useState<CompanyNetworkViewMode>("network");
   const [selectedCompanyId, setSelectedCompanyId] = useState(defaultCompanyId);
+  const [selectedRelationId, setSelectedRelationId] = useState<string | null>(null);
   const [hops, setHops] = useState<1 | 2>(2);
-  const [categories, setCategories] = useState<RelationCategory[]>([
-    "capital",
-    "control",
-    "historical",
-  ]);
+  const [categories, setCategories] = useState<Set<RelationCategory>>(() => new Set(ALL_CATEGORIES));
   const [verifiedOnly, setVerifiedOnly] = useState(true);
   const [showGroups, setShowGroups] = useState(true);
-  const [selectedRelationId, setSelectedRelationId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
-  const network = useMemo(() => {
-    if (!data || !selectedCompanyId) {
-      return { relationships: [], depthByCompany: new Map<string, number>() };
-    }
-    return buildReachableNetwork({
-      selectedCompanyId,
-      relationships: data.relationships,
-      hops,
-      categories,
-      verifiedOnly,
-    });
-  }, [categories, data, hops, selectedCompanyId, verifiedOnly]);
+  const relationships = useMemo(() => {
+    if (!data) return [];
+    return data.relationships.filter(
+      (relationship) =>
+        categories.has(relationship.relationCategory) &&
+        (!verifiedOnly || relationship.verificationStatus === "verified"),
+    );
+  }, [categories, data, verifiedOnly]);
 
-  const visibleCompanyIds = useMemo(
-    () => new Set(network.depthByCompany.keys()),
-    [network.depthByCompany],
-  );
-  const visibleMemberships = useMemo(() => {
+  const memberships = useMemo(() => {
     if (!data || !showGroups) return [];
     return data.memberships.filter(
-      (membership) =>
-        visibleCompanyIds.has(membership.companyId) &&
-        (!verifiedOnly || membership.verificationStatus === "verified"),
+      (membership) => !verifiedOnly || membership.verificationStatus === "verified",
     );
-  }, [data, showGroups, verifiedOnly, visibleCompanyIds]);
+  }, [data, showGroups, verifiedOnly]);
 
-  const positions = useMemo(() => companyPositions(network.depthByCompany), [network.depthByCompany]);
-  const groupNodePositions = useMemo(() => groupPositions(visibleMemberships), [visibleMemberships]);
-  const companyById = useMemo(
-    () => new Map(data?.companies.map((company) => [company.id, company]) ?? []),
-    [data],
-  );
-  const selectedRelation =
-    network.relationships.find((relationship) => relationship.relationId === selectedRelationId) ??
-    network.relationships[0] ??
-    null;
+  const selectedCompany = data?.companies.find((company) => company.id === selectedCompanyId) ?? null;
+  const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
+  const currentView = VIEWS.find((item) => item.mode === view) ?? VIEWS[0];
+  const viewIndex = VIEWS.findIndex((item) => item.mode === view);
 
-  if (!data || result.status === "error" || result.status === "unconfigured" || result.status === "unauthenticated") {
-    return (
-      <main className={styles.page}>
-        <section className={styles.shell}>
-          <Link href="/premium" className={styles.backLink}>← Premium</Link>
-          <h1>企業関係マップ</h1>
-          <p className={styles.message}>{result.message}</p>
-        </section>
-      </main>
-    );
+  const selectCompany = (companyId: string) => {
+    setSelectedCompanyId(companyId);
+    setSelectedRelationId(null);
+  };
+
+  const toggleCategory = (category: RelationCategory) => {
+    setCategories((current) => {
+      const next = new Set(current);
+      if (next.has(category)) next.delete(category);
+      else next.add(category);
+      return next;
+    });
+    setSelectedRelationId(null);
+  };
+
+  if (result.status === "unconfigured") {
+    return <StateScreen title="Supabase 連携が未設定です" body={result.message} />;
+  }
+  if (result.status === "unauthenticated") {
+    return <StateScreen title="Supabase にログインしてください" body={result.message} />;
+  }
+  if (result.status === "error") {
+    return <StateScreen title="企業関係マップを取得できませんでした" body={`${result.message} 0件ではなく取得失敗です。`} />;
+  }
+  if (!data || data.companies.length === 0) {
+    return <StateScreen title="企業関係データがまだありません" body={result.message ?? "企業関係を登録するとここに表示されます。"} />;
   }
 
   return (
     <main className={styles.page}>
-      <section className={styles.shell}>
-        <header className={styles.header}>
+      <nav className={styles.topNav}>
+        <Link href="/premium" className={styles.topNavLink}>← Premium ホーム</Link>
+        <Link href="/premium/industry-map" className={styles.topNavLink}>業界マップ →</Link>
+      </nav>
+
+      <header className={styles.hero}>
+        <div className={styles.heroHead}>
           <div>
-            <Link href="/premium" className={styles.backLink}>← Premium</Link>
-            <div className={styles.eyebrow}>Company relationship graph</div>
-            <h1>企業関係マップ</h1>
-            <p>
-              資本・支配・歴史的関係と企業グループ所属を、根拠付きの事実として分けて確認します。
+            <h1 className={styles.heroTitle}>企業関係マップ</h1>
+            <p className={styles.heroLead}>
+              資本・支配・歴史的関係と企業グループ所属を、4つの表現で切り替えて確認します。閲覧専用です。
             </p>
           </div>
-          <div className={styles.stats}>
-            <span>{data.companies.length} 企業</span>
-            <span>{data.relationships.length} 関係</span>
-            <span>{data.memberships.length} 所属</span>
-          </div>
-        </header>
+          <span className={styles.versionBadge}>company-network v2</span>
+        </div>
+        <div className={styles.statRow}>
+          <div className={styles.stat}><span>企業</span><strong>{data.companies.length}</strong><small>社</small></div>
+          <div className={styles.stat}><span>企業間関係</span><strong>{data.relationships.length}</strong><small>件</small></div>
+          <div className={styles.stat}><span>グループ所属</span><strong>{data.memberships.length}</strong><small>件</small></div>
+          <div className={styles.stat}><span>表示中</span><strong>{relationships.length}</strong><small>関係</small></div>
+        </div>
+      </header>
 
-        {result.status === "empty" ? <p className={styles.message}>{result.message}</p> : null}
-
-        <section className={styles.controls} aria-label="企業関係マップの表示条件">
-          <label className={styles.selectLabel}>
-            中心企業
-            <select
-              value={selectedCompanyId}
-              onChange={(event) => {
-                setSelectedCompanyId(event.target.value);
-                setSelectedRelationId(null);
-              }}
+      <section className={styles.toolbar} aria-label="企業関係マップの表示条件">
+        <div className={styles.segmented} role="tablist" aria-label="表現の切り替え">
+          <span
+            className={styles.segmentedIndicator}
+            style={{
+              left: `calc(3px + (100% - 6px) * ${Math.max(viewIndex, 0)} / ${VIEWS.length})`,
+              width: `calc((100% - 6px) / ${VIEWS.length})`,
+            }}
+            aria-hidden
+          />
+          {VIEWS.map((item) => (
+            <button
+              key={item.mode}
+              type="button"
+              role="tab"
+              aria-selected={item.mode === view}
+              className={`${styles.segmentButton} ${item.mode === view ? styles.segmentButtonActive : ""}`}
+              onClick={() => setView(item.mode)}
+              title={item.question}
             >
-              {selectableCompanies.map((company) => (
-                <option key={company.id} value={company.id}>{company.name}</option>
-              ))}
+              <span aria-hidden>{item.icon}</span>
+              <span>{item.label}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.controlRow}>
+          <label className={styles.companySelect}>
+            <span>中心企業</span>
+            <select value={selectedCompanyId} onChange={(event) => selectCompany(event.target.value)}>
+              {selectableCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
             </select>
           </label>
-
-          <div className={styles.segment} aria-label="探索の深さ">
+          <input
+            className={styles.search}
+            type="search"
+            value={query}
+            placeholder="企業名・関係を検索"
+            aria-label="企業関係を検索"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <div className={styles.hopControl} aria-label="探索の深さ">
             {[1, 2].map((value) => (
-              <button
-                type="button"
-                key={value}
-                className={hops === value ? styles.activeButton : styles.button}
-                onClick={() => setHops(value as 1 | 2)}
-              >
+              <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>
                 {value}-hop
               </button>
             ))}
           </div>
+        </div>
 
-          <div className={styles.checks}>
-            {(Object.keys(CATEGORY_LABELS) as RelationCategory[]).map((category) => (
-              <label key={category}>
-                <input
-                  type="checkbox"
-                  checked={categories.includes(category)}
-                  onChange={() => setCategories((current) => toggleCategory(current, category))}
-                />
-                {CATEGORY_LABELS[category]}
-              </label>
-            ))}
-            <label>
-              <input
-                type="checkbox"
-                checked={verifiedOnly}
-                onChange={(event) => setVerifiedOnly(event.target.checked)}
-              />
-              verifiedのみ
-            </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={showGroups}
-                onChange={(event) => setShowGroups(event.target.checked)}
-              />
-              グループ表示
-            </label>
-          </div>
-        </section>
-
-        <section className={styles.mapPanel}>
-          <div className={styles.legend}>
-            <span><i className={styles.legendCenter} />中心企業</span>
-            <span><i className={styles.legendCompany} />関係企業</span>
-            <span><i className={styles.legendGroup} />企業グループ</span>
-            <span>実線: 企業間 / 破線: 所属</span>
-          </div>
-          <div className={styles.svgScroller}>
-            <svg viewBox="0 0 1100 700" className={styles.graph} role="img" aria-label="企業関係ネットワーク">
-              <defs>
-                <marker id="company-network-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M 0 0 L 10 5 L 0 10 z" className={styles.arrowHead} />
-                </marker>
-              </defs>
-
-              {network.relationships.map((relationship) => {
-                const source = positions.get(relationship.sourceCompanyId);
-                const target = positions.get(relationship.targetCompanyId);
-                if (!source || !target) return null;
-                const sourceRadius = network.depthByCompany.get(relationship.sourceCompanyId) === 0 ? 58 : 50;
-                const targetRadius = network.depthByCompany.get(relationship.targetCompanyId) === 0 ? 58 : 50;
-                const edge = edgeGeometry(source, target, sourceRadius, targetRadius);
-                return (
-                  <g key={relationship.relationId}>
-                    <line
-                      x1={edge.x1}
-                      y1={edge.y1}
-                      x2={edge.x2}
-                      y2={edge.y2}
-                      className={relationship.verificationStatus === "verified" ? styles.edge : styles.proposedEdge}
-                      markerEnd="url(#company-network-arrow)"
-                    />
-                    <text x={edge.midX} y={edge.midY - 8} textAnchor="middle" className={styles.edgeLabel}>
-                      {relationLabel(relationship)}
-                    </text>
-                  </g>
-                );
-              })}
-
-              {visibleMemberships.map((membership) => {
-                const company = positions.get(membership.companyId);
-                const group = groupNodePositions.get(membership.groupId);
-                if (!company || !group) return null;
-                return (
-                  <line
-                    key={membership.membershipId}
-                    x1={company.x}
-                    y1={company.y}
-                    x2={group.x}
-                    y2={group.y}
-                    className={styles.membershipEdge}
-                  />
-                );
-              })}
-
-              {[...network.depthByCompany.entries()].map(([companyId, depth]) => {
-                const company = companyById.get(companyId);
-                const point = positions.get(companyId);
-                if (!company || !point) return null;
-                return (
-                  <g
-                    key={companyId}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`${company.name}を中心にする`}
-                    onClick={() => {
-                      setSelectedCompanyId(companyId);
-                      setSelectedRelationId(null);
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        setSelectedCompanyId(companyId);
-                        setSelectedRelationId(null);
-                      }
-                    }}
-                    className={styles.nodeButton}
-                  >
-                    <circle
-                      cx={point.x}
-                      cy={point.y}
-                      r={depth === 0 ? 58 : 50}
-                      className={depth === 0 ? styles.centerNode : styles.companyNode}
-                    />
-                    <text x={point.x} y={point.y - 2} textAnchor="middle" className={styles.nodeLabel}>
-                      {shortName(company.name, 14)}
-                    </text>
-                    <text x={point.x} y={point.y + 17} textAnchor="middle" className={styles.depthLabel}>
-                      {depth === 0 ? "center" : `${depth}-hop`}
-                    </text>
-                  </g>
-                );
-              })}
-
-              {[...new Map(visibleMemberships.map((membership) => [membership.groupId, membership])).values()].map((membership) => {
-                const point = groupNodePositions.get(membership.groupId);
-                if (!point) return null;
-                return (
-                  <g key={membership.groupId}>
-                    <rect x={point.x - 80} y={point.y - 34} width="160" height="68" rx="18" className={styles.groupNode} />
-                    <text x={point.x} y={point.y - 3} textAnchor="middle" className={styles.groupLabel}>
-                      {shortName(membership.groupName, 15)}
-                    </text>
-                    <text x={point.x} y={point.y + 16} textAnchor="middle" className={styles.groupTypeLabel}>
-                      {membership.groupType}
-                    </text>
-                  </g>
-                );
-              })}
-            </svg>
-          </div>
-        </section>
-
-        <section className={styles.detailsGrid}>
-          <div className={styles.detailCard}>
-            <div className={styles.sectionHeading}>
-              <h2>企業間関係</h2>
-              <span>{network.relationships.length}件</span>
-            </div>
-            {network.relationships.length === 0 ? (
-              <p className={styles.muted}>現在の条件で表示できる企業間関係はありません。</p>
-            ) : (
-              <div className={styles.relationList}>
-                {network.relationships.map((relationship) => (
-                  <button
-                    type="button"
-                    key={relationship.relationId}
-                    className={selectedRelation?.relationId === relationship.relationId ? styles.relationActive : styles.relationItem}
-                    onClick={() => setSelectedRelationId(relationship.relationId)}
-                  >
-                    <strong>{relationship.sourceCompanyName} → {relationship.targetCompanyName}</strong>
-                    <span>{CATEGORY_LABELS[relationship.relationCategory]} / {relationLabel(relationship)}</span>
-                    <span>{relationship.verificationStatus} · {relationship.confidence}</span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className={styles.detailCard}>
-            <div className={styles.sectionHeading}><h2>根拠</h2></div>
-            {selectedRelation ? (
-              <div className={styles.evidence}>
-                <div className={styles.badges}>
-                  <span>{selectedRelation.verificationStatus}</span>
-                  <span>{selectedRelation.confidence}</span>
-                  <span>{formatAsOf(selectedRelation.sourceAsOf)}</span>
-                </div>
-                <h3>{selectedRelation.sourceCompanyName} → {selectedRelation.targetCompanyName}</h3>
-                <p>{selectedRelation.note || "補足なし"}</p>
-                {selectedRelation.sourceUrl ? (
-                  <a href={selectedRelation.sourceUrl} target="_blank" rel="noreferrer">
-                    {selectedRelation.sourceTitle ?? "根拠ソースを開く"} ↗
-                  </a>
-                ) : (
-                  <span className={styles.muted}>URL付きの根拠は登録されていません。</span>
-                )}
-              </div>
-            ) : (
-              <p className={styles.muted}>企業間関係を選ぶと、根拠と基準日を表示します。</p>
-            )}
-
-            {visibleMemberships.length > 0 ? (
-              <div className={styles.membershipList}>
-                <h3>表示中のグループ所属</h3>
-                {visibleMemberships.map((membership) => (
-                  <div key={membership.membershipId}>
-                    <strong>{membership.companyName} → {membership.groupName}</strong>
-                    <span>{membership.membershipBasis} · {membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</span>
-                    {membership.sourceUrl ? (
-                      <a href={membership.sourceUrl} target="_blank" rel="noreferrer">根拠 ↗</a>
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        </section>
+        <div className={styles.filterRow}>
+          {ALL_CATEGORIES.map((category) => (
+            <button
+              key={category}
+              type="button"
+              className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`}
+              aria-pressed={categories.has(category)}
+              onClick={() => toggleCategory(category)}
+            >
+              <span className={styles.toggleDot} />
+              {CATEGORY_LABEL[category]}
+            </button>
+          ))}
+          <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>
+            verifiedのみ
+          </button>
+          <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>
+            グループ表示
+          </button>
+        </div>
       </section>
+
+      <p className={styles.hint}>{currentView.question}</p>
+
+      <div className={styles.workspace}>
+        <section className={styles.canvas}>
+          {relationships.length === 0 && memberships.length === 0 ? (
+            <p className={styles.empty}>現在のフィルタ条件では表示できる関係がありません。</p>
+          ) : null}
+          {view === "network" ? (
+            <NetworkView
+              companies={data.companies}
+              relationships={relationships}
+              memberships={memberships}
+              selectedCompanyId={selectedCompanyId}
+              selectedRelationId={selectedRelationId}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+          {view === "radial" ? (
+            <RadialView
+              companies={data.companies}
+              relationships={relationships}
+              memberships={memberships}
+              selectedCompanyId={selectedCompanyId}
+              selectedRelationId={selectedRelationId}
+              hops={hops}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+          {view === "hierarchy" ? (
+            <HierarchyView
+              companies={data.companies}
+              relationships={relationships}
+              selectedCompanyId={selectedCompanyId}
+              selectedRelationId={selectedRelationId}
+              hops={hops}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+          {view === "table" ? (
+            <TableView
+              relationships={relationships}
+              selectedRelationId={selectedRelationId}
+              query={query}
+              onSelectRelation={setSelectedRelationId}
+              onSelectCompany={selectCompany}
+            />
+          ) : null}
+        </section>
+
+        <DetailPanel
+          company={selectedCompany}
+          relationships={relationships}
+          memberships={memberships}
+          selectedRelation={selectedRelation}
+          onSelectCompany={selectCompany}
+          onSelectRelation={setSelectedRelationId}
+        />
+      </div>
+
+      <p className={styles.note}>
+        企業グループ所属は親子・支配関係とは別エッジです。系列ビューには混ぜません。関係の表示は保存済み事実の閲覧であり、業績連動や投資判断を自動推論しません。
+      </p>
     </main>
   );
 }

--- a/app/premium/company-network/graph-layout.test.ts
+++ b/app/premium/company-network/graph-layout.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildSeriesRows, seedSimNodes } from "./graph-layout";
+import type { CompanyRelationship } from "./types";
+
+function relationship(
+  relationId: string,
+  sourceCompanyId: string,
+  targetCompanyId: string,
+  overrides: Partial<CompanyRelationship> = {},
+): CompanyRelationship {
+  return {
+    relationId,
+    sourceCompanyId,
+    sourceCompanyName: sourceCompanyId,
+    targetCompanyId,
+    targetCompanyName: targetCompanyId,
+    relationCategory: "capital",
+    relationType: "equity_ownership",
+    ownershipPct: null,
+    votingRightsPct: null,
+    isConsolidated: null,
+    note: "",
+    verificationStatus: "verified",
+    confidence: "high",
+    sourceTitle: null,
+    sourceUrl: null,
+    sourceType: null,
+    sourceAsOf: null,
+    checkedAt: null,
+    ...overrides,
+  };
+}
+
+describe("company-network graph layout", () => {
+  it("force初期配置は同じ入力から決定的に作られる", () => {
+    const nodes = [
+      { id: "a", label: "A", kind: "company" as const },
+      { id: "b", label: "B", kind: "company" as const },
+      { id: "g", label: "Group", kind: "group" as const },
+    ];
+    expect(seedSimNodes(nodes, 200)).toEqual(seedSimNodes(nodes, 200));
+  });
+
+  it("系列ビューはcanonical directionを保って上位と下位を分ける", () => {
+    const result = buildSeriesRows({
+      selectedCompanyId: "woven",
+      selectedCompanyName: "Woven",
+      maxDepth: 2,
+      relationships: [
+        relationship("toyota-woven", "toyota", "woven", { ownershipPct: 100 }),
+        relationship("woven-child", "woven", "child", { relationType: "controls", relationCategory: "control" }),
+        relationship("history", "old", "woven", { relationType: "predecessor_of", relationCategory: "historical" }),
+      ],
+    });
+
+    expect(result.upstream.map((row) => row.companyId)).toEqual(["toyota"]);
+    expect(result.downstream.map((row) => row.companyId)).toEqual(["child"]);
+    expect(result.upstream.some((row) => row.companyId === "old")).toBe(false);
+  });
+});

--- a/app/premium/company-network/graph-layout.ts
+++ b/app/premium/company-network/graph-layout.ts
@@ -1,0 +1,197 @@
+import type { CompanyNetworkCompany, CompanyRelationship } from "./types";
+
+export type VisualNode = {
+  id: string;
+  label: string;
+  kind: "company" | "group";
+  company?: CompanyNetworkCompany;
+  groupId?: string;
+  groupType?: string;
+};
+
+export type SimNode = VisualNode & {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+};
+
+export type SimLink = {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  kind: "relationship" | "membership";
+};
+
+export type ForceOptions = {
+  repulsion: number;
+  springStrength: number;
+  springLength: number;
+  centering: number;
+  damping: number;
+};
+
+export const DEFAULT_FORCE_OPTIONS: ForceOptions = {
+  repulsion: 9800,
+  springStrength: 0.035,
+  springLength: 112,
+  centering: 0.012,
+  damping: 0.86,
+};
+
+/** 乱数を使わず、同じ入力から同じ初期配置を作る。 */
+export function seedSimNodes(nodes: VisualNode[], spread: number): SimNode[] {
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  return nodes.map((node, index) => {
+    const angle = index * goldenAngle;
+    const radius = spread * Math.sqrt((index + 1) / Math.max(nodes.length, 1));
+    return {
+      ...node,
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+      vx: 0,
+      vy: 0,
+    };
+  });
+}
+
+export function stepForce(
+  nodes: SimNode[],
+  links: SimLink[],
+  options: ForceOptions = DEFAULT_FORCE_OPTIONS,
+): void {
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+
+  for (let i = 0; i < nodes.length; i += 1) {
+    for (let j = i + 1; j < nodes.length; j += 1) {
+      const a = nodes[i];
+      const b = nodes[j];
+      let dx = b.x - a.x;
+      let dy = b.y - a.y;
+      let distanceSq = dx * dx + dy * dy;
+      if (distanceSq < 1) {
+        dx = (i % 2 === 0 ? 1 : -1) * 0.5;
+        dy = (j % 2 === 0 ? 1 : -1) * 0.5;
+        distanceSq = dx * dx + dy * dy;
+      }
+      const distance = Math.sqrt(distanceSq);
+      const force = options.repulsion / distanceSq;
+      const fx = (dx / distance) * force;
+      const fy = (dy / distance) * force;
+      a.vx -= fx;
+      a.vy -= fy;
+      b.vx += fx;
+      b.vy += fy;
+    }
+  }
+
+  for (const link of links) {
+    const source = byId.get(link.sourceId);
+    const target = byId.get(link.targetId);
+    if (!source || !target) continue;
+    const dx = target.x - source.x;
+    const dy = target.y - source.y;
+    const distance = Math.hypot(dx, dy) || 1;
+    const length = link.kind === "membership" ? options.springLength * 1.25 : options.springLength;
+    const force = (distance - length) * options.springStrength;
+    const fx = (dx / distance) * force;
+    const fy = (dy / distance) * force;
+    source.vx += fx;
+    source.vy += fy;
+    target.vx -= fx;
+    target.vy -= fy;
+  }
+
+  for (const node of nodes) {
+    node.vx -= node.x * options.centering;
+    node.vy -= node.y * options.centering;
+    node.vx *= options.damping;
+    node.vy *= options.damping;
+    node.x += node.vx;
+    node.y += node.vy;
+  }
+}
+
+export function simExtent(nodes: SimNode[], minimum: number): number {
+  return nodes.reduce(
+    (extent, node) => Math.max(extent, Math.abs(node.x), Math.abs(node.y)),
+    minimum,
+  );
+}
+
+export type SeriesRow = {
+  companyId: string;
+  companyName: string;
+  depth: number;
+  direction: "upstream" | "center" | "downstream";
+  relationship: CompanyRelationship | null;
+  cycle: boolean;
+};
+
+const SERIES_TYPES = new Set(["equity_ownership", "parent_of", "controls", "equity_method_investment"]);
+
+/**
+ * 選択企業から「上位」と「下位」を別方向へたどる。
+ * 企業グループ所属や歴史的関係は系列ツリーへ混ぜない。
+ */
+export function buildSeriesRows({
+  selectedCompanyId,
+  selectedCompanyName,
+  relationships,
+  maxDepth,
+}: {
+  selectedCompanyId: string;
+  selectedCompanyName: string;
+  relationships: CompanyRelationship[];
+  maxDepth: 1 | 2;
+}): { upstream: SeriesRow[]; center: SeriesRow; downstream: SeriesRow[] } {
+  const eligible = relationships.filter(
+    (relationship) =>
+      SERIES_TYPES.has(relationship.relationType) &&
+      relationship.relationCategory !== "historical",
+  );
+
+  const walk = (direction: "upstream" | "downstream"): SeriesRow[] => {
+    const rows: SeriesRow[] = [];
+    let frontier = new Set<string>([selectedCompanyId]);
+    const visited = new Set<string>([selectedCompanyId]);
+
+    for (let depth = 1; depth <= maxDepth && frontier.size > 0; depth += 1) {
+      const next = new Set<string>();
+      for (const relationship of eligible) {
+        const matches = direction === "upstream"
+          ? frontier.has(relationship.targetCompanyId)
+          : frontier.has(relationship.sourceCompanyId);
+        if (!matches) continue;
+
+        const companyId = direction === "upstream"
+          ? relationship.sourceCompanyId
+          : relationship.targetCompanyId;
+        const companyName = direction === "upstream"
+          ? relationship.sourceCompanyName
+          : relationship.targetCompanyName;
+        const cycle = visited.has(companyId);
+        rows.push({ companyId, companyName, depth, direction, relationship, cycle });
+        if (!cycle) {
+          visited.add(companyId);
+          next.add(companyId);
+        }
+      }
+      frontier = next;
+    }
+    return rows;
+  };
+
+  return {
+    upstream: walk("upstream"),
+    center: {
+      companyId: selectedCompanyId,
+      companyName: selectedCompanyName,
+      depth: 0,
+      direction: "center",
+      relationship: null,
+      cycle: false,
+    },
+    downstream: walk("downstream"),
+  };
+}

--- a/app/premium/company-network/presentation.ts
+++ b/app/premium/company-network/presentation.ts
@@ -1,0 +1,80 @@
+import type { RelationCategory } from "./types";
+
+export type CompanyNetworkViewMode = "network" | "radial" | "hierarchy" | "table";
+
+export const CATEGORY_LABEL: Record<RelationCategory, string> = {
+  capital: "資本",
+  control: "支配",
+  historical: "歴史",
+};
+
+export const CATEGORY_COLOR: Record<RelationCategory, string> = {
+  capital: "#2563eb",
+  control: "#7c3aed",
+  historical: "#64748b",
+};
+
+export const RELATION_LABEL: Record<string, string> = {
+  equity_ownership: "出資",
+  parent_of: "親会社",
+  controls: "支配",
+  equity_method_investment: "持分法",
+  spun_off: "分社",
+  predecessor_of: "前身",
+  merged_into: "統合",
+};
+
+export const GROUP_TYPE_LABEL: Record<string, string> = {
+  corporate_group: "企業グループ",
+  capital_group: "資本グループ",
+  keiretsu: "系列",
+  zaibatsu_lineage: "財閥系譜",
+  historical_group: "歴史的グループ",
+  strategic_alliance: "戦略連合",
+  presidents_club: "社長会",
+};
+
+export const VIEWS: readonly {
+  mode: CompanyNetworkViewMode;
+  icon: string;
+  label: string;
+  question: string;
+}[] = [
+  {
+    mode: "network",
+    icon: "🕸",
+    label: "関係",
+    question: "企業・企業グループのつながりを全体ネットワークで見る。",
+  },
+  {
+    mode: "radial",
+    icon: "🌐",
+    label: "放射",
+    question: "選択した企業を中心に、1-hop / 2-hopの広がりを見る。",
+  },
+  {
+    mode: "hierarchy",
+    icon: "🗂",
+    label: "系列",
+    question: "親会社・支配・出資の向きを保ったまま上位 / 下位をたどる。",
+  },
+  {
+    mode: "table",
+    icon: "☰",
+    label: "表",
+    question: "関係種別・比率・検証状態・根拠日を正確に確認する。",
+  },
+];
+
+export function relationLabel(type: string, ownershipPct: number | null): string {
+  const base = RELATION_LABEL[type] ?? type;
+  return ownershipPct === null ? base : `${base} ${ownershipPct}%`;
+}
+
+export function groupTypeLabel(value: string): string {
+  return GROUP_TYPE_LABEL[value] ?? value;
+}
+
+export function formatAsOf(value: string | null): string {
+  return value ? value.slice(0, 10) : "基準日なし";
+}

--- a/app/premium/company-network/views/DetailPanel.tsx
+++ b/app/premium/company-network/views/DetailPanel.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import styles from "../CompanyNetwork.module.css";
+import { CATEGORY_LABEL, formatAsOf, groupTypeLabel, relationLabel } from "../presentation";
+import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship } from "../types";
+
+type Props = {
+  company: CompanyNetworkCompany | null;
+  relationships: CompanyRelationship[];
+  memberships: CompanyGroupMembership[];
+  selectedRelation: CompanyRelationship | null;
+  onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+};
+
+export default function DetailPanel({
+  company,
+  relationships,
+  memberships,
+  selectedRelation,
+  onSelectCompany,
+  onSelectRelation,
+}: Props) {
+  if (!company) {
+    return (
+      <aside className={styles.detailPanel}>
+        <p className={styles.empty}>企業を選択すると詳細を表示します。</p>
+      </aside>
+    );
+  }
+
+  const related = relationships.filter(
+    (relationship) =>
+      relationship.sourceCompanyId === company.id || relationship.targetCompanyId === company.id,
+  );
+  const companyMemberships = memberships.filter((membership) => membership.companyId === company.id);
+
+  return (
+    <aside className={styles.detailPanel}>
+      <section className={styles.detailSection}>
+        <span className={styles.detailKicker}>SELECTED COMPANY</span>
+        <h2>{company.name}</h2>
+        <div className={styles.badges}>
+          <span>{company.listingStatus || "上場区分未確認"}</span>
+          {company.countryCode ? <span>{company.countryCode}</span> : null}
+          <span>{company.status}</span>
+        </div>
+      </section>
+
+      {selectedRelation ? (
+        <section className={styles.detailSection}>
+          <div className={styles.detailSectionHead}>
+            <h3>選択中の企業関係</h3>
+            <span>{CATEGORY_LABEL[selectedRelation.relationCategory]}</span>
+          </div>
+          <div className={styles.relationDirection}>
+            <button type="button" onClick={() => onSelectCompany(selectedRelation.sourceCompanyId)}>{selectedRelation.sourceCompanyName}</button>
+            <span>→</span>
+            <button type="button" onClick={() => onSelectCompany(selectedRelation.targetCompanyId)}>{selectedRelation.targetCompanyName}</button>
+          </div>
+          <strong className={styles.relationTitle}>
+            {relationLabel(selectedRelation.relationType, selectedRelation.ownershipPct)}
+          </strong>
+          <div className={styles.badges}>
+            <span>{selectedRelation.verificationStatus}</span>
+            <span>confidence {selectedRelation.confidence}</span>
+            {selectedRelation.isConsolidated !== null ? <span>{selectedRelation.isConsolidated ? "連結" : "非連結"}</span> : null}
+          </div>
+          <dl className={styles.detailList}>
+            <div><dt>議決権</dt><dd>{selectedRelation.votingRightsPct === null ? "—" : `${selectedRelation.votingRightsPct}%`}</dd></div>
+            <div><dt>基準日</dt><dd>{formatAsOf(selectedRelation.sourceAsOf)}</dd></div>
+            <div><dt>確認日</dt><dd>{formatAsOf(selectedRelation.checkedAt)}</dd></div>
+            <div><dt>source type</dt><dd>{selectedRelation.sourceType ?? "—"}</dd></div>
+          </dl>
+          {selectedRelation.note ? <p className={styles.detailNote}>{selectedRelation.note}</p> : null}
+          {selectedRelation.sourceUrl ? (
+            <a className={styles.sourceLink} href={selectedRelation.sourceUrl} target="_blank" rel="noreferrer">
+              {selectedRelation.sourceTitle ?? "根拠を開く"} ↗
+            </a>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className={styles.detailSection}>
+        <div className={styles.detailSectionHead}>
+          <h3>接続する企業関係</h3>
+          <span>{related.length}件</span>
+        </div>
+        {related.length > 0 ? (
+          <div className={styles.detailRelations}>
+            {related.map((relationship) => {
+              const outbound = relationship.sourceCompanyId === company.id;
+              const otherId = outbound ? relationship.targetCompanyId : relationship.sourceCompanyId;
+              const otherName = outbound ? relationship.targetCompanyName : relationship.sourceCompanyName;
+              return (
+                <button
+                  type="button"
+                  key={relationship.relationId}
+                  className={styles.detailRelationButton}
+                  onClick={() => onSelectRelation(relationship.relationId)}
+                >
+                  <span>{outbound ? "→" : "←"} {otherName}</span>
+                  <strong>{relationLabel(relationship.relationType, relationship.ownershipPct)}</strong>
+                  <small>{relationship.verificationStatus} · {formatAsOf(relationship.sourceAsOf)}</small>
+                  <span className={styles.srOnly} onClick={() => onSelectCompany(otherId)}>{otherId}</span>
+                </button>
+              );
+            })}
+          </div>
+        ) : <p className={styles.empty}>現在の条件で接続する企業関係はありません。</p>}
+      </section>
+
+      <section className={styles.detailSection}>
+        <div className={styles.detailSectionHead}>
+          <h3>企業グループ所属</h3>
+          <span>{companyMemberships.length}件</span>
+        </div>
+        {companyMemberships.length > 0 ? (
+          <div className={styles.groupList}>
+            {companyMemberships.map((membership) => (
+              <article key={membership.membershipId}>
+                <strong>{membership.groupName}</strong>
+                <span>{groupTypeLabel(membership.groupType)} / {membership.membershipBasis}</span>
+                <small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>
+                {membership.sourceUrl ? <a href={membership.sourceUrl} target="_blank" rel="noreferrer">根拠 ↗</a> : null}
+              </article>
+            ))}
+          </div>
+        ) : <p className={styles.empty}>現在の条件で確認できるグループ所属はありません。</p>}
+      </section>
+    </aside>
+  );
+}

--- a/app/premium/company-network/views/HierarchyView.tsx
+++ b/app/premium/company-network/views/HierarchyView.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo } from "react";
+import styles from "../CompanyNetwork.module.css";
+import { buildSeriesRows, type SeriesRow } from "../graph-layout";
+import { relationLabel } from "../presentation";
+import type { CompanyNetworkCompany, CompanyRelationship } from "../types";
+
+type Props = {
+  companies: CompanyNetworkCompany[];
+  relationships: CompanyRelationship[];
+  selectedCompanyId: string;
+  selectedRelationId: string | null;
+  hops: 1 | 2;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+};
+
+function Row({
+  row,
+  selectedRelationId,
+  query,
+  onSelectCompany,
+  onSelectRelation,
+}: {
+  row: SeriesRow;
+  selectedRelationId: string | null;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+}) {
+  const normalized = query.trim().toLocaleLowerCase("ja");
+  const dimmed = normalized.length > 0 && !row.companyName.toLocaleLowerCase("ja").includes(normalized);
+  const relationship = row.relationship;
+  return (
+    <div
+      className={`${styles.seriesRow} ${dimmed ? styles.seriesRowDim : ""}`}
+      style={{ marginLeft: Math.min(row.depth - 1, 3) * 18 }}
+    >
+      <button type="button" className={styles.seriesCompany} onClick={() => onSelectCompany(row.companyId)}>
+        <span className={styles.seriesDepth}>L{row.depth}</span>
+        <strong>{row.companyName}</strong>
+        {row.cycle ? <span className={styles.warningBadge}>循環</span> : null}
+      </button>
+      {relationship ? (
+        <button
+          type="button"
+          className={`${styles.seriesRelation} ${selectedRelationId === relationship.relationId ? styles.seriesRelationActive : ""}`}
+          onClick={() => onSelectRelation(relationship.relationId)}
+          title={`${relationship.sourceCompanyName} → ${relationship.targetCompanyName}`}
+        >
+          {relationship.sourceCompanyName} → {relationship.targetCompanyName}
+          <span>{relationLabel(relationship.relationType, relationship.ownershipPct)}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export default function HierarchyView({
+  companies,
+  relationships,
+  selectedCompanyId,
+  selectedRelationId,
+  hops,
+  query,
+  onSelectCompany,
+  onSelectRelation,
+}: Props) {
+  const selectedCompany = companies.find((company) => company.id === selectedCompanyId);
+  const series = useMemo(
+    () => selectedCompany
+      ? buildSeriesRows({
+          selectedCompanyId,
+          selectedCompanyName: selectedCompany.name,
+          relationships,
+          maxDepth: hops,
+        })
+      : null,
+    [hops, relationships, selectedCompany, selectedCompanyId],
+  );
+
+  if (!selectedCompany || !series) {
+    return <p className={styles.empty}>中心企業を選択してください。</p>;
+  }
+
+  return (
+    <div className={`${styles.seriesView} ${styles.viewFade}`}>
+      <p className={styles.seriesIntro}>
+        系列ビューは <strong>出資・親会社・支配・持分法</strong> だけを方向付きで表示します。
+        企業グループ所属や歴史的系譜は親子関係と同一視しないため、ここには混ぜません。
+      </p>
+
+      <section className={styles.seriesSection}>
+        <div className={styles.seriesSectionHead}>
+          <div>
+            <span className={styles.seriesKicker}>UPSTREAM</span>
+            <h3>上位・出資元・支配元</h3>
+          </div>
+          <span>{series.upstream.length}件</span>
+        </div>
+        {series.upstream.length > 0 ? (
+          <div className={styles.seriesRows}>
+            {[...series.upstream].reverse().map((row) => (
+              <Row
+                key={`up:${row.relationship?.relationId}:${row.companyId}:${row.depth}`}
+                row={row}
+                selectedRelationId={selectedRelationId}
+                query={query}
+                onSelectCompany={onSelectCompany}
+                onSelectRelation={onSelectRelation}
+              />
+            ))}
+          </div>
+        ) : <p className={styles.empty}>この範囲で確認済みの上位関係はありません。</p>}
+      </section>
+
+      <div className={styles.seriesCenter}>
+        <span>中心企業</span>
+        <strong>{selectedCompany.name}</strong>
+        <small>{selectedCompany.listingStatus || "上場区分未確認"}</small>
+      </div>
+
+      <section className={styles.seriesSection}>
+        <div className={styles.seriesSectionHead}>
+          <div>
+            <span className={styles.seriesKicker}>DOWNSTREAM</span>
+            <h3>下位・出資先・支配先</h3>
+          </div>
+          <span>{series.downstream.length}件</span>
+        </div>
+        {series.downstream.length > 0 ? (
+          <div className={styles.seriesRows}>
+            {series.downstream.map((row) => (
+              <Row
+                key={`down:${row.relationship?.relationId}:${row.companyId}:${row.depth}`}
+                row={row}
+                selectedRelationId={selectedRelationId}
+                query={query}
+                onSelectCompany={onSelectCompany}
+                onSelectRelation={onSelectRelation}
+              />
+            ))}
+          </div>
+        ) : <p className={styles.empty}>この範囲で確認済みの下位関係はありません。</p>}
+      </section>
+    </div>
+  );
+}

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { usePanZoom } from "../../industry-map/use-pan-zoom";
+import styles from "../CompanyNetwork.module.css";
+import { seedSimNodes, simExtent, stepForce, type SimLink, type SimNode, type VisualNode } from "../graph-layout";
+import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
+import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship } from "../types";
+
+const TOTAL_STEPS = 300;
+const STEPS_PER_FRAME = 3;
+const VIEWBOX_HALF = 500;
+const LABEL_PADDING = 120;
+const SEED_SPREAD = 270;
+
+function truncate(value: string, max = 16) {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+type Props = {
+  companies: CompanyNetworkCompany[];
+  relationships: CompanyRelationship[];
+  memberships: CompanyGroupMembership[];
+  selectedCompanyId: string;
+  selectedRelationId: string | null;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+};
+
+export default function NetworkView({
+  companies,
+  relationships,
+  memberships,
+  selectedCompanyId,
+  selectedRelationId,
+  query,
+  onSelectCompany,
+  onSelectRelation,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const resetKey = `${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
+  const panZoom = usePanZoom(svgRef, resetKey);
+  const [frame, setFrame] = useState<{ source: SimNode[]; nodes: SimNode[] } | null>(null);
+  const [runId, setRunId] = useState(0);
+
+  const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
+
+  const graph = useMemo(() => {
+    const companyIds = new Set<string>([selectedCompanyId]);
+    for (const relationship of relationships) {
+      companyIds.add(relationship.sourceCompanyId);
+      companyIds.add(relationship.targetCompanyId);
+    }
+    for (const membership of memberships) companyIds.add(membership.companyId);
+
+    const nodes: VisualNode[] = [...companyIds]
+      .map((companyId) => companyById.get(companyId))
+      .filter((company): company is CompanyNetworkCompany => Boolean(company))
+      .map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
+
+    const groupById = new Map(memberships.map((membership) => [membership.groupId, membership]));
+    for (const membership of groupById.values()) {
+      nodes.push({
+        id: `group:${membership.groupId}`,
+        label: membership.groupName,
+        kind: "group",
+        groupId: membership.groupId,
+        groupType: membership.groupType,
+      });
+    }
+
+    const links: SimLink[] = [
+      ...relationships.map((relationship) => ({
+        id: relationship.relationId,
+        sourceId: relationship.sourceCompanyId,
+        targetId: relationship.targetCompanyId,
+        kind: "relationship" as const,
+      })),
+      ...memberships.map((membership) => ({
+        id: membership.membershipId,
+        sourceId: membership.companyId,
+        targetId: `group:${membership.groupId}`,
+        kind: "membership" as const,
+      })),
+    ];
+
+    return { nodes, links };
+  }, [companyById, memberships, relationships, selectedCompanyId]);
+
+  const seeded = useMemo(() => seedSimNodes(graph.nodes, SEED_SPREAD), [graph.nodes, runId]);
+
+  useEffect(() => {
+    const working = seeded.map((node) => ({ ...node }));
+    let steps = 0;
+    let handle = 0;
+    const advance = () => {
+      for (let index = 0; index < STEPS_PER_FRAME; index += 1) stepForce(working, graph.links);
+      steps += STEPS_PER_FRAME;
+      setFrame({ source: seeded, nodes: working.map((node) => ({ ...node })) });
+      if (steps < TOTAL_STEPS) handle = requestAnimationFrame(advance);
+    };
+    handle = requestAnimationFrame(advance);
+    return () => cancelAnimationFrame(handle);
+  }, [graph.links, seeded]);
+
+  const nodes = frame?.source === seeded ? frame.nodes : seeded;
+  const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, 240);
+  const size = VIEWBOX_HALF * 2;
+
+  const focusIds = useMemo(() => {
+    const ids = new Set<string>([selectedCompanyId]);
+    for (const relationship of relationships) {
+      if (relationship.sourceCompanyId === selectedCompanyId) ids.add(relationship.targetCompanyId);
+      if (relationship.targetCompanyId === selectedCompanyId) ids.add(relationship.sourceCompanyId);
+    }
+    for (const membership of memberships) {
+      if (membership.companyId === selectedCompanyId) ids.add(`group:${membership.groupId}`);
+    }
+    return ids;
+  }, [memberships, relationships, selectedCompanyId]);
+
+  const normalizedQuery = query.trim().toLocaleLowerCase("ja");
+  const queryMatch = (node: SimNode) =>
+    normalizedQuery.length === 0 || node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
+
+  return (
+    <div className={styles.viewFade}>
+      <div className={styles.viewTools}>
+        <span>全体ネットワーク</span>
+        <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>
+          再配置
+        </button>
+      </div>
+      <div className={styles.svgWrap}>
+        <div className={styles.zoomControls}>
+          <button type="button" onClick={panZoom.zoomIn} aria-label="拡大">＋</button>
+          <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
+          <button type="button" onClick={panZoom.reset} disabled={!panZoom.canReset}>戻す</button>
+        </div>
+        <svg
+          ref={svgRef}
+          className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
+          style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
+          viewBox={`${-VIEWBOX_HALF} ${-VIEWBOX_HALF} ${size} ${size}`}
+          role="img"
+          aria-label="企業関係の全体ネットワーク"
+          onPointerDown={panZoom.onPointerDown}
+          onDoubleClick={panZoom.onDoubleClick}
+        >
+          <defs>
+            <marker id="company-relation-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+              <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
+            </marker>
+          </defs>
+          <g transform={panZoom.transform}>
+            {relationships.map((relationship) => {
+              const source = positions.get(relationship.sourceCompanyId);
+              const target = positions.get(relationship.targetCompanyId);
+              if (!source || !target) return null;
+              const selected = relationship.relationId === selectedRelationId;
+              const focused = focusIds.has(relationship.sourceCompanyId) && focusIds.has(relationship.targetCompanyId);
+              const opacity = selected ? 1 : focused ? 0.85 : 0.18;
+              return (
+                <g key={relationship.relationId}>
+                  <line
+                    x1={source.x * fit}
+                    y1={source.y * fit}
+                    x2={target.x * fit}
+                    y2={target.y * fit}
+                    stroke={CATEGORY_COLOR[relationship.relationCategory]}
+                    strokeWidth={selected ? 3.2 : 1.7}
+                    strokeOpacity={opacity}
+                    strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
+                    markerEnd="url(#company-relation-arrow)"
+                    color={CATEGORY_COLOR[relationship.relationCategory]}
+                    onClick={() => onSelectRelation(relationship.relationId)}
+                    className={styles.edgeHitTarget}
+                  />
+                  {focused || selected ? (
+                    <text
+                      x={((source.x + target.x) / 2) * fit}
+                      y={((source.y + target.y) / 2) * fit - 7}
+                      textAnchor="middle"
+                      className={styles.svgEdgeLabel}
+                    >
+                      {relationLabel(relationship.relationType, relationship.ownershipPct)}
+                    </text>
+                  ) : null}
+                </g>
+              );
+            })}
+
+            {memberships.map((membership) => {
+              const source = positions.get(membership.companyId);
+              const target = positions.get(`group:${membership.groupId}`);
+              if (!source || !target) return null;
+              const focused = membership.companyId === selectedCompanyId;
+              return (
+                <line
+                  key={membership.membershipId}
+                  x1={source.x * fit}
+                  y1={source.y * fit}
+                  x2={target.x * fit}
+                  y2={target.y * fit}
+                  className={styles.membershipLine}
+                  strokeOpacity={focused ? 0.9 : 0.2}
+                />
+              );
+            })}
+
+            {nodes.map((node) => {
+              const selected = node.id === selectedCompanyId;
+              const focused = focusIds.has(node.id);
+              const dimmed = !queryMatch(node) || (!focused && selectedCompanyId.length > 0);
+              const radius = node.kind === "group" ? 9 : selected ? 11 : 8;
+              const fill = node.kind === "group" ? "#fff7ed" : selected ? "#2554ff" : "var(--color-bg-card)";
+              const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
+              return (
+                <g
+                  key={node.id}
+                  transform={`translate(${node.x * fit} ${node.y * fit})`}
+                  className={dimmed ? styles.svgNodeDim : undefined}
+                  style={{ cursor: node.kind === "company" ? "pointer" : "default" }}
+                  onClick={() => {
+                    if (node.kind === "company" && !panZoom.didPan()) onSelectCompany(node.id);
+                  }}
+                  role={node.kind === "company" ? "button" : undefined}
+                  tabIndex={node.kind === "company" ? 0 : undefined}
+                  onKeyDown={(event) => {
+                    if (node.kind === "company" && (event.key === "Enter" || event.key === " ")) {
+                      event.preventDefault();
+                      onSelectCompany(node.id);
+                    }
+                  }}
+                >
+                  <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
+                  {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
+                  <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected ? 3 : 2} />
+                  <text className={styles.svgLabel} x={radius + 6} dominantBaseline="middle">
+                    {truncate(node.label)}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -213,7 +213,9 @@ export default function NetworkView({
             {nodes.map((node) => {
               const selected = node.id === selectedCompanyId;
               const focused = focusIds.has(node.id);
-              const dimmed = !queryMatch(node) || (!focused && selectedCompanyId.length > 0);
+              const dimmed = normalizedQuery.length > 0
+                ? !queryMatch(node)
+                : (!focused && selectedCompanyId.length > 0);
               const radius = node.kind === "group" ? 9 : selected ? 11 : 8;
               const fill = node.kind === "group" ? "#fff7ed" : selected ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";

--- a/app/premium/company-network/views/RadialView.tsx
+++ b/app/premium/company-network/views/RadialView.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { usePanZoom } from "../../industry-map/use-pan-zoom";
+import { buildReachableNetwork } from "../graph";
+import styles from "../CompanyNetwork.module.css";
+import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
+import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship } from "../types";
+
+type Point = { x: number; y: number };
+
+function truncate(value: string, max = 15) {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function companyPositions(depthByCompany: Map<string, number>): Map<string, Point> {
+  const result = new Map<string, Point>();
+  const byDepth = new Map<number, string[]>();
+  for (const [companyId, depth] of depthByCompany) {
+    const bucket = byDepth.get(depth) ?? [];
+    bucket.push(companyId);
+    byDepth.set(depth, bucket);
+  }
+
+  for (const [depth, ids] of byDepth) {
+    if (depth === 0) {
+      result.set(ids[0], { x: 0, y: 0 });
+      continue;
+    }
+    const radius = depth === 1 ? 180 : 315;
+    ids.forEach((companyId, index) => {
+      const angle = -Math.PI / 2 + (Math.PI * 2 * index) / Math.max(ids.length, 1);
+      result.set(companyId, { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
+    });
+  }
+  return result;
+}
+
+function groupPositions(memberships: CompanyGroupMembership[]): Map<string, Point> {
+  const groups = [...new Map(memberships.map((membership) => [membership.groupId, membership])).values()];
+  const result = new Map<string, Point>();
+  groups.forEach((group, index) => {
+    const angle = -Math.PI / 2 + (Math.PI * 2 * index) / Math.max(groups.length, 1);
+    result.set(group.groupId, { x: Math.cos(angle) * 425, y: Math.sin(angle) * 425 });
+  });
+  return result;
+}
+
+function shortenEdge(source: Point, target: Point, sourceRadius: number, targetRadius: number) {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const distance = Math.hypot(dx, dy) || 1;
+  const ux = dx / distance;
+  const uy = dy / distance;
+  return {
+    x1: source.x + ux * sourceRadius,
+    y1: source.y + uy * sourceRadius,
+    x2: target.x - ux * targetRadius,
+    y2: target.y - uy * targetRadius,
+    midX: (source.x + target.x) / 2,
+    midY: (source.y + target.y) / 2,
+  };
+}
+
+type Props = {
+  companies: CompanyNetworkCompany[];
+  relationships: CompanyRelationship[];
+  memberships: CompanyGroupMembership[];
+  selectedCompanyId: string;
+  selectedRelationId: string | null;
+  hops: 1 | 2;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+};
+
+export default function RadialView({
+  companies,
+  relationships,
+  memberships,
+  selectedCompanyId,
+  selectedRelationId,
+  hops,
+  query,
+  onSelectCompany,
+  onSelectRelation,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const panZoom = usePanZoom(svgRef, `${selectedCompanyId}:${hops}`);
+  const network = useMemo(
+    () => buildReachableNetwork({
+      selectedCompanyId,
+      relationships,
+      hops,
+      categories: ["capital", "control", "historical"],
+      verifiedOnly: false,
+    }),
+    [hops, relationships, selectedCompanyId],
+  );
+  const visibleCompanyIds = useMemo(() => new Set(network.depthByCompany.keys()), [network.depthByCompany]);
+  const visibleMemberships = useMemo(
+    () => memberships.filter((membership) => visibleCompanyIds.has(membership.companyId)),
+    [memberships, visibleCompanyIds],
+  );
+  const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
+  const positions = useMemo(() => companyPositions(network.depthByCompany), [network.depthByCompany]);
+  const groups = useMemo(() => groupPositions(visibleMemberships), [visibleMemberships]);
+  const normalizedQuery = query.trim().toLocaleLowerCase("ja");
+
+  return (
+    <div className={styles.viewFade}>
+      <div className={styles.viewTools}>
+        <span>中心企業から {hops}-hop</span>
+        <span>{network.depthByCompany.size}企業 / {network.relationships.length}関係</span>
+      </div>
+      <div className={styles.svgWrap}>
+        <div className={styles.zoomControls}>
+          <button type="button" onClick={panZoom.zoomIn} aria-label="拡大">＋</button>
+          <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
+          <button type="button" onClick={panZoom.reset} disabled={!panZoom.canReset}>戻す</button>
+        </div>
+        <svg
+          ref={svgRef}
+          className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
+          style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
+          viewBox="-520 -520 1040 1040"
+          role="img"
+          aria-label="選択企業を中心にした企業関係の放射マップ"
+          onPointerDown={panZoom.onPointerDown}
+          onDoubleClick={panZoom.onDoubleClick}
+        >
+          <defs>
+            <marker id="company-radial-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+              <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
+            </marker>
+          </defs>
+          <g transform={panZoom.transform}>
+            <circle r="180" className={styles.radialRing} />
+            {hops === 2 ? <circle r="315" className={styles.radialRing} /> : null}
+            {visibleMemberships.length > 0 ? <circle r="425" className={styles.radialGroupRing} /> : null}
+
+            {network.relationships.map((relationship) => {
+              const source = positions.get(relationship.sourceCompanyId);
+              const target = positions.get(relationship.targetCompanyId);
+              if (!source || !target) return null;
+              const edge = shortenEdge(source, target, relationship.sourceCompanyId === selectedCompanyId ? 34 : 26, relationship.targetCompanyId === selectedCompanyId ? 34 : 26);
+              const selected = selectedRelationId === relationship.relationId;
+              return (
+                <g key={relationship.relationId} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget}>
+                  <line
+                    x1={edge.x1}
+                    y1={edge.y1}
+                    x2={edge.x2}
+                    y2={edge.y2}
+                    stroke={CATEGORY_COLOR[relationship.relationCategory]}
+                    strokeWidth={selected ? 3.2 : 1.8}
+                    strokeOpacity={selected ? 1 : 0.78}
+                    strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
+                    markerEnd="url(#company-radial-arrow)"
+                    color={CATEGORY_COLOR[relationship.relationCategory]}
+                  />
+                  <text x={edge.midX} y={edge.midY - 7} textAnchor="middle" className={styles.svgEdgeLabel}>
+                    {relationLabel(relationship.relationType, relationship.ownershipPct)}
+                  </text>
+                </g>
+              );
+            })}
+
+            {visibleMemberships.map((membership) => {
+              const source = positions.get(membership.companyId);
+              const target = groups.get(membership.groupId);
+              if (!source || !target) return null;
+              return (
+                <line
+                  key={membership.membershipId}
+                  x1={source.x}
+                  y1={source.y}
+                  x2={target.x}
+                  y2={target.y}
+                  className={styles.membershipLine}
+                />
+              );
+            })}
+
+            {[...network.depthByCompany.entries()].map(([companyId, depth]) => {
+              const company = companyById.get(companyId);
+              const point = positions.get(companyId);
+              if (!company || !point) return null;
+              const selected = companyId === selectedCompanyId;
+              const queryDim = normalizedQuery.length > 0 && !company.name.toLocaleLowerCase("ja").includes(normalizedQuery);
+              const radius = selected ? 34 : 26;
+              return (
+                <g
+                  key={companyId}
+                  transform={`translate(${point.x} ${point.y})`}
+                  className={queryDim ? styles.svgNodeDim : undefined}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => { if (!panZoom.didPan()) onSelectCompany(companyId); }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onSelectCompany(companyId);
+                    }
+                  }}
+                  style={{ cursor: "pointer" }}
+                >
+                  {selected ? <circle className={styles.pulse} r={radius + 9} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
+                  <circle r={radius} fill={selected ? "#2554ff" : "var(--color-bg-card)"} stroke="#2554ff" strokeWidth={selected ? 3 : 2} />
+                  <text textAnchor="middle" y="-2" className={selected ? styles.radialCenterLabel : styles.radialNodeLabel}>{truncate(company.name, 11)}</text>
+                  <text textAnchor="middle" y="13" className={selected ? styles.radialCenterMeta : styles.radialNodeMeta}>{depth === 0 ? "center" : `${depth}-hop`}</text>
+                </g>
+              );
+            })}
+
+            {[...new Map(visibleMemberships.map((membership) => [membership.groupId, membership])).values()].map((membership) => {
+              const point = groups.get(membership.groupId);
+              if (!point) return null;
+              return (
+                <g key={membership.groupId} transform={`translate(${point.x} ${point.y})`}>
+                  <rect x="-60" y="-25" width="120" height="50" rx="14" className={styles.radialGroupNode} />
+                  <text textAnchor="middle" y="-2" className={styles.radialGroupLabel}>{truncate(membership.groupName, 13)}</text>
+                  <text textAnchor="middle" y="13" className={styles.radialGroupMeta}>{groupTypeLabel(membership.groupType)}</text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/app/premium/company-network/views/TableView.tsx
+++ b/app/premium/company-network/views/TableView.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import styles from "../CompanyNetwork.module.css";
+import { CATEGORY_LABEL, formatAsOf, relationLabel } from "../presentation";
+import type { CompanyRelationship } from "../types";
+
+type SortKey = "source" | "target" | "relation" | "ownership" | "date";
+
+const COLUMNS: { key: SortKey; label: string }[] = [
+  { key: "source", label: "起点企業" },
+  { key: "relation", label: "関係" },
+  { key: "target", label: "相手企業" },
+  { key: "ownership", label: "持株比率" },
+  { key: "date", label: "基準日" },
+];
+
+type Props = {
+  relationships: CompanyRelationship[];
+  selectedRelationId: string | null;
+  query: string;
+  onSelectRelation: (relationId: string) => void;
+  onSelectCompany: (companyId: string) => void;
+};
+
+export default function TableView({
+  relationships,
+  selectedRelationId,
+  query,
+  onSelectRelation,
+  onSelectCompany,
+}: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>("source");
+  const [ascending, setAscending] = useState(true);
+  const normalized = query.trim().toLocaleLowerCase("ja");
+
+  const visible = useMemo(() => {
+    const filtered = relationships.filter((relationship) => {
+      if (!normalized) return true;
+      return [
+        relationship.sourceCompanyName,
+        relationship.targetCompanyName,
+        relationLabel(relationship.relationType, relationship.ownershipPct),
+        relationship.note,
+      ].some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+    });
+    const direction = ascending ? 1 : -1;
+    const compare = (a: CompanyRelationship, b: CompanyRelationship) => {
+      switch (sortKey) {
+        case "target":
+          return a.targetCompanyName.localeCompare(b.targetCompanyName, "ja");
+        case "relation":
+          return relationLabel(a.relationType, a.ownershipPct).localeCompare(relationLabel(b.relationType, b.ownershipPct), "ja");
+        case "ownership":
+          return (a.ownershipPct ?? -1) - (b.ownershipPct ?? -1);
+        case "date":
+          return (a.sourceAsOf ?? "").localeCompare(b.sourceAsOf ?? "");
+        default:
+          return a.sourceCompanyName.localeCompare(b.sourceCompanyName, "ja");
+      }
+    };
+    return [...filtered].sort((a, b) => compare(a, b) * direction || a.relationId.localeCompare(b.relationId));
+  }, [ascending, normalized, relationships, sortKey]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) setAscending((value) => !value);
+    else {
+      setSortKey(key);
+      setAscending(true);
+    }
+  };
+
+  if (visible.length === 0) {
+    return <p className={`${styles.empty} ${styles.viewFade}`}>条件に一致する企業関係がありません。</p>;
+  }
+
+  return (
+    <div className={`${styles.tableScroll} ${styles.viewFade}`}>
+      <table className={styles.table}>
+        <caption>{relationships.length}件の企業関係のうち {visible.length}件を表示</caption>
+        <thead>
+          <tr>
+            {COLUMNS.map((column) => (
+              <th
+                key={column.key}
+                className={styles.sortable}
+                onClick={() => toggleSort(column.key)}
+                aria-sort={sortKey === column.key ? (ascending ? "ascending" : "descending") : "none"}
+              >
+                {column.label}{sortKey === column.key ? (ascending ? " ▲" : " ▼") : ""}
+              </th>
+            ))}
+            <th>区分</th>
+            <th>検証</th>
+            <th>根拠</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map((relationship) => (
+            <tr
+              key={relationship.relationId}
+              className={selectedRelationId === relationship.relationId ? styles.tableRowSelected : undefined}
+              onClick={() => onSelectRelation(relationship.relationId)}
+            >
+              <td>
+                <button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.sourceCompanyId); }}>
+                  {relationship.sourceCompanyName}
+                </button>
+              </td>
+              <td className={styles.tableRelation}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</td>
+              <td>
+                <button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.targetCompanyId); }}>
+                  {relationship.targetCompanyName}
+                </button>
+              </td>
+              <td>{relationship.ownershipPct === null ? "—" : `${relationship.ownershipPct}%`}</td>
+              <td>{formatAsOf(relationship.sourceAsOf)}</td>
+              <td>{CATEGORY_LABEL[relationship.relationCategory]}</td>
+              <td>{relationship.verificationStatus}</td>
+              <td className={styles.tableSource}>{relationship.sourceTitle ?? relationship.sourceType ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docs/decision-log/2026-08-28-company-network-multiview.md
+++ b/docs/decision-log/2026-08-28-company-network-multiview.md
@@ -1,0 +1,57 @@
+# 企業関係マップを4ビューへ分離する
+
+## 結論
+
+`/premium/company-network` は単一の固定放射図ではなく、同じ企業関係データを **関係 / 放射 / 系列 / 表** の4表現で切り替える。
+
+業界マップの「問いごとに表現を選ぶ」UI思想を踏襲するが、企業関係は分類木ではなくグラフが中心なのでビュー構成はそのままコピーしない。
+
+## ビューと問い
+
+| ビュー | 担当する問い |
+|---|---|
+| 関係（既定） | 企業・企業グループ全体がどうつながっているか |
+| 放射 | 選択企業から1-hop / 2-hopに何があるか |
+| 系列 | 出資・親会社・支配の上位 / 下位がどうつながるか |
+| 表 | 関係種別・比率・verification・source_as_ofを正確に確認する |
+
+## 既存資産の再利用
+
+- 現行 `buildReachableNetwork()` は放射ビューでそのまま使う
+- 業界マップのpan/zoom hookを企業関係SVGでも利用する
+- force配置の考え方を企業関係専用型へ移植する
+- 業界マップと同じ white card / sticky toolbar / workspace + detail panel の操作感へ寄せる
+
+## 系列ビューの境界
+
+系列ビューに入れる関係:
+- `equity_ownership`
+- `parent_of`
+- `controls`
+- `equity_method_investment`
+
+入れないもの:
+- corporate group / keiretsu等のgroup membership
+- historical relation
+
+同じ企業グループであることを親子・支配関係として描かない。
+
+## 事実の向き
+
+企業間edgeはDBに保存されたcanonical directionを維持する。UI都合で逆向きedgeを生成しない。
+
+例: `Toyota Motor -> Woven by Toyota / equity_ownership 100%` は、放射・関係・系列・表のどのビューでも事実方向を変えない。
+
+## 今回採らないもの
+
+- 企業×企業マトリクス: 企業数が増えると疎行列になりやすいため保留
+- 企業×グループマトリクス: membership coverageが増えた時点で再評価
+- supplier / customer / joint research等: Phase 6 #497で関係種別を拡張してから表示設計を追加
+
+## UI共通原則
+
+- verified-onlyを既定にする
+- proposedは破線などで区別する
+- 企業グループ所属は別edgeとして表示する
+- 取得失敗と0件を区別する
+- 事実表示から業績連動・テーマ受益・売買判断を自動推論しない


### PR DESCRIPTION
## 概要

Issue #505 として、既存の `/premium/company-network` を業界マップと同じ「問いごとに表現を切り替える」UI思想へ刷新しました。

## 検証
- lint/test/build: CI #976 success
- merge後の本番モバイル表示: ユーザー確認済み
- 設定UIの間延びは follow-up PR で改善

Closes #505