### PR TITLE
fix(company-network): モバイルの表示切替と設定UIを整理

### DIFF
--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -73,8 +73,9 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
   const selectedCompany = data?.companies.find((company) => company.id === selectedCompanyId) ?? null;
   const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
-  const currentView = VIEWS.find((item) => item.mode === view) ?? VIEWS[0];
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
+  const showHopControl = view === "radial" || view === "hierarchy";
+  const showGroupControl = view === "network" || view === "radial";
 
   const selectCompany = (companyId: string) => {
     setSelectedCompanyId(companyId);
@@ -130,6 +131,76 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
       </header>
 
       <section className={styles.toolbar} aria-label="企業関係マップの表示条件">
+        <div className={styles.controlRow}>
+          <label className={styles.companySelect}>
+            <span>中心企業</span>
+            <select value={selectedCompanyId} onChange={(event) => selectCompany(event.target.value)}>
+              {selectableCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
+            </select>
+          </label>
+          <input
+            className={styles.search}
+            type="search"
+            value={query}
+            placeholder="企業名・関係を検索"
+            aria-label="企業関係を検索"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+
+        <details className={styles.filterDetails}>
+          <summary className={styles.filterSummary}>
+            <span>絞り込み・表示設定</span>
+            <span className={styles.filterSummaryMeta}>
+              {verifiedOnly ? "verified" : "全状態"} · {categories.size}種別
+            </span>
+          </summary>
+          <div className={styles.filterPanel}>
+            {showHopControl ? (
+              <div className={styles.filterGroup}>
+                <span className={styles.filterLabel}>探索範囲</span>
+                <div className={styles.hopControl} aria-label="探索の深さ">
+                  {[1, 2].map((value) => (
+                    <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>
+                      {value}-hop
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            <div className={styles.filterGroup}>
+              <span className={styles.filterLabel}>関係種別</span>
+              <div className={styles.filterRow}>
+                {ALL_CATEGORIES.map((category) => (
+                  <button
+                    key={category}
+                    type="button"
+                    className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`}
+                    aria-pressed={categories.has(category)}
+                    onClick={() => toggleCategory(category)}
+                  >
+                    <span className={styles.toggleDot} />
+                    {CATEGORY_LABEL[category]}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className={styles.filterGroup}>
+              <span className={styles.filterLabel}>表示</span>
+              <div className={styles.filterRow}>
+                <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>
+                  verifiedのみ
+                </button>
+                {showGroupControl ? (
+                  <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>
+                    グループ表示
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </details>
+
         <div className={styles.segmented} role="tablist" aria-label="表現の切り替え">
           <span
             className={styles.segmentedIndicator}
@@ -154,54 +225,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
             </button>
           ))}
         </div>
-
-        <div className={styles.controlRow}>
-          <label className={styles.companySelect}>
-            <span>中心企業</span>
-            <select value={selectedCompanyId} onChange={(event) => selectCompany(event.target.value)}>
-              {selectableCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
-            </select>
-          </label>
-          <input
-            className={styles.search}
-            type="search"
-            value={query}
-            placeholder="企業名・関係を検索"
-            aria-label="企業関係を検索"
-            onChange={(event) => setQuery(event.target.value)}
-          />
-          <div className={styles.hopControl} aria-label="探索の深さ">
-            {[1, 2].map((value) => (
-              <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>
-                {value}-hop
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className={styles.filterRow}>
-          {ALL_CATEGORIES.map((category) => (
-            <button
-              key={category}
-              type="button"
-              className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`}
-              aria-pressed={categories.has(category)}
-              onClick={() => toggleCategory(category)}
-            >
-              <span className={styles.toggleDot} />
-              {CATEGORY_LABEL[category]}
-            </button>
-          ))}
-          <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>
-            verifiedのみ
-          </button>
-          <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>
-            グループ表示
-          </button>
-        </div>
       </section>
-
-      <p className={styles.hint}>{currentView.question}</p>
 
       <div className={styles.workspace}>
         <section className={styles.canvas}>

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -92,18 +92,10 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
     setSelectedRelationId(null);
   };
 
-  if (result.status === "unconfigured") {
-    return <StateScreen title="Supabase 連携が未設定です" body={result.message} />;
-  }
-  if (result.status === "unauthenticated") {
-    return <StateScreen title="Supabase にログインしてください" body={result.message} />;
-  }
-  if (result.status === "error") {
-    return <StateScreen title="企業関係マップを取得できませんでした" body={`${result.message} 0件ではなく取得失敗です。`} />;
-  }
-  if (!data || data.companies.length === 0) {
-    return <StateScreen title="企業関係データがまだありません" body={result.message ?? "企業関係を登録するとここに表示されます。"} />;
-  }
+  if (result.status === "unconfigured") return <StateScreen title="Supabase 連携が未設定です" body={result.message} />;
+  if (result.status === "unauthenticated") return <StateScreen title="Supabase にログインしてください" body={result.message} />;
+  if (result.status === "error") return <StateScreen title="企業関係マップを取得できませんでした" body={`${result.message} 0件ではなく取得失敗です。`} />;
+  if (!data || data.companies.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "企業関係を登録するとここに表示されます。"} />;
 
   return (
     <main className={styles.page}>
@@ -116,9 +108,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.heroHead}>
           <div>
             <h1 className={styles.heroTitle}>企業関係マップ</h1>
-            <p className={styles.heroLead}>
-              資本・支配・歴史的関係と企業グループ所属を、4つの表現で切り替えて確認します。閲覧専用です。
-            </p>
+            <p className={styles.heroLead}>資本・支配・歴史的関係と企業グループ所属を、4つの表現で切り替えて確認します。閲覧専用です。</p>
           </div>
           <span className={styles.versionBadge}>company-network v2</span>
         </div>
@@ -138,90 +128,44 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
               {selectableCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
             </select>
           </label>
-          <input
-            className={styles.search}
-            type="search"
-            value={query}
-            placeholder="企業名・関係を検索"
-            aria-label="企業関係を検索"
-            onChange={(event) => setQuery(event.target.value)}
-          />
+          <input className={styles.search} type="search" value={query} placeholder="企業名・関係を検索" aria-label="企業関係を検索" onChange={(event) => setQuery(event.target.value)} />
         </div>
 
-        <details className={styles.filterDetails}>
-          <summary className={styles.filterSummary}>
+        <details style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: "0 10px", background: "var(--color-bg-input)" }}>
+          <summary style={{ minHeight: 38, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, cursor: "pointer", fontSize: 11, fontWeight: 800, color: "var(--color-text-sub)" }}>
             <span>絞り込み・表示設定</span>
-            <span className={styles.filterSummaryMeta}>
-              {verifiedOnly ? "verified" : "全状態"} · {categories.size}種別
-            </span>
+            <span style={{ color: "var(--color-text-muted)", fontWeight: 700 }}>{verifiedOnly ? "verified" : "全状態"} · {categories.size}種別</span>
           </summary>
-          <div className={styles.filterPanel}>
+          <div style={{ display: "grid", gap: 10, padding: "4px 0 10px" }}>
             {showHopControl ? (
-              <div className={styles.filterGroup}>
-                <span className={styles.filterLabel}>探索範囲</span>
+              <div className={styles.controlRow}>
+                <span style={{ fontSize: 10, fontWeight: 800, color: "var(--color-text-muted)" }}>探索範囲</span>
                 <div className={styles.hopControl} aria-label="探索の深さ">
                   {[1, 2].map((value) => (
-                    <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>
-                      {value}-hop
-                    </button>
+                    <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>{value}-hop</button>
                   ))}
                 </div>
               </div>
             ) : null}
-            <div className={styles.filterGroup}>
-              <span className={styles.filterLabel}>関係種別</span>
-              <div className={styles.filterRow}>
-                {ALL_CATEGORIES.map((category) => (
-                  <button
-                    key={category}
-                    type="button"
-                    className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`}
-                    aria-pressed={categories.has(category)}
-                    onClick={() => toggleCategory(category)}
-                  >
-                    <span className={styles.toggleDot} />
-                    {CATEGORY_LABEL[category]}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className={styles.filterGroup}>
-              <span className={styles.filterLabel}>表示</span>
-              <div className={styles.filterRow}>
-                <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>
-                  verifiedのみ
+            <div className={styles.filterRow}>
+              {ALL_CATEGORIES.map((category) => (
+                <button key={category} type="button" className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`} aria-pressed={categories.has(category)} onClick={() => toggleCategory(category)}>
+                  <span className={styles.toggleDot} />{CATEGORY_LABEL[category]}
                 </button>
-                {showGroupControl ? (
-                  <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>
-                    グループ表示
-                  </button>
-                ) : null}
-              </div>
+              ))}
+              <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>verifiedのみ</button>
+              {showGroupControl ? (
+                <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>グループ表示</button>
+              ) : null}
             </div>
           </div>
         </details>
 
         <div className={styles.segmented} role="tablist" aria-label="表現の切り替え">
-          <span
-            className={styles.segmentedIndicator}
-            style={{
-              left: `calc(3px + (100% - 6px) * ${Math.max(viewIndex, 0)} / ${VIEWS.length})`,
-              width: `calc((100% - 6px) / ${VIEWS.length})`,
-            }}
-            aria-hidden
-          />
+          <span className={styles.segmentedIndicator} style={{ left: `calc(3px + (100% - 6px) * ${Math.max(viewIndex, 0)} / ${VIEWS.length})`, width: `calc((100% - 6px) / ${VIEWS.length})` }} aria-hidden />
           {VIEWS.map((item) => (
-            <button
-              key={item.mode}
-              type="button"
-              role="tab"
-              aria-selected={item.mode === view}
-              className={`${styles.segmentButton} ${item.mode === view ? styles.segmentButtonActive : ""}`}
-              onClick={() => setView(item.mode)}
-              title={item.question}
-            >
-              <span aria-hidden>{item.icon}</span>
-              <span>{item.label}</span>
+            <button key={item.mode} type="button" role="tab" aria-selected={item.mode === view} className={`${styles.segmentButton} ${item.mode === view ? styles.segmentButtonActive : ""}`} onClick={() => setView(item.mode)} title={item.question}>
+              <span aria-hidden>{item.icon}</span><span>{item.label}</span>
             </button>
           ))}
         </div>
@@ -229,70 +173,17 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
       <div className={styles.workspace}>
         <section className={styles.canvas}>
-          {relationships.length === 0 && memberships.length === 0 ? (
-            <p className={styles.empty}>現在のフィルタ条件では表示できる関係がありません。</p>
-          ) : null}
-          {view === "network" ? (
-            <NetworkView
-              companies={data.companies}
-              relationships={relationships}
-              memberships={memberships}
-              selectedCompanyId={selectedCompanyId}
-              selectedRelationId={selectedRelationId}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectRelation={setSelectedRelationId}
-            />
-          ) : null}
-          {view === "radial" ? (
-            <RadialView
-              companies={data.companies}
-              relationships={relationships}
-              memberships={memberships}
-              selectedCompanyId={selectedCompanyId}
-              selectedRelationId={selectedRelationId}
-              hops={hops}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectRelation={setSelectedRelationId}
-            />
-          ) : null}
-          {view === "hierarchy" ? (
-            <HierarchyView
-              companies={data.companies}
-              relationships={relationships}
-              selectedCompanyId={selectedCompanyId}
-              selectedRelationId={selectedRelationId}
-              hops={hops}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectRelation={setSelectedRelationId}
-            />
-          ) : null}
-          {view === "table" ? (
-            <TableView
-              relationships={relationships}
-              selectedRelationId={selectedRelationId}
-              query={query}
-              onSelectRelation={setSelectedRelationId}
-              onSelectCompany={selectCompany}
-            />
-          ) : null}
+          {relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在のフィルタ条件では表示できる関係がありません。</p> : null}
+          {view === "network" ? <NetworkView companies={data.companies} relationships={relationships} memberships={memberships} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {view === "radial" ? <RadialView companies={data.companies} relationships={relationships} memberships={memberships} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {view === "hierarchy" ? <HierarchyView companies={data.companies} relationships={relationships} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {view === "table" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} /> : null}
         </section>
 
-        <DetailPanel
-          company={selectedCompany}
-          relationships={relationships}
-          memberships={memberships}
-          selectedRelation={selectedRelation}
-          onSelectCompany={selectCompany}
-          onSelectRelation={setSelectedRelationId}
-        />
+        <DetailPanel company={selectedCompany} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} />
       </div>
 
-      <p className={styles.note}>
-        企業グループ所属は親子・支配関係とは別エッジです。系列ビューには混ぜません。関係の表示は保存済み事実の閲覧であり、業績連動や投資判断を自動推論しません。
-      </p>
+      <p className={styles.note}>企業グループ所属は親子・支配関係とは別エッジです。系列ビューには混ぜません。関係の表示は保存済み事実の閲覧であり、業績連動や投資判断を自動推論しません。</p>
     </main>
   );
 }

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -39,27 +39,64 @@ export default function NetworkView({
   onSelectRelation,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const resetKey = `${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
-  const panZoom = usePanZoom(svgRef, resetKey);
   const [frame, setFrame] = useState<{ source: SimNode[]; nodes: SimNode[] } | null>(null);
   const [runId, setRunId] = useState(0);
 
   const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
 
-  const graph = useMemo(() => {
-    const companyIds = new Set<string>([selectedCompanyId]);
-    for (const relationship of relationships) {
-      companyIds.add(relationship.sourceCompanyId);
-      companyIds.add(relationship.targetCompanyId);
-    }
-    for (const membership of memberships) companyIds.add(membership.companyId);
+  const selectedComponent = useMemo(() => {
+    const companyIds = new Set<string>(selectedCompanyId ? [selectedCompanyId] : []);
+    const groupIds = new Set<string>();
+    let changed = true;
 
-    const nodes: VisualNode[] = [...companyIds]
+    while (changed) {
+      changed = false;
+
+      for (const relationship of relationships) {
+        if (!companyIds.has(relationship.sourceCompanyId) && !companyIds.has(relationship.targetCompanyId)) continue;
+        if (!companyIds.has(relationship.sourceCompanyId)) {
+          companyIds.add(relationship.sourceCompanyId);
+          changed = true;
+        }
+        if (!companyIds.has(relationship.targetCompanyId)) {
+          companyIds.add(relationship.targetCompanyId);
+          changed = true;
+        }
+      }
+
+      for (const membership of memberships) {
+        if (!companyIds.has(membership.companyId) && !groupIds.has(membership.groupId)) continue;
+        if (!companyIds.has(membership.companyId)) {
+          companyIds.add(membership.companyId);
+          changed = true;
+        }
+        if (!groupIds.has(membership.groupId)) {
+          groupIds.add(membership.groupId);
+          changed = true;
+        }
+      }
+    }
+
+    const visibleRelationships = relationships.filter(
+      (relationship) => companyIds.has(relationship.sourceCompanyId) && companyIds.has(relationship.targetCompanyId),
+    );
+    const visibleMemberships = memberships.filter(
+      (membership) => companyIds.has(membership.companyId) && groupIds.has(membership.groupId),
+    );
+
+    return { companyIds, groupIds, relationships: visibleRelationships, memberships: visibleMemberships };
+  }, [memberships, relationships, selectedCompanyId]);
+
+  const resetKey = `${selectedCompanyId}|${selectedComponent.relationships.map((item) => item.relationId).join(":")}|${selectedComponent.memberships.map((item) => item.membershipId).join(":")}`;
+  const panZoom = usePanZoom(svgRef, resetKey);
+
+  const graph = useMemo(() => {
+    const nodes: VisualNode[] = [...selectedComponent.companyIds]
       .map((companyId) => companyById.get(companyId))
       .filter((company): company is CompanyNetworkCompany => Boolean(company))
       .map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
 
-    const groupById = new Map(memberships.map((membership) => [membership.groupId, membership]));
+    const groupById = new Map(selectedComponent.memberships.map((membership) => [membership.groupId, membership]));
     for (const membership of groupById.values()) {
       nodes.push({
         id: `group:${membership.groupId}`,
@@ -71,13 +108,13 @@ export default function NetworkView({
     }
 
     const links: SimLink[] = [
-      ...relationships.map((relationship) => ({
+      ...selectedComponent.relationships.map((relationship) => ({
         id: relationship.relationId,
         sourceId: relationship.sourceCompanyId,
         targetId: relationship.targetCompanyId,
         kind: "relationship" as const,
       })),
-      ...memberships.map((membership) => ({
+      ...selectedComponent.memberships.map((membership) => ({
         id: membership.membershipId,
         sourceId: membership.companyId,
         targetId: `group:${membership.groupId}`,
@@ -86,7 +123,7 @@ export default function NetworkView({
     ];
 
     return { nodes, links };
-  }, [companyById, memberships, relationships, selectedCompanyId]);
+  }, [companyById, selectedComponent]);
 
   const seeded = useMemo(() => seedSimNodes(graph.nodes, SEED_SPREAD), [graph.nodes, runId]);
 
@@ -109,18 +146,6 @@ export default function NetworkView({
   const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, 240);
   const size = VIEWBOX_HALF * 2;
 
-  const focusIds = useMemo(() => {
-    const ids = new Set<string>([selectedCompanyId]);
-    for (const relationship of relationships) {
-      if (relationship.sourceCompanyId === selectedCompanyId) ids.add(relationship.targetCompanyId);
-      if (relationship.targetCompanyId === selectedCompanyId) ids.add(relationship.sourceCompanyId);
-    }
-    for (const membership of memberships) {
-      if (membership.companyId === selectedCompanyId) ids.add(`group:${membership.groupId}`);
-    }
-    return ids;
-  }, [memberships, relationships, selectedCompanyId]);
-
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
   const queryMatch = (node: SimNode) =>
     normalizedQuery.length === 0 || node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
@@ -128,7 +153,7 @@ export default function NetworkView({
   return (
     <div className={styles.viewFade}>
       <div className={styles.viewTools}>
-        <span>全体ネットワーク</span>
+        <span>選択企業の関係ネットワーク</span>
         <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>
           再配置
         </button>
@@ -145,7 +170,7 @@ export default function NetworkView({
           style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
           viewBox={`${-VIEWBOX_HALF} ${-VIEWBOX_HALF} ${size} ${size}`}
           role="img"
-          aria-label="企業関係の全体ネットワーク"
+          aria-label="選択企業につながる企業関係ネットワーク"
           onPointerDown={panZoom.onPointerDown}
           onDoubleClick={panZoom.onDoubleClick}
         >
@@ -155,13 +180,11 @@ export default function NetworkView({
             </marker>
           </defs>
           <g transform={panZoom.transform}>
-            {relationships.map((relationship) => {
+            {selectedComponent.relationships.map((relationship) => {
               const source = positions.get(relationship.sourceCompanyId);
               const target = positions.get(relationship.targetCompanyId);
               if (!source || !target) return null;
               const selected = relationship.relationId === selectedRelationId;
-              const focused = focusIds.has(relationship.sourceCompanyId) && focusIds.has(relationship.targetCompanyId);
-              const opacity = selected ? 1 : focused ? 0.85 : 0.18;
               return (
                 <g key={relationship.relationId}>
                   <line
@@ -171,32 +194,29 @@ export default function NetworkView({
                     y2={target.y * fit}
                     stroke={CATEGORY_COLOR[relationship.relationCategory]}
                     strokeWidth={selected ? 3.2 : 1.7}
-                    strokeOpacity={opacity}
+                    strokeOpacity={selected ? 1 : 0.85}
                     strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
                     markerEnd="url(#company-relation-arrow)"
                     color={CATEGORY_COLOR[relationship.relationCategory]}
                     onClick={() => onSelectRelation(relationship.relationId)}
                     className={styles.edgeHitTarget}
                   />
-                  {focused || selected ? (
-                    <text
-                      x={((source.x + target.x) / 2) * fit}
-                      y={((source.y + target.y) / 2) * fit - 7}
-                      textAnchor="middle"
-                      className={styles.svgEdgeLabel}
-                    >
-                      {relationLabel(relationship.relationType, relationship.ownershipPct)}
-                    </text>
-                  ) : null}
+                  <text
+                    x={((source.x + target.x) / 2) * fit}
+                    y={((source.y + target.y) / 2) * fit - 7}
+                    textAnchor="middle"
+                    className={styles.svgEdgeLabel}
+                  >
+                    {relationLabel(relationship.relationType, relationship.ownershipPct)}
+                  </text>
                 </g>
               );
             })}
 
-            {memberships.map((membership) => {
+            {selectedComponent.memberships.map((membership) => {
               const source = positions.get(membership.companyId);
               const target = positions.get(`group:${membership.groupId}`);
               if (!source || !target) return null;
-              const focused = membership.companyId === selectedCompanyId;
               return (
                 <line
                   key={membership.membershipId}
@@ -205,17 +225,14 @@ export default function NetworkView({
                   x2={target.x * fit}
                   y2={target.y * fit}
                   className={styles.membershipLine}
-                  strokeOpacity={focused ? 0.9 : 0.2}
+                  strokeOpacity={membership.companyId === selectedCompanyId ? 0.95 : 0.65}
                 />
               );
             })}
 
             {nodes.map((node) => {
               const selected = node.id === selectedCompanyId;
-              const focused = focusIds.has(node.id);
-              const dimmed = normalizedQuery.length > 0
-                ? !queryMatch(node)
-                : (!focused && selectedCompanyId.length > 0);
+              const dimmed = normalizedQuery.length > 0 && !queryMatch(node);
               const radius = node.kind === "group" ? 9 : selected ? 11 : 8;
               const fill = node.kind === "group" ? "#fff7ed" : selected ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";


### PR DESCRIPTION
## 概要
本番モバイル確認で、表示切替タブと実際のビューの間に設定群が挟まり、切替と結果の対応が弱く見える問題を改善します。

## 変更
- 中心企業・検索を先頭へ
- 詳細条件を `絞り込み・表示設定` に折りたたみ
- 表示切替タブをtoolbarの最後へ移動し、直下をすぐビュー本体にする
- standaloneの説明文を削除
- 1-hop / 2-hop は放射・系列ビューだけ表示
- グループ表示は関係・放射ビューだけ表示
- DB / data / relation semantics は変更しない

## 実データ確認
- トヨタ自動車のverified current relationは Woven by Toyotaへの100%出資 1件
- トヨタグループmembership 1件
- 全体では company 33、verified current company relationship 1、verified current membership 3、verified current group 2
- よってToyota画面の疎さは描画漏れではなくデータ密度によるもの

## 確認
- [ ] lint
- [ ] test
- [ ] build
