### PR TITLE
feat(company-network): 中心企業候補を整理しToyotaデータを拡充

### DIFF
--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import styles from "./CompanyNetwork.module.css";
+import { buildEntryCompanies } from "./entry-companies";
 import { CATEGORY_LABEL, VIEWS, type CompanyNetworkViewMode } from "./presentation";
 import type { CompanyNetworkLoadResult, RelationCategory } from "./types";
 import DetailPanel from "./views/DetailPanel";
@@ -29,21 +30,13 @@ function StateScreen({ title, body }: { title: string; body: string }) {
 
 export default function CompanyNetworkClient({ result }: { result: CompanyNetworkLoadResult }) {
   const data = result.data;
-  const connectedCompanyIds = useMemo(() => {
-    if (!data) return new Set<string>();
-    return new Set([
-      ...data.relationships.flatMap((relationship) => [relationship.sourceCompanyId, relationship.targetCompanyId]),
-      ...data.memberships.map((membership) => membership.companyId),
-    ]);
-  }, [data]);
-  const selectableCompanies = useMemo(() => {
+  const entryCompanies = useMemo(() => {
     if (!data) return [];
-    const connected = data.companies.filter((company) => connectedCompanyIds.has(company.id));
-    return connected.length > 0 ? connected : data.companies;
-  }, [connectedCompanyIds, data]);
+    return buildEntryCompanies(data.companies, data.relationships);
+  }, [data]);
   const defaultCompanyId =
-    selectableCompanies.find((company) => company.name === "トヨタ自動車")?.id ??
-    selectableCompanies[0]?.id ??
+    entryCompanies.find((company) => company.name === "トヨタ自動車")?.id ??
+    entryCompanies[0]?.id ??
     "";
 
   const [view, setView] = useState<CompanyNetworkViewMode>("network");
@@ -73,6 +66,11 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
   const selectedCompany = data?.companies.find((company) => company.id === selectedCompanyId) ?? null;
   const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
+  const dropdownCompanies = useMemo(() => {
+    if (!selectedCompany || entryCompanies.some((company) => company.id === selectedCompany.id)) return entryCompanies;
+    return [...entryCompanies, selectedCompany];
+  }, [entryCompanies, selectedCompany]);
+  const entryCompanyIds = useMemo(() => new Set(entryCompanies.map((company) => company.id)), [entryCompanies]);
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
   const showHopControl = view === "radial" || view === "hierarchy";
   const showGroupControl = view === "network" || view === "radial";
@@ -123,9 +121,13 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
       <section className={styles.toolbar} aria-label="企業関係マップの表示条件">
         <div className={styles.controlRow}>
           <label className={styles.companySelect}>
-            <span>中心企業</span>
+            <span>中心企業（入口）</span>
             <select value={selectedCompanyId} onChange={(event) => selectCompany(event.target.value)}>
-              {selectableCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
+              {dropdownCompanies.map((company) => (
+                <option key={company.id} value={company.id}>
+                  {company.name}{entryCompanyIds.has(company.id) ? "" : "（フォーカス中）"}
+                </option>
+              ))}
             </select>
           </label>
           <input className={styles.search} type="search" value={query} placeholder="企業名・関係を検索" aria-label="企業関係を検索" onChange={(event) => setQuery(event.target.value)} />
@@ -183,7 +185,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <DetailPanel company={selectedCompany} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} />
       </div>
 
-      <p className={styles.note}>企業グループ所属は親子・支配関係とは別エッジです。系列ビューには混ぜません。関係の表示は保存済み事実の閲覧であり、業績連動や投資判断を自動推論しません。</p>
+      <p className={styles.note}>中心企業の入口候補は上場企業または下流relationを持つ企業です。接続先の企業もグラフから一時フォーカスできます。企業グループ所属は親子・支配関係とは別エッジで、系列ビューには混ぜません。</p>
     </main>
   );
 }

--- a/app/premium/company-network/entry-companies.test.ts
+++ b/app/premium/company-network/entry-companies.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildEntryCompanies } from "./entry-companies";
+import type { CompanyNetworkCompany, CompanyRelationship } from "./types";
+
+const companies: CompanyNetworkCompany[] = [
+  { id: "toyota", name: "トヨタ自動車", countryCode: "JP", listingStatus: "domestic_listed", status: "active" },
+  { id: "woven", name: "ウーブン・バイ・トヨタ", countryCode: "JP", listingStatus: "private", status: "active" },
+  { id: "denso", name: "デンソー", countryCode: "JP", listingStatus: "domestic_listed", status: "active" },
+  { id: "private-parent", name: "非上場親会社", countryCode: "JP", listingStatus: "private", status: "active" },
+];
+
+const relationships = [
+  {
+    relationId: "r1",
+    sourceCompanyId: "toyota",
+    sourceCompanyName: "トヨタ自動車",
+    targetCompanyId: "woven",
+    targetCompanyName: "ウーブン・バイ・トヨタ",
+    relationCategory: "capital",
+    relationType: "equity_ownership",
+    ownershipPct: 100,
+    votingRightsPct: null,
+    isConsolidated: null,
+    note: "",
+    verificationStatus: "verified",
+    confidence: "high",
+    sourceTitle: null,
+    sourceUrl: null,
+    sourceType: null,
+    sourceAsOf: null,
+    checkedAt: null,
+  },
+  {
+    relationId: "r2",
+    sourceCompanyId: "private-parent",
+    sourceCompanyName: "非上場親会社",
+    targetCompanyId: "woven",
+    targetCompanyName: "ウーブン・バイ・トヨタ",
+    relationCategory: "control",
+    relationType: "controls",
+    ownershipPct: null,
+    votingRightsPct: null,
+    isConsolidated: null,
+    note: "",
+    verificationStatus: "verified",
+    confidence: "high",
+    sourceTitle: null,
+    sourceUrl: null,
+    sourceType: null,
+    sourceAsOf: null,
+    checkedAt: null,
+  },
+] satisfies CompanyRelationship[];
+
+describe("buildEntryCompanies", () => {
+  it("keeps listed companies and outbound relationship sources as entry candidates", () => {
+    expect(buildEntryCompanies(companies, relationships).map((company) => company.id)).toEqual([
+      "toyota",
+      "denso",
+      "private-parent",
+    ]);
+  });
+
+  it("does not promote a private target-only company to the entry selector", () => {
+    expect(buildEntryCompanies(companies, relationships).some((company) => company.id === "woven")).toBe(false);
+  });
+});

--- a/app/premium/company-network/entry-companies.ts
+++ b/app/premium/company-network/entry-companies.ts
@@ -1,0 +1,13 @@
+import type { CompanyNetworkCompany, CompanyRelationship } from "./types";
+
+export function buildEntryCompanies(
+  companies: CompanyNetworkCompany[],
+  relationships: CompanyRelationship[],
+) {
+  const outboundCompanyIds = new Set(relationships.map((relationship) => relationship.sourceCompanyId));
+  const entries = companies.filter(
+    (company) => company.listingStatus === "domestic_listed" || outboundCompanyIds.has(company.id),
+  );
+
+  return entries.length > 0 ? entries : companies;
+}


### PR DESCRIPTION
## 概要
Issue #508 のUI部分として、企業関係マップの「中心企業候補」とグラフ上でフォーカス可能な企業を分離します。

## UI変更
- 中心企業候補 = domestic_listed または outbound company relation のsource企業
- privateかつtarget-onlyの企業（現状のWoven等）は入口プルダウンから除外
- グラフ上の企業ノードからは従来どおり一時フォーカス可能
- 一時フォーカス中はプルダウンに `（フォーカス中）` として一時表示
- 1-hop/2-hopは入口候補判定に使わない
- entry candidate判定のunit test追加

## Supabase実データ（同Issueで先行反映済み）
Toyota公式2026年6月グループ一覧に基づき、未登録15社をcompany entityとして追加し、official_group_memberをverified登録。既存Toyota/Wovenを含めToyota Group membershipは17社。

さらにToyota公式国内生産拠点ページの「トヨタ自動車の100％出資会社」表記を根拠に、以下4社へのequity_ownership 100%をverified追加。
- トヨタ車体
- トヨタ自動車東日本
- トヨタ自動車九州
- ダイハツ工業

既存Woven 100%と合わせToyota outbound 100% relationは5件。

豊田自動織機は2026-06-01上場廃止済みのためprivateとしてentity登録。

## 原則
- group membership と capital/control relationを混同しない
- 日野自動車は2026年6月の現行Toyota公式グループ一覧にないため今回追加しない
- DB schema変更なし
- migration driftは #498 の対象

## 確認
- [ ] lint
- [ ] test
- [ ] build

Closes #508