### PR TITLE
refactor(company-network): 初期ロード軽量化と操作分離

### DIFF
--- a/app/api/premium/company-network/route.ts
+++ b/app/api/premium/company-network/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
+import { isSyncConfigured } from "@/lib/supabase/config";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { loadCompanyNetworkScope } from "@/app/premium/company-network/data-loader";
+import type { RelationCategory } from "@/app/premium/company-network/types";
+
+const VALID_CATEGORIES = new Set<RelationCategory>(["capital", "control", "historical"]);
+
+export async function GET(request: Request) {
+  const cookieStore = await cookies();
+  const session = cookieStore.get(PREMIUM_COOKIE_NAME)?.value;
+  if (!verifyPremiumSession(session)) {
+    return NextResponse.json({ status: "unauthenticated", data: null, message: "Premium認証が必要です。" }, { status: 401 });
+  }
+  if (!isSyncConfigured()) {
+    return NextResponse.json({ status: "unconfigured", data: null, message: "Supabase連携が未設定です。" }, { status: 503 });
+  }
+
+  const url = new URL(request.url);
+  const companyId = url.searchParams.get("companyId")?.trim() ?? "";
+  const hops = url.searchParams.get("hops") === "1" ? 1 : 2;
+  const verifiedOnly = url.searchParams.get("verifiedOnly") !== "false";
+  const includeGroups = url.searchParams.get("includeGroups") !== "false";
+  const categories = (url.searchParams.get("categories") ?? "capital,control,historical")
+    .split(",")
+    .filter((value): value is RelationCategory => VALID_CATEGORIES.has(value as RelationCategory));
+
+  if (!companyId) {
+    return NextResponse.json({ status: "error", data: null, message: "companyIdが必要です。" }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ status: "unauthenticated", data: null, message: "Supabaseにログインしてください。" }, { status: 401 });
+  }
+
+  const result = await loadCompanyNetworkScope(supabase, {
+    companyId,
+    hops,
+    verifiedOnly,
+    categories,
+    includeGroups,
+  });
+  return NextResponse.json(result, { status: result.status === "error" ? 500 : 200 });
+}

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styles from "./CompanyNetwork.module.css";
-import { buildEntryCompanies } from "./entry-companies";
 import { CATEGORY_LABEL, VIEWS, type CompanyNetworkViewMode } from "./presentation";
-import type { CompanyNetworkLoadResult, RelationCategory } from "./types";
+import type {
+  CompanyNetworkBootstrapResult,
+  CompanyNetworkData,
+  CompanyNetworkScopeResult,
+  RelationCategory,
+} from "./types";
 import DetailPanel from "./views/DetailPanel";
 import HierarchyView from "./views/HierarchyView";
 import NetworkView from "./views/NetworkView";
@@ -28,18 +32,12 @@ function StateScreen({ title, body }: { title: string; body: string }) {
   );
 }
 
-export default function CompanyNetworkClient({ result }: { result: CompanyNetworkLoadResult }) {
-  const data = result.data;
-  const entryCompanies = useMemo(() => {
-    if (!data) return [];
-    return buildEntryCompanies(data.companies, data.relationships);
-  }, [data]);
-  const defaultCompanyId =
-    entryCompanies.find((company) => company.name === "トヨタ自動車")?.id ??
-    entryCompanies[0]?.id ??
-    "";
+export default function CompanyNetworkClient({ result }: { result: CompanyNetworkBootstrapResult }) {
+  const bootstrap = result.data;
+  const defaultCompanyId = bootstrap?.defaultCompanyId ?? "";
 
   const [view, setView] = useState<CompanyNetworkViewMode>("network");
+  const [centerCompanyId, setCenterCompanyId] = useState(defaultCompanyId);
   const [selectedCompanyId, setSelectedCompanyId] = useState(defaultCompanyId);
   const [selectedRelationId, setSelectedRelationId] = useState<string | null>(null);
   const [hops, setHops] = useState<1 | 2>(2);
@@ -47,35 +45,68 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const [verifiedOnly, setVerifiedOnly] = useState(true);
   const [showGroups, setShowGroups] = useState(true);
   const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<CompanyNetworkData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
-  const relationships = useMemo(() => {
-    if (!data) return [];
-    return data.relationships.filter(
-      (relationship) =>
-        categories.has(relationship.relationCategory) &&
-        (!verifiedOnly || relationship.verificationStatus === "verified"),
-    );
-  }, [categories, data, verifiedOnly]);
+  const categoryKey = useMemo(() => [...categories].sort().join(","), [categories]);
 
-  const memberships = useMemo(() => {
-    if (!data || !showGroups) return [];
-    return data.memberships.filter(
-      (membership) => !verifiedOnly || membership.verificationStatus === "verified",
-    );
-  }, [data, showGroups, verifiedOnly]);
+  useEffect(() => {
+    if (!centerCompanyId) return;
+    const controller = new AbortController();
+    const params = new URLSearchParams({
+      companyId: centerCompanyId,
+      hops: String(hops),
+      verifiedOnly: String(verifiedOnly),
+      includeGroups: String(showGroups),
+      categories: categoryKey,
+    });
 
-  const selectedCompany = data?.companies.find((company) => company.id === selectedCompanyId) ?? null;
+    setLoading(true);
+    setLoadError(null);
+    fetch(`/api/premium/company-network?${params.toString()}`, {
+      credentials: "same-origin",
+      signal: controller.signal,
+      cache: "no-store",
+    })
+      .then(async (response) => {
+        const payload = await response.json() as CompanyNetworkScopeResult;
+        if (!response.ok || payload.status === "error" || payload.status === "unauthenticated" || payload.status === "unconfigured") {
+          throw new Error(payload.message);
+        }
+        return payload.data;
+      })
+      .then((data) => {
+        setScope(data);
+        setSelectedRelationId(null);
+        setSelectedCompanyId((current) => data.companies.some((company) => company.id === current) ? current : centerCompanyId);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setLoadError(error instanceof Error ? error.message : "企業関係の取得に失敗しました。");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [categoryKey, centerCompanyId, hops, showGroups, verifiedOnly]);
+
+  const relationships = scope?.relationships ?? [];
+  const memberships = showGroups ? (scope?.memberships ?? []) : [];
+  const selectedCompany = scope?.companies.find((company) => company.id === selectedCompanyId) ?? null;
   const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
-  const dropdownCompanies = useMemo(() => {
-    if (!selectedCompany || entryCompanies.some((company) => company.id === selectedCompany.id)) return entryCompanies;
-    return [...entryCompanies, selectedCompany];
-  }, [entryCompanies, selectedCompany]);
-  const entryCompanyIds = useMemo(() => new Set(entryCompanies.map((company) => company.id)), [entryCompanies]);
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
   const showHopControl = view === "radial" || view === "hierarchy";
   const showGroupControl = view === "network" || view === "radial";
 
-  const selectCompany = (companyId: string) => {
+  const selectNode = (companyId: string) => {
+    setSelectedCompanyId(companyId);
+    setSelectedRelationId(null);
+  };
+
+  const changeCenter = (companyId: string) => {
+    setCenterCompanyId(companyId);
     setSelectedCompanyId(companyId);
     setSelectedRelationId(null);
   };
@@ -93,7 +124,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   if (result.status === "unconfigured") return <StateScreen title="Supabase 連携が未設定です" body={result.message} />;
   if (result.status === "unauthenticated") return <StateScreen title="Supabase にログインしてください" body={result.message} />;
   if (result.status === "error") return <StateScreen title="企業関係マップを取得できませんでした" body={`${result.message} 0件ではなく取得失敗です。`} />;
-  if (!data || data.companies.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "企業関係を登録するとここに表示されます。"} />;
+  if (!bootstrap || bootstrap.entryCompanies.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "中心企業候補を登録するとここに表示されます。"} />;
 
   return (
     <main className={styles.page}>
@@ -106,15 +137,15 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.heroHead}>
           <div>
             <h1 className={styles.heroTitle}>企業関係マップ</h1>
-            <p className={styles.heroLead}>資本・支配・歴史的関係と企業グループ所属を、4つの表現で切り替えて確認します。閲覧専用です。</p>
+            <p className={styles.heroLead}>入口一覧だけを先に読み込み、選択した企業の周辺データを必要な時だけ取得します。閲覧専用です。</p>
           </div>
-          <span className={styles.versionBadge}>company-network v2</span>
+          <span className={styles.versionBadge}>company-network v3</span>
         </div>
         <div className={styles.statRow}>
-          <div className={styles.stat}><span>企業</span><strong>{data.companies.length}</strong><small>社</small></div>
-          <div className={styles.stat}><span>企業間関係</span><strong>{data.relationships.length}</strong><small>件</small></div>
-          <div className={styles.stat}><span>グループ所属</span><strong>{data.memberships.length}</strong><small>件</small></div>
-          <div className={styles.stat}><span>表示中</span><strong>{relationships.length}</strong><small>関係</small></div>
+          <div className={styles.stat}><span>入口企業</span><strong>{bootstrap.entryCompanies.length}</strong><small>社</small></div>
+          <div className={styles.stat}><span>企業グループ</span><strong>{bootstrap.groups.length}</strong><small>件</small></div>
+          <div className={styles.stat}><span>表示企業</span><strong>{scope?.companies.length ?? 0}</strong><small>社</small></div>
+          <div className={styles.stat}><span>表示関係</span><strong>{relationships.length}</strong><small>件</small></div>
         </div>
       </header>
 
@@ -122,12 +153,8 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.controlRow}>
           <label className={styles.companySelect}>
             <span>中心企業（入口）</span>
-            <select value={selectedCompanyId} onChange={(event) => selectCompany(event.target.value)}>
-              {dropdownCompanies.map((company) => (
-                <option key={company.id} value={company.id}>
-                  {company.name}{entryCompanyIds.has(company.id) ? "" : "（フォーカス中）"}
-                </option>
-              ))}
+            <select value={centerCompanyId} onChange={(event) => changeCenter(event.target.value)}>
+              {bootstrap.entryCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
             </select>
           </label>
           <input className={styles.search} type="search" value={query} placeholder="企業名・関係を検索" aria-label="企業関係を検索" onChange={(event) => setQuery(event.target.value)} />
@@ -174,18 +201,20 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
       </section>
 
       <div className={styles.workspace}>
-        <section className={styles.canvas}>
-          {relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在のフィルタ条件では表示できる関係がありません。</p> : null}
-          {view === "network" ? <NetworkView companies={data.companies} relationships={relationships} memberships={memberships} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
-          {view === "radial" ? <RadialView companies={data.companies} relationships={relationships} memberships={memberships} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
-          {view === "hierarchy" ? <HierarchyView companies={data.companies} relationships={relationships} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
-          {view === "table" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} /> : null}
+        <section className={styles.canvas} aria-busy={loading}>
+          {loading && !scope ? <p className={styles.empty}>選択企業の関係を読み込んでいます…</p> : null}
+          {loadError ? <p className={styles.empty}>{loadError}</p> : null}
+          {!loading && scope && relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在の条件では表示できる関係がありません。</p> : null}
+          {scope && view === "network" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "radial" ? <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "hierarchy" ? <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "table" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectNode} /> : null}
         </section>
 
-        <DetailPanel company={selectedCompany} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} />
+        <DetailPanel company={selectedCompany} centerCompanyId={centerCompanyId} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
       </div>
 
-      <p className={styles.note}>中心企業の入口候補は上場企業または下流relationを持つ企業です。接続先の企業もグラフから一時フォーカスできます。企業グループ所属は親子・支配関係とは別エッジで、系列ビューには混ぜません。</p>
+      <p className={styles.note}>ノード選択は詳細と強調だけを変え、配置は動かしません。中心企業を変える場合だけ周辺データを再取得し、「再配置」は同じノード集合の位置だけを計算し直します。</p>
     </main>
   );
 }

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -18,6 +18,9 @@ import TableView from "./views/TableView";
 
 const ALL_CATEGORIES: readonly RelationCategory[] = ["capital", "control", "historical"];
 
+type ScopedState = { key: string; data: CompanyNetworkData };
+type ScopedError = { key: string; message: string };
+
 function StateScreen({ title, body }: { title: string; body: string }) {
   return (
     <main className={styles.page}>
@@ -45,11 +48,14 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const [verifiedOnly, setVerifiedOnly] = useState(true);
   const [showGroups, setShowGroups] = useState(true);
   const [query, setQuery] = useState("");
-  const [scope, setScope] = useState<CompanyNetworkData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [scopedState, setScopedState] = useState<ScopedState | null>(null);
+  const [scopedError, setScopedError] = useState<ScopedError | null>(null);
 
   const categoryKey = useMemo(() => [...categories].sort().join(","), [categories]);
+  const requestKey = `${centerCompanyId}|${hops}|${verifiedOnly ? "v" : "all"}|${showGroups ? "g" : "nog"}|${categoryKey}`;
+  const scope = scopedState?.key === requestKey ? scopedState.data : null;
+  const loadError = scopedError?.key === requestKey ? scopedError.message : null;
+  const loading = Boolean(centerCompanyId) && scope === null && loadError === null;
 
   useEffect(() => {
     if (!centerCompanyId) return;
@@ -61,9 +67,8 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
       includeGroups: String(showGroups),
       categories: categoryKey,
     });
+    const key = requestKey;
 
-    setLoading(true);
-    setLoadError(null);
     fetch(`/api/premium/company-network?${params.toString()}`, {
       credentials: "same-origin",
       signal: controller.signal,
@@ -77,23 +82,22 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         return payload.data;
       })
       .then((data) => {
-        setScope(data);
+        if (controller.signal.aborted) return;
+        setScopedState({ key, data });
+        setScopedError(null);
         setSelectedRelationId(null);
         setSelectedCompanyId((current) => data.companies.some((company) => company.id === current) ? current : centerCompanyId);
       })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
-        setLoadError(error instanceof Error ? error.message : "企業関係の取得に失敗しました。");
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+        setScopedError({ key, message: error instanceof Error ? error.message : "企業関係の取得に失敗しました。" });
       });
 
     return () => controller.abort();
-  }, [categoryKey, centerCompanyId, hops, showGroups, verifiedOnly]);
+  }, [categoryKey, centerCompanyId, hops, requestKey, showGroups, verifiedOnly]);
 
   const relationships = scope?.relationships ?? [];
-  const memberships = showGroups ? (scope?.memberships ?? []) : [];
+  const memberships = scope?.memberships ?? [];
   const selectedCompany = scope?.companies.find((company) => company.id === selectedCompanyId) ?? null;
   const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
@@ -137,7 +141,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.heroHead}>
           <div>
             <h1 className={styles.heroTitle}>企業関係マップ</h1>
-            <p className={styles.heroLead}>入口一覧だけを先に読み込み、選択した企業の周辺データを必要な時だけ取得します。閲覧専用です。</p>
+            <p className={styles.heroLead}>企業グループと入口企業だけを先に読み込み、選択した企業の周辺データを必要な時だけ取得します。閲覧専用です。</p>
           </div>
           <span className={styles.versionBadge}>company-network v3</span>
         </div>
@@ -202,7 +206,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
       <div className={styles.workspace}>
         <section className={styles.canvas} aria-busy={loading}>
-          {loading && !scope ? <p className={styles.empty}>選択企業の関係を読み込んでいます…</p> : null}
+          {loading ? <p className={styles.empty}>選択企業の関係を読み込んでいます…</p> : null}
           {loadError ? <p className={styles.empty}>{loadError}</p> : null}
           {!loading && scope && relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在の条件では表示できる関係がありません。</p> : null}
           {scope && view === "network" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -37,6 +37,7 @@ function StateScreen({ title, body }: { title: string; body: string }) {
 
 export default function CompanyNetworkClient({ result }: { result: CompanyNetworkBootstrapResult }) {
   const bootstrap = result.data;
+  const entryCompanies = bootstrap?.entryCompanies ?? [];
   const defaultCompanyId = bootstrap?.defaultCompanyId ?? "";
 
   const [view, setView] = useState<CompanyNetworkViewMode>("network");
@@ -56,6 +57,11 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const scope = scopedState?.key === requestKey ? scopedState.data : null;
   const loadError = scopedError?.key === requestKey ? scopedError.message : null;
   const loading = Boolean(centerCompanyId) && scope === null && loadError === null;
+  const entryCompanyIds = useMemo(() => new Set(entryCompanies.map((company) => company.id)), [entryCompanies]);
+  const temporaryCenter = entryCompanyIds.has(centerCompanyId)
+    ? null
+    : scopedState?.data.companies.find((company) => company.id === centerCompanyId) ?? null;
+  const dropdownCompanies = temporaryCenter ? [...entryCompanies, temporaryCenter] : entryCompanies;
 
   useEffect(() => {
     if (!centerCompanyId) return;
@@ -128,7 +134,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   if (result.status === "unconfigured") return <StateScreen title="Supabase 連携が未設定です" body={result.message} />;
   if (result.status === "unauthenticated") return <StateScreen title="Supabase にログインしてください" body={result.message} />;
   if (result.status === "error") return <StateScreen title="企業関係マップを取得できませんでした" body={`${result.message} 0件ではなく取得失敗です。`} />;
-  if (!bootstrap || bootstrap.entryCompanies.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "中心企業候補を登録するとここに表示されます。"} />;
+  if (!bootstrap || entryCompanies.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "中心企業候補を登録するとここに表示されます。"} />;
 
   return (
     <main className={styles.page}>
@@ -146,7 +152,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           <span className={styles.versionBadge}>company-network v3</span>
         </div>
         <div className={styles.statRow}>
-          <div className={styles.stat}><span>入口企業</span><strong>{bootstrap.entryCompanies.length}</strong><small>社</small></div>
+          <div className={styles.stat}><span>入口企業</span><strong>{entryCompanies.length}</strong><small>社</small></div>
           <div className={styles.stat}><span>企業グループ</span><strong>{bootstrap.groups.length}</strong><small>件</small></div>
           <div className={styles.stat}><span>表示企業</span><strong>{scope?.companies.length ?? 0}</strong><small>社</small></div>
           <div className={styles.stat}><span>表示関係</span><strong>{relationships.length}</strong><small>件</small></div>
@@ -158,7 +164,11 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           <label className={styles.companySelect}>
             <span>中心企業（入口）</span>
             <select value={centerCompanyId} onChange={(event) => changeCenter(event.target.value)}>
-              {bootstrap.entryCompanies.map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
+              {dropdownCompanies.map((company) => (
+                <option key={company.id} value={company.id}>
+                  {company.name}{entryCompanyIds.has(company.id) ? "" : "（中心表示中）"}
+                </option>
+              ))}
             </select>
           </label>
           <input className={styles.search} type="search" value={query} placeholder="企業名・関係を検索" aria-label="企業関係を検索" onChange={(event) => setQuery(event.target.value)} />

--- a/app/premium/company-network/data-loader.ts
+++ b/app/premium/company-network/data-loader.ts
@@ -17,6 +17,10 @@ const RELATION_CATEGORIES: readonly string[] = ["capital", "control", "historica
 const VERIFICATION_STATUSES: readonly string[] = ["proposed", "verified", "rejected", "superseded"];
 const CONFIDENCES: readonly string[] = ["high", "medium", "low"];
 const COMPANY_SELECT = "id,display_name,country_code,listing_status,status";
+const RELATIONSHIP_SELECT =
+  "relation_id,source_company_id,source_company_name,target_company_id,target_company_name," +
+  "relation_category,relation_type,ownership_pct,voting_rights_pct,is_consolidated,relation_note," +
+  "verification_status,confidence,source_title,source_url,source_type,source_as_of,checked_at,valid_to";
 const MEMBERSHIP_SELECT =
   "membership_id,company_entity_id,company_name,group_id,group_slug,group_name,group_type," +
   "membership_role,membership_basis,relation_note,verification_status,confidence," +
@@ -149,17 +153,16 @@ export function companyNetworkAuthRequired(): CompanyNetworkBootstrapResult {
 }
 
 export async function loadCompanyNetworkBootstrap(supabase: SupabaseClient): Promise<CompanyNetworkBootstrapResult> {
-  const [listedResult, outboundResult, groupsResult] = await Promise.all([
-    supabase
-      .from("stock_notes_company_entities")
-      .select(COMPANY_SELECT)
-      .eq("listing_status", "domestic_listed")
-      .neq("status", "archived")
-      .order("display_name", { ascending: true })
-      .limit(ROW_LIMIT),
+  const [outboundResult, membershipIdsResult, groupsResult] = await Promise.all([
     supabase
       .from("stock_notes_company_relationship_edges_v")
       .select("source_company_id")
+      .is("valid_to", null)
+      .in("verification_status", ["verified", "proposed"])
+      .limit(ROW_LIMIT),
+    supabase
+      .from("stock_notes_company_group_memberships_v")
+      .select("company_entity_id")
       .is("valid_to", null)
       .in("verification_status", ["verified", "proposed"])
       .limit(ROW_LIMIT),
@@ -173,33 +176,42 @@ export async function loadCompanyNetworkBootstrap(supabase: SupabaseClient): Pro
       .limit(ROW_LIMIT),
   ]);
 
-  if (listedResult.error || outboundResult.error || groupsResult.error) {
+  if (outboundResult.error || membershipIdsResult.error || groupsResult.error) {
     return { status: "error", data: null, message: "企業関係マップの入口一覧を取得できませんでした。" };
   }
 
-  const listed = ((listedResult.data ?? []) as unknown as Row[]).map(parseCompany).filter((row): row is CompanyNetworkCompany => row !== null);
-  const listedIds = new Set(listed.map((company) => company.id));
-  const outboundIds = [...new Set(((outboundResult.data ?? []) as unknown as Row[]).map((row) => nullableString(row, "source_company_id")).filter((id): id is string => Boolean(id)))];
-  const missingOutboundIds = outboundIds.filter((id) => !listedIds.has(id));
+  const outboundIds = new Set(
+    ((outboundResult.data ?? []) as unknown as Row[])
+      .map((row) => nullableString(row, "source_company_id"))
+      .filter((id): id is string => Boolean(id)),
+  );
+  const membershipIds = ((membershipIdsResult.data ?? []) as unknown as Row[])
+    .map((row) => nullableString(row, "company_entity_id"))
+    .filter((id): id is string => Boolean(id));
+  const candidateIds = [...new Set([...outboundIds, ...membershipIds])];
 
-  let outboundCompanies: CompanyNetworkCompany[] = [];
-  if (missingOutboundIds.length > 0) {
-    const outboundCompaniesResult = await supabase
+  let candidates: CompanyNetworkCompany[] = [];
+  if (candidateIds.length > 0) {
+    const candidatesResult = await supabase
       .from("stock_notes_company_entities")
       .select(COMPANY_SELECT)
-      .in("id", missingOutboundIds)
+      .in("id", candidateIds)
       .neq("status", "archived")
       .order("display_name", { ascending: true });
-    if (outboundCompaniesResult.error) {
+    if (candidatesResult.error) {
       return { status: "error", data: null, message: "中心企業候補を取得できませんでした。" };
     }
-    outboundCompanies = ((outboundCompaniesResult.data ?? []) as unknown as Row[]).map(parseCompany).filter((row): row is CompanyNetworkCompany => row !== null);
+    candidates = ((candidatesResult.data ?? []) as unknown as Row[])
+      .map(parseCompany)
+      .filter((row): row is CompanyNetworkCompany => row !== null);
   }
 
-  const entryCompanies = [...listed, ...outboundCompanies]
-    .filter((company, index, rows) => rows.findIndex((row) => row.id === company.id) === index)
+  const entryCompanies = candidates
+    .filter((company) => company.listingStatus === "domestic_listed" || outboundIds.has(company.id))
     .sort((a, b) => a.name.localeCompare(b.name, "ja"));
-  const groups = ((groupsResult.data ?? []) as unknown as Row[]).map(parseGroup).filter((row): row is CompanyNetworkGroup => row !== null);
+  const groups = ((groupsResult.data ?? []) as unknown as Row[])
+    .map(parseGroup)
+    .filter((row): row is CompanyNetworkGroup => row !== null);
 
   if (entryCompanies.length === 0) {
     return { status: "empty", data: { entryCompanies: [], groups, defaultCompanyId: "" }, message: "中心企業候補がまだありません。" };
@@ -220,55 +232,78 @@ export async function loadCompanyNetworkScope(
   },
 ): Promise<CompanyNetworkScopeResult> {
   const statuses = options.verifiedOnly ? ["verified"] : ["verified", "proposed"];
-  const networkResult = await supabase.rpc("stock_notes_company_network", {
-    p_company_id: options.companyId,
-    p_max_hops: options.hops,
-    p_verified_only: options.verifiedOnly,
-    p_active_only: true,
-    p_relation_categories: options.categories.length > 0 ? options.categories : null,
-  });
 
-  if (networkResult.error) {
-    return { status: "error", data: null, message: "選択企業の企業間関係を取得できませんでした。" };
+  let relationshipIds: string[] = [];
+  if (options.categories.length > 0) {
+    const networkResult = await supabase.rpc("stock_notes_company_network", {
+      p_company_id: options.companyId,
+      p_max_hops: options.hops,
+      p_verified_only: options.verifiedOnly,
+      p_active_only: true,
+      p_relation_categories: options.categories,
+    });
+    if (networkResult.error) {
+      return { status: "error", data: null, message: "選択企業の企業間関係を取得できませんでした。" };
+    }
+    relationshipIds = [...new Set(
+      ((networkResult.data ?? []) as unknown as Row[])
+        .map((row) => nullableString(row, "relation_id"))
+        .filter((id): id is string => Boolean(id)),
+    )];
   }
 
-  const relationships = ((networkResult.data ?? []) as unknown as Row[])
-    .map(parseRelationship)
-    .filter((row): row is CompanyRelationship => row !== null);
-
-  const centerMembershipResult = await supabase
-    .from("stock_notes_company_group_memberships_v")
-    .select(MEMBERSHIP_SELECT)
-    .eq("company_entity_id", options.companyId)
-    .is("valid_to", null)
-    .in("verification_status", statuses)
-    .limit(ROW_LIMIT);
-
-  if (centerMembershipResult.error) {
-    return { status: "error", data: null, message: "選択企業のグループ所属を取得できませんでした。" };
-  }
-
-  const centerMemberships = ((centerMembershipResult.data ?? []) as unknown as Row[])
-    .map(parseMembership)
-    .filter((row): row is CompanyGroupMembership => row !== null);
-  const groupIds = [...new Set(centerMemberships.map((membership) => membership.groupId))];
-
-  let memberships = centerMemberships;
-  if (options.includeGroups && groupIds.length > 0) {
-    const groupMembershipResult = await supabase
-      .from("stock_notes_company_group_memberships_v")
-      .select(MEMBERSHIP_SELECT)
-      .in("group_id", groupIds)
+  let relationships: CompanyRelationship[] = [];
+  if (relationshipIds.length > 0) {
+    const relationshipResult = await supabase
+      .from("stock_notes_company_relationship_edges_v")
+      .select(RELATIONSHIP_SELECT)
+      .in("relation_id", relationshipIds)
       .is("valid_to", null)
       .in("verification_status", statuses)
-      .order("company_name", { ascending: true })
-      .limit(ROW_LIMIT);
-    if (groupMembershipResult.error) {
-      return { status: "error", data: null, message: "所属グループの企業一覧を取得できませんでした。" };
+      .order("source_company_name", { ascending: true });
+    if (relationshipResult.error) {
+      return { status: "error", data: null, message: "企業関係の根拠情報を取得できませんでした。" };
     }
-    memberships = ((groupMembershipResult.data ?? []) as unknown as Row[])
+    relationships = ((relationshipResult.data ?? []) as unknown as Row[])
+      .map(parseRelationship)
+      .filter((row): row is CompanyRelationship => row !== null);
+  }
+
+  let memberships: CompanyGroupMembership[] = [];
+  if (options.includeGroups) {
+    const centerMembershipResult = await supabase
+      .from("stock_notes_company_group_memberships_v")
+      .select(MEMBERSHIP_SELECT)
+      .eq("company_entity_id", options.companyId)
+      .is("valid_to", null)
+      .in("verification_status", statuses)
+      .limit(ROW_LIMIT);
+
+    if (centerMembershipResult.error) {
+      return { status: "error", data: null, message: "選択企業のグループ所属を取得できませんでした。" };
+    }
+
+    const centerMemberships = ((centerMembershipResult.data ?? []) as unknown as Row[])
       .map(parseMembership)
       .filter((row): row is CompanyGroupMembership => row !== null);
+    const groupIds = [...new Set(centerMemberships.map((membership) => membership.groupId))];
+
+    if (groupIds.length > 0) {
+      const groupMembershipResult = await supabase
+        .from("stock_notes_company_group_memberships_v")
+        .select(MEMBERSHIP_SELECT)
+        .in("group_id", groupIds)
+        .is("valid_to", null)
+        .in("verification_status", statuses)
+        .order("company_name", { ascending: true })
+        .limit(ROW_LIMIT);
+      if (groupMembershipResult.error) {
+        return { status: "error", data: null, message: "所属グループの企業一覧を取得できませんでした。" };
+      }
+      memberships = ((groupMembershipResult.data ?? []) as unknown as Row[])
+        .map(parseMembership)
+        .filter((row): row is CompanyGroupMembership => row !== null);
+    }
   }
 
   const companyIds = new Set<string>([options.companyId]);

--- a/app/premium/company-network/data-loader.ts
+++ b/app/premium/company-network/data-loader.ts
@@ -1,9 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   CompanyGroupMembership,
+  CompanyNetworkBootstrapResult,
   CompanyNetworkCompany,
   CompanyNetworkData,
-  CompanyNetworkLoadResult,
+  CompanyNetworkGroup,
+  CompanyNetworkScopeResult,
   CompanyRelationship,
   Confidence,
   RelationCategory,
@@ -14,6 +16,11 @@ const ROW_LIMIT = 2000;
 const RELATION_CATEGORIES: readonly string[] = ["capital", "control", "historical"];
 const VERIFICATION_STATUSES: readonly string[] = ["proposed", "verified", "rejected", "superseded"];
 const CONFIDENCES: readonly string[] = ["high", "medium", "low"];
+const COMPANY_SELECT = "id,display_name,country_code,listing_status,status";
+const MEMBERSHIP_SELECT =
+  "membership_id,company_entity_id,company_name,group_id,group_slug,group_name,group_type," +
+  "membership_role,membership_basis,relation_note,verification_status,confidence," +
+  "source_title,source_url,source_type,source_as_of,valid_to";
 
 type Row = Record<string, unknown>;
 
@@ -70,17 +77,10 @@ function parseRelationship(row: Row): CompanyRelationship | null {
   const verificationStatus = oneOf<VerificationStatus>(row, "verification_status", VERIFICATION_STATUSES);
   const confidence = oneOf<Confidence>(row, "confidence", CONFIDENCES);
   if (
-    !relationId ||
-    !sourceCompanyId ||
-    !sourceCompanyName ||
-    !targetCompanyId ||
-    !targetCompanyName ||
-    !relationCategory ||
-    !verificationStatus ||
-    !confidence
-  ) {
-    return null;
-  }
+    !relationId || !sourceCompanyId || !sourceCompanyName || !targetCompanyId || !targetCompanyName ||
+    !relationCategory || !verificationStatus || !confidence
+  ) return null;
+
   return {
     relationId,
     sourceCompanyId,
@@ -111,9 +111,8 @@ function parseMembership(row: Row): CompanyGroupMembership | null {
   const groupName = nullableString(row, "group_name");
   const verificationStatus = oneOf<VerificationStatus>(row, "verification_status", VERIFICATION_STATUSES);
   const confidence = oneOf<Confidence>(row, "confidence", CONFIDENCES);
-  if (!membershipId || !companyId || !companyName || !groupId || !groupName || !verificationStatus || !confidence) {
-    return null;
-  }
+  if (!membershipId || !companyId || !companyName || !groupId || !groupName || !verificationStatus || !confidence) return null;
+
   return {
     membershipId,
     companyId,
@@ -134,79 +133,166 @@ function parseMembership(row: Row): CompanyGroupMembership | null {
   };
 }
 
-export function companyNetworkUnconfigured(): CompanyNetworkLoadResult {
-  return {
-    status: "unconfigured",
-    data: null,
-    message: "Supabase 連携が未設定のため企業関係マップを取得できません。",
-  };
+function parseGroup(row: Row): CompanyNetworkGroup | null {
+  const id = nullableString(row, "id");
+  const name = nullableString(row, "display_name");
+  if (!id || !name) return null;
+  return { id, name, groupType: stringValue(row, "group_type") };
 }
 
-export function companyNetworkAuthRequired(): CompanyNetworkLoadResult {
-  return {
-    status: "unauthenticated",
-    data: null,
-    message: "Supabase にログインすると、保存済みの企業関係マップを表示します。",
-  };
+export function companyNetworkUnconfigured(): CompanyNetworkBootstrapResult {
+  return { status: "unconfigured", data: null, message: "Supabase 連携が未設定のため企業関係マップを取得できません。" };
 }
 
-export async function loadCompanyNetwork(supabase: SupabaseClient): Promise<CompanyNetworkLoadResult> {
-  const [companiesResult, relationshipsResult, membershipsResult] = await Promise.all([
+export function companyNetworkAuthRequired(): CompanyNetworkBootstrapResult {
+  return { status: "unauthenticated", data: null, message: "Supabase にログインすると、保存済みの企業関係マップを表示します。" };
+}
+
+export async function loadCompanyNetworkBootstrap(supabase: SupabaseClient): Promise<CompanyNetworkBootstrapResult> {
+  const [listedResult, outboundResult, groupsResult] = await Promise.all([
     supabase
       .from("stock_notes_company_entities")
-      .select("id,display_name,country_code,listing_status,status")
+      .select(COMPANY_SELECT)
+      .eq("listing_status", "domestic_listed")
       .neq("status", "archived")
       .order("display_name", { ascending: true })
       .limit(ROW_LIMIT),
     supabase
       .from("stock_notes_company_relationship_edges_v")
-      .select(
-        "relation_id,source_company_id,source_company_name,target_company_id,target_company_name," +
-          "relation_category,relation_type,ownership_pct,voting_rights_pct,is_consolidated,relation_note," +
-          "verification_status,confidence,source_title,source_url,source_type,source_as_of,checked_at,valid_to",
-      )
+      .select("source_company_id")
       .is("valid_to", null)
       .in("verification_status", ["verified", "proposed"])
-      .order("source_company_name", { ascending: true })
       .limit(ROW_LIMIT),
     supabase
-      .from("stock_notes_company_group_memberships_v")
-      .select(
-        "membership_id,company_entity_id,company_name,group_id,group_slug,group_name,group_type," +
-          "membership_role,membership_basis,relation_note,verification_status,confidence," +
-          "source_title,source_url,source_type,source_as_of,valid_to",
-      )
+      .from("stock_notes_corporate_groups")
+      .select("id,display_name,group_type")
+      .eq("status", "active")
       .is("valid_to", null)
       .in("verification_status", ["verified", "proposed"])
-      .order("company_name", { ascending: true })
+      .order("display_name", { ascending: true })
       .limit(ROW_LIMIT),
   ]);
 
-  if (companiesResult.error || relationshipsResult.error || membershipsResult.error) {
-    return {
-      status: "error",
-      data: null,
-      message: "企業関係マップの取得に失敗しました。Supabase のView/RLS設定を確認してください。",
-    };
+  if (listedResult.error || outboundResult.error || groupsResult.error) {
+    return { status: "error", data: null, message: "企業関係マップの入口一覧を取得できませんでした。" };
+  }
+
+  const listed = ((listedResult.data ?? []) as unknown as Row[]).map(parseCompany).filter((row): row is CompanyNetworkCompany => row !== null);
+  const listedIds = new Set(listed.map((company) => company.id));
+  const outboundIds = [...new Set(((outboundResult.data ?? []) as unknown as Row[]).map((row) => nullableString(row, "source_company_id")).filter((id): id is string => Boolean(id)))];
+  const missingOutboundIds = outboundIds.filter((id) => !listedIds.has(id));
+
+  let outboundCompanies: CompanyNetworkCompany[] = [];
+  if (missingOutboundIds.length > 0) {
+    const outboundCompaniesResult = await supabase
+      .from("stock_notes_company_entities")
+      .select(COMPANY_SELECT)
+      .in("id", missingOutboundIds)
+      .neq("status", "archived")
+      .order("display_name", { ascending: true });
+    if (outboundCompaniesResult.error) {
+      return { status: "error", data: null, message: "中心企業候補を取得できませんでした。" };
+    }
+    outboundCompanies = ((outboundCompaniesResult.data ?? []) as unknown as Row[]).map(parseCompany).filter((row): row is CompanyNetworkCompany => row !== null);
+  }
+
+  const entryCompanies = [...listed, ...outboundCompanies]
+    .filter((company, index, rows) => rows.findIndex((row) => row.id === company.id) === index)
+    .sort((a, b) => a.name.localeCompare(b.name, "ja"));
+  const groups = ((groupsResult.data ?? []) as unknown as Row[]).map(parseGroup).filter((row): row is CompanyNetworkGroup => row !== null);
+
+  if (entryCompanies.length === 0) {
+    return { status: "empty", data: { entryCompanies: [], groups, defaultCompanyId: "" }, message: "中心企業候補がまだありません。" };
+  }
+
+  const defaultCompanyId = entryCompanies.find((company) => company.name === "トヨタ自動車")?.id ?? entryCompanies[0].id;
+  return { status: "ok", data: { entryCompanies, groups, defaultCompanyId }, message: null };
+}
+
+export async function loadCompanyNetworkScope(
+  supabase: SupabaseClient,
+  options: {
+    companyId: string;
+    hops: 1 | 2;
+    verifiedOnly: boolean;
+    categories: RelationCategory[];
+    includeGroups: boolean;
+  },
+): Promise<CompanyNetworkScopeResult> {
+  const statuses = options.verifiedOnly ? ["verified"] : ["verified", "proposed"];
+  const networkResult = await supabase.rpc("stock_notes_company_network", {
+    p_company_id: options.companyId,
+    p_max_hops: options.hops,
+    p_verified_only: options.verifiedOnly,
+    p_active_only: true,
+    p_relation_categories: options.categories.length > 0 ? options.categories : null,
+  });
+
+  if (networkResult.error) {
+    return { status: "error", data: null, message: "選択企業の企業間関係を取得できませんでした。" };
+  }
+
+  const relationships = ((networkResult.data ?? []) as unknown as Row[])
+    .map(parseRelationship)
+    .filter((row): row is CompanyRelationship => row !== null);
+
+  const centerMembershipResult = await supabase
+    .from("stock_notes_company_group_memberships_v")
+    .select(MEMBERSHIP_SELECT)
+    .eq("company_entity_id", options.companyId)
+    .is("valid_to", null)
+    .in("verification_status", statuses)
+    .limit(ROW_LIMIT);
+
+  if (centerMembershipResult.error) {
+    return { status: "error", data: null, message: "選択企業のグループ所属を取得できませんでした。" };
+  }
+
+  const centerMemberships = ((centerMembershipResult.data ?? []) as unknown as Row[])
+    .map(parseMembership)
+    .filter((row): row is CompanyGroupMembership => row !== null);
+  const groupIds = [...new Set(centerMemberships.map((membership) => membership.groupId))];
+
+  let memberships = centerMemberships;
+  if (options.includeGroups && groupIds.length > 0) {
+    const groupMembershipResult = await supabase
+      .from("stock_notes_company_group_memberships_v")
+      .select(MEMBERSHIP_SELECT)
+      .in("group_id", groupIds)
+      .is("valid_to", null)
+      .in("verification_status", statuses)
+      .order("company_name", { ascending: true })
+      .limit(ROW_LIMIT);
+    if (groupMembershipResult.error) {
+      return { status: "error", data: null, message: "所属グループの企業一覧を取得できませんでした。" };
+    }
+    memberships = ((groupMembershipResult.data ?? []) as unknown as Row[])
+      .map(parseMembership)
+      .filter((row): row is CompanyGroupMembership => row !== null);
+  }
+
+  const companyIds = new Set<string>([options.companyId]);
+  relationships.forEach((relationship) => {
+    companyIds.add(relationship.sourceCompanyId);
+    companyIds.add(relationship.targetCompanyId);
+  });
+  memberships.forEach((membership) => companyIds.add(membership.companyId));
+
+  const companiesResult = await supabase
+    .from("stock_notes_company_entities")
+    .select(COMPANY_SELECT)
+    .in("id", [...companyIds])
+    .neq("status", "archived")
+    .order("display_name", { ascending: true });
+
+  if (companiesResult.error) {
+    return { status: "error", data: null, message: "表示対象企業の情報を取得できませんでした。" };
   }
 
   const companies = ((companiesResult.data ?? []) as unknown as Row[])
     .map(parseCompany)
     .filter((row): row is CompanyNetworkCompany => row !== null);
-  const relationships = ((relationshipsResult.data ?? []) as unknown as Row[])
-    .map(parseRelationship)
-    .filter((row): row is CompanyRelationship => row !== null);
-  const memberships = ((membershipsResult.data ?? []) as unknown as Row[])
-    .map(parseMembership)
-    .filter((row): row is CompanyGroupMembership => row !== null);
-
   const data: CompanyNetworkData = { companies, relationships, memberships };
-  if (relationships.length === 0 && memberships.length === 0) {
-    return {
-      status: "empty",
-      data,
-      message: "保存済みの企業関係がまだありません。",
-    };
-  }
-  return { status: "ok", data, message: null };
+  const empty = relationships.length === 0 && memberships.length === 0;
+  return { status: empty ? "empty" : "ok", data, message: empty ? "この企業には現在の条件で表示できる関係がありません。" : null };
 }

--- a/app/premium/company-network/page.tsx
+++ b/app/premium/company-network/page.tsx
@@ -8,9 +8,9 @@ import CompanyNetworkClient from "./CompanyNetworkClient";
 import {
   companyNetworkAuthRequired,
   companyNetworkUnconfigured,
-  loadCompanyNetwork,
+  loadCompanyNetworkBootstrap,
 } from "./data-loader";
-import type { CompanyNetworkLoadResult } from "./types";
+import type { CompanyNetworkBootstrapResult } from "./types";
 
 export const metadata: Metadata = {
   title: "企業関係マップ | mini-tools premium",
@@ -33,13 +33,13 @@ export default async function PremiumCompanyNetworkPage() {
     redirect(`/premium/login?next=${encodeURIComponent("/premium/company-network")}`);
   }
 
-  let result: CompanyNetworkLoadResult = companyNetworkUnconfigured();
+  let result: CompanyNetworkBootstrapResult = companyNetworkUnconfigured();
   if (isSyncConfigured()) {
     const supabase = await createSupabaseServerClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    result = user ? await loadCompanyNetwork(supabase) : companyNetworkAuthRequired();
+    result = user ? await loadCompanyNetworkBootstrap(supabase) : companyNetworkAuthRequired();
   }
 
   return <CompanyNetworkClient result={result} />;

--- a/app/premium/company-network/types.ts
+++ b/app/premium/company-network/types.ts
@@ -50,12 +50,28 @@ export type CompanyGroupMembership = {
   sourceAsOf: string | null;
 };
 
+export type CompanyNetworkGroup = {
+  id: string;
+  name: string;
+  groupType: string;
+};
+
 export type CompanyNetworkData = {
   companies: CompanyNetworkCompany[];
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
 };
 
-export type CompanyNetworkLoadResult =
-  | { status: "ok"; data: CompanyNetworkData; message: null }
-  | { status: "empty" | "error" | "unconfigured" | "unauthenticated"; data: CompanyNetworkData | null; message: string };
+export type CompanyNetworkBootstrapData = {
+  entryCompanies: CompanyNetworkCompany[];
+  groups: CompanyNetworkGroup[];
+  defaultCompanyId: string;
+};
+
+export type CompanyNetworkBootstrapResult =
+  | { status: "ok"; data: CompanyNetworkBootstrapData; message: null }
+  | { status: "empty" | "error" | "unconfigured" | "unauthenticated"; data: CompanyNetworkBootstrapData | null; message: string };
+
+export type CompanyNetworkScopeResult =
+  | { status: "ok" | "empty"; data: CompanyNetworkData; message: string | null }
+  | { status: "error" | "unconfigured" | "unauthenticated"; data: null; message: string };

--- a/app/premium/company-network/views/DetailPanel.tsx
+++ b/app/premium/company-network/views/DetailPanel.tsx
@@ -6,65 +6,46 @@ import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship
 
 type Props = {
   company: CompanyNetworkCompany | null;
+  centerCompanyId: string;
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
   selectedRelation: CompanyRelationship | null;
   onSelectCompany: (companyId: string) => void;
   onSelectRelation: (relationId: string) => void;
+  onMakeCenter: (companyId: string) => void;
 };
 
-export default function DetailPanel({
-  company,
-  relationships,
-  memberships,
-  selectedRelation,
-  onSelectCompany,
-  onSelectRelation,
-}: Props) {
+export default function DetailPanel({ company, centerCompanyId, relationships, memberships, selectedRelation, onSelectCompany, onSelectRelation, onMakeCenter }: Props) {
   if (!company) {
-    return (
-      <aside className={styles.detailPanel}>
-        <p className={styles.empty}>企業を選択すると詳細を表示します。</p>
-      </aside>
-    );
+    return <aside className={styles.detailPanel}><p className={styles.empty}>企業を選択すると詳細を表示します。</p></aside>;
   }
 
-  const related = relationships.filter(
-    (relationship) =>
-      relationship.sourceCompanyId === company.id || relationship.targetCompanyId === company.id,
-  );
+  const related = relationships.filter((relationship) => relationship.sourceCompanyId === company.id || relationship.targetCompanyId === company.id);
   const companyMemberships = memberships.filter((membership) => membership.companyId === company.id);
+  const isCenter = company.id === centerCompanyId;
 
   return (
     <aside className={styles.detailPanel}>
       <section className={styles.detailSection}>
-        <span className={styles.detailKicker}>SELECTED COMPANY</span>
+        <span className={styles.detailKicker}>{isCenter ? "CENTER COMPANY" : "SELECTED COMPANY"}</span>
         <h2>{company.name}</h2>
         <div className={styles.badges}>
           <span>{company.listingStatus || "上場区分未確認"}</span>
           {company.countryCode ? <span>{company.countryCode}</span> : null}
           <span>{company.status}</span>
         </div>
+        {!isCenter ? <button type="button" className={styles.smallButton} onClick={() => onMakeCenter(company.id)}>この企業を中心に見る</button> : null}
       </section>
 
       {selectedRelation ? (
         <section className={styles.detailSection}>
-          <div className={styles.detailSectionHead}>
-            <h3>選択中の企業関係</h3>
-            <span>{CATEGORY_LABEL[selectedRelation.relationCategory]}</span>
-          </div>
+          <div className={styles.detailSectionHead}><h3>選択中の企業関係</h3><span>{CATEGORY_LABEL[selectedRelation.relationCategory]}</span></div>
           <div className={styles.relationDirection}>
-            <button type="button" onClick={() => onSelectCompany(selectedRelation.sourceCompanyId)}>{selectedRelation.sourceCompanyName}</button>
-            <span>→</span>
-            <button type="button" onClick={() => onSelectCompany(selectedRelation.targetCompanyId)}>{selectedRelation.targetCompanyName}</button>
+            <button type="button" onClick={() => onSelectCompany(selectedRelation.sourceCompanyId)}>{selectedRelation.sourceCompanyName}</button><span>→</span><button type="button" onClick={() => onSelectCompany(selectedRelation.targetCompanyId)}>{selectedRelation.targetCompanyName}</button>
           </div>
-          <strong className={styles.relationTitle}>
-            {relationLabel(selectedRelation.relationType, selectedRelation.ownershipPct)}
-          </strong>
+          <strong className={styles.relationTitle}>{relationLabel(selectedRelation.relationType, selectedRelation.ownershipPct)}</strong>
           <div className={styles.badges}>
-            <span>{selectedRelation.verificationStatus}</span>
-            <span>confidence {selectedRelation.confidence}</span>
-            {selectedRelation.isConsolidated !== null ? <span>{selectedRelation.isConsolidated ? "連結" : "非連結"}</span> : null}
+            <span>{selectedRelation.verificationStatus}</span><span>confidence {selectedRelation.confidence}</span>{selectedRelation.isConsolidated !== null ? <span>{selectedRelation.isConsolidated ? "連結" : "非連結"}</span> : null}
           </div>
           <dl className={styles.detailList}>
             <div><dt>議決権</dt><dd>{selectedRelation.votingRightsPct === null ? "—" : `${selectedRelation.votingRightsPct}%`}</dd></div>
@@ -73,59 +54,31 @@ export default function DetailPanel({
             <div><dt>source type</dt><dd>{selectedRelation.sourceType ?? "—"}</dd></div>
           </dl>
           {selectedRelation.note ? <p className={styles.detailNote}>{selectedRelation.note}</p> : null}
-          {selectedRelation.sourceUrl ? (
-            <a className={styles.sourceLink} href={selectedRelation.sourceUrl} target="_blank" rel="noreferrer">
-              {selectedRelation.sourceTitle ?? "根拠を開く"} ↗
-            </a>
-          ) : null}
+          {selectedRelation.sourceUrl ? <a className={styles.sourceLink} href={selectedRelation.sourceUrl} target="_blank" rel="noreferrer">{selectedRelation.sourceTitle ?? "根拠を開く"} ↗</a> : null}
         </section>
       ) : null}
 
       <section className={styles.detailSection}>
-        <div className={styles.detailSectionHead}>
-          <h3>接続する企業関係</h3>
-          <span>{related.length}件</span>
-        </div>
+        <div className={styles.detailSectionHead}><h3>接続する企業関係</h3><span>{related.length}件</span></div>
         {related.length > 0 ? (
           <div className={styles.detailRelations}>
             {related.map((relationship) => {
               const outbound = relationship.sourceCompanyId === company.id;
               const otherId = outbound ? relationship.targetCompanyId : relationship.sourceCompanyId;
               const otherName = outbound ? relationship.targetCompanyName : relationship.sourceCompanyName;
-              return (
-                <button
-                  type="button"
-                  key={relationship.relationId}
-                  className={styles.detailRelationButton}
-                  onClick={() => onSelectRelation(relationship.relationId)}
-                >
-                  <span>{outbound ? "→" : "←"} {otherName}</span>
-                  <strong>{relationLabel(relationship.relationType, relationship.ownershipPct)}</strong>
-                  <small>{relationship.verificationStatus} · {formatAsOf(relationship.sourceAsOf)}</small>
-                  <span className={styles.srOnly} onClick={() => onSelectCompany(otherId)}>{otherId}</span>
-                </button>
-              );
+              return <div key={relationship.relationId} className={styles.detailRelationButton}>
+                <button type="button" onClick={() => onSelectCompany(otherId)}><span>{outbound ? "→" : "←"} {otherName}</span></button>
+                <button type="button" onClick={() => onSelectRelation(relationship.relationId)}><strong>{relationLabel(relationship.relationType, relationship.ownershipPct)}</strong><small>{relationship.verificationStatus} · {formatAsOf(relationship.sourceAsOf)}</small></button>
+              </div>;
             })}
           </div>
         ) : <p className={styles.empty}>現在の条件で接続する企業関係はありません。</p>}
       </section>
 
       <section className={styles.detailSection}>
-        <div className={styles.detailSectionHead}>
-          <h3>企業グループ所属</h3>
-          <span>{companyMemberships.length}件</span>
-        </div>
+        <div className={styles.detailSectionHead}><h3>企業グループ所属</h3><span>{companyMemberships.length}件</span></div>
         {companyMemberships.length > 0 ? (
-          <div className={styles.groupList}>
-            {companyMemberships.map((membership) => (
-              <article key={membership.membershipId}>
-                <strong>{membership.groupName}</strong>
-                <span>{groupTypeLabel(membership.groupType)} / {membership.membershipBasis}</span>
-                <small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>
-                {membership.sourceUrl ? <a href={membership.sourceUrl} target="_blank" rel="noreferrer">根拠 ↗</a> : null}
-              </article>
-            ))}
-          </div>
+          <div className={styles.groupList}>{companyMemberships.map((membership) => <article key={membership.membershipId}><strong>{membership.groupName}</strong><span>{groupTypeLabel(membership.groupType)} / {membership.membershipBasis}</span><small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>{membership.sourceUrl ? <a href={membership.sourceUrl} target="_blank" rel="noreferrer">根拠 ↗</a> : null}</article>)}</div>
         ) : <p className={styles.empty}>現在の条件で確認できるグループ所属はありません。</p>}
       </section>
     </aside>

--- a/app/premium/company-network/views/HierarchyView.tsx
+++ b/app/premium/company-network/views/HierarchyView.tsx
@@ -9,6 +9,7 @@ import type { CompanyNetworkCompany, CompanyRelationship } from "../types";
 type Props = {
   companies: CompanyNetworkCompany[];
   relationships: CompanyRelationship[];
+  centerCompanyId: string;
   selectedCompanyId: string;
   selectedRelationId: string | null;
   hops: 1 | 2;
@@ -17,14 +18,9 @@ type Props = {
   onSelectRelation: (relationId: string) => void;
 };
 
-function Row({
-  row,
-  selectedRelationId,
-  query,
-  onSelectCompany,
-  onSelectRelation,
-}: {
+function Row({ row, selectedCompanyId, selectedRelationId, query, onSelectCompany, onSelectRelation }: {
   row: SeriesRow;
+  selectedCompanyId: string;
   selectedRelationId: string | null;
   query: string;
   onSelectCompany: (companyId: string) => void;
@@ -34,116 +30,38 @@ function Row({
   const dimmed = normalized.length > 0 && !row.companyName.toLocaleLowerCase("ja").includes(normalized);
   const relationship = row.relationship;
   return (
-    <div
-      className={`${styles.seriesRow} ${dimmed ? styles.seriesRowDim : ""}`}
-      style={{ marginLeft: Math.min(row.depth - 1, 3) * 18 }}
-    >
-      <button type="button" className={styles.seriesCompany} onClick={() => onSelectCompany(row.companyId)}>
-        <span className={styles.seriesDepth}>L{row.depth}</span>
-        <strong>{row.companyName}</strong>
-        {row.cycle ? <span className={styles.warningBadge}>循環</span> : null}
+    <div className={`${styles.seriesRow} ${dimmed ? styles.seriesRowDim : ""}`} style={{ marginLeft: Math.min(row.depth - 1, 3) * 18 }}>
+      <button type="button" className={styles.seriesCompany} onClick={() => onSelectCompany(row.companyId)} aria-pressed={selectedCompanyId === row.companyId}>
+        <span className={styles.seriesDepth}>L{row.depth}</span><strong>{row.companyName}</strong>{row.cycle ? <span className={styles.warningBadge}>循環</span> : null}
       </button>
       {relationship ? (
-        <button
-          type="button"
-          className={`${styles.seriesRelation} ${selectedRelationId === relationship.relationId ? styles.seriesRelationActive : ""}`}
-          onClick={() => onSelectRelation(relationship.relationId)}
-          title={`${relationship.sourceCompanyName} → ${relationship.targetCompanyName}`}
-        >
-          {relationship.sourceCompanyName} → {relationship.targetCompanyName}
-          <span>{relationLabel(relationship.relationType, relationship.ownershipPct)}</span>
+        <button type="button" className={`${styles.seriesRelation} ${selectedRelationId === relationship.relationId ? styles.seriesRelationActive : ""}`} onClick={() => onSelectRelation(relationship.relationId)} title={`${relationship.sourceCompanyName} → ${relationship.targetCompanyName}`}>
+          {relationship.sourceCompanyName} → {relationship.targetCompanyName}<span>{relationLabel(relationship.relationType, relationship.ownershipPct)}</span>
         </button>
       ) : null}
     </div>
   );
 }
 
-export default function HierarchyView({
-  companies,
-  relationships,
-  selectedCompanyId,
-  selectedRelationId,
-  hops,
-  query,
-  onSelectCompany,
-  onSelectRelation,
-}: Props) {
-  const selectedCompany = companies.find((company) => company.id === selectedCompanyId);
-  const series = useMemo(
-    () => selectedCompany
-      ? buildSeriesRows({
-          selectedCompanyId,
-          selectedCompanyName: selectedCompany.name,
-          relationships,
-          maxDepth: hops,
-        })
-      : null,
-    [hops, relationships, selectedCompany, selectedCompanyId],
-  );
+export default function HierarchyView({ companies, relationships, centerCompanyId, selectedCompanyId, selectedRelationId, hops, query, onSelectCompany, onSelectRelation }: Props) {
+  const centerCompany = companies.find((company) => company.id === centerCompanyId);
+  const series = useMemo(() => centerCompany ? buildSeriesRows({ selectedCompanyId: centerCompanyId, selectedCompanyName: centerCompany.name, relationships, maxDepth: hops }) : null, [centerCompany, centerCompanyId, hops, relationships]);
 
-  if (!selectedCompany || !series) {
-    return <p className={styles.empty}>中心企業を選択してください。</p>;
-  }
+  if (!centerCompany || !series) return <p className={styles.empty}>中心企業を選択してください。</p>;
 
   return (
     <div className={`${styles.seriesView} ${styles.viewFade}`}>
-      <p className={styles.seriesIntro}>
-        系列ビューは <strong>出資・親会社・支配・持分法</strong> だけを方向付きで表示します。
-        企業グループ所属や歴史的系譜は親子関係と同一視しないため、ここには混ぜません。
-      </p>
-
+      <p className={styles.seriesIntro}>系列ビューは <strong>出資・親会社・支配・持分法</strong> だけを方向付きで表示します。企業グループ所属や歴史的系譜は親子関係と同一視しません。</p>
       <section className={styles.seriesSection}>
-        <div className={styles.seriesSectionHead}>
-          <div>
-            <span className={styles.seriesKicker}>UPSTREAM</span>
-            <h3>上位・出資元・支配元</h3>
-          </div>
-          <span>{series.upstream.length}件</span>
-        </div>
-        {series.upstream.length > 0 ? (
-          <div className={styles.seriesRows}>
-            {[...series.upstream].reverse().map((row) => (
-              <Row
-                key={`up:${row.relationship?.relationId}:${row.companyId}:${row.depth}`}
-                row={row}
-                selectedRelationId={selectedRelationId}
-                query={query}
-                onSelectCompany={onSelectCompany}
-                onSelectRelation={onSelectRelation}
-              />
-            ))}
-          </div>
-        ) : <p className={styles.empty}>この範囲で確認済みの上位関係はありません。</p>}
+        <div className={styles.seriesSectionHead}><div><span className={styles.seriesKicker}>UPSTREAM</span><h3>上位・出資元・支配元</h3></div><span>{series.upstream.length}件</span></div>
+        {series.upstream.length > 0 ? <div className={styles.seriesRows}>{[...series.upstream].reverse().map((row) => <Row key={`up:${row.relationship?.relationId}:${row.companyId}:${row.depth}`} row={row} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={onSelectCompany} onSelectRelation={onSelectRelation} />)}</div> : <p className={styles.empty}>この範囲で確認済みの上位関係はありません。</p>}
       </section>
-
-      <div className={styles.seriesCenter}>
-        <span>中心企業</span>
-        <strong>{selectedCompany.name}</strong>
-        <small>{selectedCompany.listingStatus || "上場区分未確認"}</small>
-      </div>
-
+      <button type="button" className={styles.seriesCenter} onClick={() => onSelectCompany(centerCompanyId)}>
+        <span>中心企業</span><strong>{centerCompany.name}</strong><small>{centerCompany.listingStatus || "上場区分未確認"}</small>
+      </button>
       <section className={styles.seriesSection}>
-        <div className={styles.seriesSectionHead}>
-          <div>
-            <span className={styles.seriesKicker}>DOWNSTREAM</span>
-            <h3>下位・出資先・支配先</h3>
-          </div>
-          <span>{series.downstream.length}件</span>
-        </div>
-        {series.downstream.length > 0 ? (
-          <div className={styles.seriesRows}>
-            {series.downstream.map((row) => (
-              <Row
-                key={`down:${row.relationship?.relationId}:${row.companyId}:${row.depth}`}
-                row={row}
-                selectedRelationId={selectedRelationId}
-                query={query}
-                onSelectCompany={onSelectCompany}
-                onSelectRelation={onSelectRelation}
-              />
-            ))}
-          </div>
-        ) : <p className={styles.empty}>この範囲で確認済みの下位関係はありません。</p>}
+        <div className={styles.seriesSectionHead}><div><span className={styles.seriesKicker}>DOWNSTREAM</span><h3>下位・出資先・支配先</h3></div><span>{series.downstream.length}件</span></div>
+        {series.downstream.length > 0 ? <div className={styles.seriesRows}>{series.downstream.map((row) => <Row key={`down:${row.relationship?.relationId}:${row.companyId}:${row.depth}`} row={row} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={onSelectCompany} onSelectRelation={onSelectRelation} />)}</div> : <p className={styles.empty}>この範囲で確認済みの下位関係はありません。</p>}
       </section>
     </div>
   );

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -21,6 +21,7 @@ type Props = {
   companies: CompanyNetworkCompany[];
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
+  centerCompanyId: string;
   selectedCompanyId: string;
   selectedRelationId: string | null;
   query: string;
@@ -32,6 +33,7 @@ export default function NetworkView({
   companies,
   relationships,
   memberships,
+  centerCompanyId,
   selectedCompanyId,
   selectedRelationId,
   query,
@@ -41,89 +43,21 @@ export default function NetworkView({
   const svgRef = useRef<SVGSVGElement>(null);
   const [frame, setFrame] = useState<{ source: SimNode[]; nodes: SimNode[] } | null>(null);
   const [runId, setRunId] = useState(0);
-
-  const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
-
-  const selectedComponent = useMemo(() => {
-    const companyIds = new Set<string>(selectedCompanyId ? [selectedCompanyId] : []);
-    const groupIds = new Set<string>();
-    let changed = true;
-
-    while (changed) {
-      changed = false;
-
-      for (const relationship of relationships) {
-        if (!companyIds.has(relationship.sourceCompanyId) && !companyIds.has(relationship.targetCompanyId)) continue;
-        if (!companyIds.has(relationship.sourceCompanyId)) {
-          companyIds.add(relationship.sourceCompanyId);
-          changed = true;
-        }
-        if (!companyIds.has(relationship.targetCompanyId)) {
-          companyIds.add(relationship.targetCompanyId);
-          changed = true;
-        }
-      }
-
-      for (const membership of memberships) {
-        if (!companyIds.has(membership.companyId) && !groupIds.has(membership.groupId)) continue;
-        if (!companyIds.has(membership.companyId)) {
-          companyIds.add(membership.companyId);
-          changed = true;
-        }
-        if (!groupIds.has(membership.groupId)) {
-          groupIds.add(membership.groupId);
-          changed = true;
-        }
-      }
-    }
-
-    const visibleRelationships = relationships.filter(
-      (relationship) => companyIds.has(relationship.sourceCompanyId) && companyIds.has(relationship.targetCompanyId),
-    );
-    const visibleMemberships = memberships.filter(
-      (membership) => companyIds.has(membership.companyId) && groupIds.has(membership.groupId),
-    );
-
-    return { companyIds, groupIds, relationships: visibleRelationships, memberships: visibleMemberships };
-  }, [memberships, relationships, selectedCompanyId]);
-
-  const resetKey = `${selectedCompanyId}|${selectedComponent.relationships.map((item) => item.relationId).join(":")}|${selectedComponent.memberships.map((item) => item.membershipId).join(":")}`;
-  const panZoom = usePanZoom(svgRef, resetKey);
+  const graphKey = `${centerCompanyId}|${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
+  const panZoom = usePanZoom(svgRef, graphKey);
 
   const graph = useMemo(() => {
-    const nodes: VisualNode[] = [...selectedComponent.companyIds]
-      .map((companyId) => companyById.get(companyId))
-      .filter((company): company is CompanyNetworkCompany => Boolean(company))
-      .map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
-
-    const groupById = new Map(selectedComponent.memberships.map((membership) => [membership.groupId, membership]));
+    const nodes: VisualNode[] = companies.map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
+    const groupById = new Map(memberships.map((membership) => [membership.groupId, membership]));
     for (const membership of groupById.values()) {
-      nodes.push({
-        id: `group:${membership.groupId}`,
-        label: membership.groupName,
-        kind: "group",
-        groupId: membership.groupId,
-        groupType: membership.groupType,
-      });
+      nodes.push({ id: `group:${membership.groupId}`, label: membership.groupName, kind: "group" as const, groupId: membership.groupId, groupType: membership.groupType });
     }
-
     const links: SimLink[] = [
-      ...selectedComponent.relationships.map((relationship) => ({
-        id: relationship.relationId,
-        sourceId: relationship.sourceCompanyId,
-        targetId: relationship.targetCompanyId,
-        kind: "relationship" as const,
-      })),
-      ...selectedComponent.memberships.map((membership) => ({
-        id: membership.membershipId,
-        sourceId: membership.companyId,
-        targetId: `group:${membership.groupId}`,
-        kind: "membership" as const,
-      })),
+      ...relationships.map((relationship) => ({ id: relationship.relationId, sourceId: relationship.sourceCompanyId, targetId: relationship.targetCompanyId, kind: "relationship" as const })),
+      ...memberships.map((membership) => ({ id: membership.membershipId, sourceId: membership.companyId, targetId: `group:${membership.groupId}`, kind: "membership" as const })),
     ];
-
     return { nodes, links };
-  }, [companyById, selectedComponent]);
+  }, [companies, memberships, relationships]);
 
   const seeded = useMemo(() => seedSimNodes(graph.nodes, SEED_SPREAD), [graph.nodes, runId]);
 
@@ -145,18 +79,25 @@ export default function NetworkView({
   const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
   const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, 240);
   const size = VIEWBOX_HALF * 2;
-
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
-  const queryMatch = (node: SimNode) =>
-    normalizedQuery.length === 0 || node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
+
+  const selectedNeighbours = useMemo(() => {
+    const ids = new Set<string>(selectedCompanyId ? [selectedCompanyId] : []);
+    relationships.forEach((relationship) => {
+      if (relationship.sourceCompanyId === selectedCompanyId) ids.add(relationship.targetCompanyId);
+      if (relationship.targetCompanyId === selectedCompanyId) ids.add(relationship.sourceCompanyId);
+    });
+    memberships.forEach((membership) => {
+      if (membership.companyId === selectedCompanyId) ids.add(`group:${membership.groupId}`);
+    });
+    return ids;
+  }, [memberships, relationships, selectedCompanyId]);
 
   return (
     <div className={styles.viewFade}>
       <div className={styles.viewTools}>
-        <span>選択企業の関係ネットワーク</span>
-        <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>
-          再配置
-        </button>
+        <span>中心企業の関係ネットワーク</span>
+        <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button>
       </div>
       <div className={styles.svgWrap}>
         <div className={styles.zoomControls}>
@@ -164,104 +105,42 @@ export default function NetworkView({
           <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
           <button type="button" onClick={panZoom.reset} disabled={!panZoom.canReset}>戻す</button>
         </div>
-        <svg
-          ref={svgRef}
-          className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
-          style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
-          viewBox={`${-VIEWBOX_HALF} ${-VIEWBOX_HALF} ${size} ${size}`}
-          role="img"
-          aria-label="選択企業につながる企業関係ネットワーク"
-          onPointerDown={panZoom.onPointerDown}
-          onDoubleClick={panZoom.onDoubleClick}
-        >
-          <defs>
-            <marker id="company-relation-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
-              <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
-            </marker>
-          </defs>
+        <svg ref={svgRef} className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`} style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }} viewBox={`${-VIEWBOX_HALF} ${-VIEWBOX_HALF} ${size} ${size}`} role="img" aria-label="企業関係ネットワーク" onPointerDown={panZoom.onPointerDown} onDoubleClick={panZoom.onDoubleClick}>
+          <defs><marker id="company-relation-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" /></marker></defs>
           <g transform={panZoom.transform}>
-            {selectedComponent.relationships.map((relationship) => {
+            {relationships.map((relationship) => {
               const source = positions.get(relationship.sourceCompanyId);
               const target = positions.get(relationship.targetCompanyId);
               if (!source || !target) return null;
               const selected = relationship.relationId === selectedRelationId;
-              return (
-                <g key={relationship.relationId}>
-                  <line
-                    x1={source.x * fit}
-                    y1={source.y * fit}
-                    x2={target.x * fit}
-                    y2={target.y * fit}
-                    stroke={CATEGORY_COLOR[relationship.relationCategory]}
-                    strokeWidth={selected ? 3.2 : 1.7}
-                    strokeOpacity={selected ? 1 : 0.85}
-                    strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
-                    markerEnd="url(#company-relation-arrow)"
-                    color={CATEGORY_COLOR[relationship.relationCategory]}
-                    onClick={() => onSelectRelation(relationship.relationId)}
-                    className={styles.edgeHitTarget}
-                  />
-                  <text
-                    x={((source.x + target.x) / 2) * fit}
-                    y={((source.y + target.y) / 2) * fit - 7}
-                    textAnchor="middle"
-                    className={styles.svgEdgeLabel}
-                  >
-                    {relationLabel(relationship.relationType, relationship.ownershipPct)}
-                  </text>
-                </g>
-              );
+              const focused = selectedNeighbours.has(relationship.sourceCompanyId) && selectedNeighbours.has(relationship.targetCompanyId);
+              return <g key={relationship.relationId}>
+                <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.2 : focused ? 1.8 : 1} strokeOpacity={selected ? 1 : focused ? 0.85 : 0.2} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
+                {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - 7} textAnchor="middle" className={styles.svgEdgeLabel}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
+              </g>;
             })}
-
-            {selectedComponent.memberships.map((membership) => {
+            {memberships.map((membership) => {
               const source = positions.get(membership.companyId);
               const target = positions.get(`group:${membership.groupId}`);
               if (!source || !target) return null;
-              return (
-                <line
-                  key={membership.membershipId}
-                  x1={source.x * fit}
-                  y1={source.y * fit}
-                  x2={target.x * fit}
-                  y2={target.y * fit}
-                  className={styles.membershipLine}
-                  strokeOpacity={membership.companyId === selectedCompanyId ? 0.95 : 0.65}
-                />
-              );
+              const focused = membership.companyId === selectedCompanyId;
+              return <line key={membership.membershipId} x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} className={styles.membershipLine} strokeOpacity={focused ? 0.9 : 0.25} />;
             })}
-
             {nodes.map((node) => {
               const selected = node.id === selectedCompanyId;
-              const dimmed = normalizedQuery.length > 0 && !queryMatch(node);
-              const radius = node.kind === "group" ? 9 : selected ? 11 : 8;
-              const fill = node.kind === "group" ? "#fff7ed" : selected ? "#2554ff" : "var(--color-bg-card)";
+              const center = node.id === centerCompanyId;
+              const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
+              const neighbourDimmed = selectedCompanyId.length > 0 && !selectedNeighbours.has(node.id);
+              const dimmed = queryDimmed || neighbourDimmed;
+              const radius = node.kind === "group" ? 9 : center ? 11 : selected ? 10 : 8;
+              const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
-              return (
-                <g
-                  key={node.id}
-                  transform={`translate(${node.x * fit} ${node.y * fit})`}
-                  className={dimmed ? styles.svgNodeDim : undefined}
-                  style={{ cursor: node.kind === "company" ? "pointer" : "default" }}
-                  onClick={() => {
-                    if (node.kind === "company" && !panZoom.didPan()) onSelectCompany(node.id);
-                  }}
-                  role={node.kind === "company" ? "button" : undefined}
-                  tabIndex={node.kind === "company" ? 0 : undefined}
-                  onKeyDown={(event) => {
-                    if (node.kind === "company" && (event.key === "Enter" || event.key === " ")) {
-                      event.preventDefault();
-                      onSelectCompany(node.id);
-                    }
-                  }}
-                >
-                  <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
-                  {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
-                  <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected ? 3 : 2} />
-                  <text className={styles.svgLabel} x={radius + 6} dominantBaseline="middle">
-                    {truncate(node.label)}
-                  </text>
-                </g>
-              );
+              return <g key={node.id} transform={`translate(${node.x * fit} ${node.y * fit})`} className={dimmed ? styles.svgNodeDim : undefined} style={{ cursor: node.kind === "company" ? "pointer" : "default" }} onClick={() => { if (node.kind === "company" && !panZoom.didPan()) onSelectCompany(node.id); }} role={node.kind === "company" ? "button" : undefined} tabIndex={node.kind === "company" ? 0 : undefined} onKeyDown={(event) => { if (node.kind === "company" && (event.key === "Enter" || event.key === " ")) { event.preventDefault(); onSelectCompany(node.id); } }}>
+                <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
+                {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
+                <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected || center ? 3 : 2} />
+                <text className={styles.svgLabel} x={radius + 6} dominantBaseline="middle">{truncate(node.label)}</text>
+              </g>;
             })}
           </g>
         </svg>

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -59,7 +59,10 @@ export default function NetworkView({
     return { nodes, links };
   }, [companies, memberships, relationships]);
 
-  const seeded = useMemo(() => seedSimNodes(graph.nodes, SEED_SPREAD), [graph.nodes, runId]);
+  const seeded = useMemo(() => {
+    void runId;
+    return seedSimNodes(graph.nodes, SEED_SPREAD);
+  }, [graph.nodes, runId]);
 
   useEffect(() => {
     const working = seeded.map((node) => ({ ...node }));

--- a/app/premium/company-network/views/RadialView.tsx
+++ b/app/premium/company-network/views/RadialView.tsx
@@ -21,7 +21,6 @@ function companyPositions(depthByCompany: Map<string, number>): Map<string, Poin
     bucket.push(companyId);
     byDepth.set(depth, bucket);
   }
-
   for (const [depth, ids] of byDepth) {
     if (depth === 0) {
       result.set(ids[0], { x: 0, y: 0 });
@@ -66,6 +65,7 @@ type Props = {
   companies: CompanyNetworkCompany[];
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
+  centerCompanyId: string;
   selectedCompanyId: string;
   selectedRelationId: string | null;
   hops: 1 | 2;
@@ -78,6 +78,7 @@ export default function RadialView({
   companies,
   relationships,
   memberships,
+  centerCompanyId,
   selectedCompanyId,
   selectedRelationId,
   hops,
@@ -86,16 +87,16 @@ export default function RadialView({
   onSelectRelation,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const panZoom = usePanZoom(svgRef, `${selectedCompanyId}:${hops}`);
+  const panZoom = usePanZoom(svgRef, `${centerCompanyId}:${hops}`);
   const network = useMemo(
     () => buildReachableNetwork({
-      selectedCompanyId,
+      selectedCompanyId: centerCompanyId,
       relationships,
       hops,
       categories: ["capital", "control", "historical"],
       verifiedOnly: false,
     }),
-    [hops, relationships, selectedCompanyId],
+    [centerCompanyId, hops, relationships],
   );
   const visibleCompanyIds = useMemo(() => new Set(network.depthByCompany.keys()), [network.depthByCompany]);
   const visibleMemberships = useMemo(
@@ -119,110 +120,48 @@ export default function RadialView({
           <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
           <button type="button" onClick={panZoom.reset} disabled={!panZoom.canReset}>戻す</button>
         </div>
-        <svg
-          ref={svgRef}
-          className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
-          style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
-          viewBox="-520 -520 1040 1040"
-          role="img"
-          aria-label="選択企業を中心にした企業関係の放射マップ"
-          onPointerDown={panZoom.onPointerDown}
-          onDoubleClick={panZoom.onDoubleClick}
-        >
-          <defs>
-            <marker id="company-radial-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
-              <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
-            </marker>
-          </defs>
+        <svg ref={svgRef} className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`} style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }} viewBox="-520 -520 1040 1040" role="img" aria-label="中心企業を基準にした企業関係の放射マップ" onPointerDown={panZoom.onPointerDown} onDoubleClick={panZoom.onDoubleClick}>
+          <defs><marker id="company-radial-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" /></marker></defs>
           <g transform={panZoom.transform}>
             <circle r="180" className={styles.radialRing} />
             {hops === 2 ? <circle r="315" className={styles.radialRing} /> : null}
             {visibleMemberships.length > 0 ? <circle r="425" className={styles.radialGroupRing} /> : null}
-
             {network.relationships.map((relationship) => {
               const source = positions.get(relationship.sourceCompanyId);
               const target = positions.get(relationship.targetCompanyId);
               if (!source || !target) return null;
-              const edge = shortenEdge(source, target, relationship.sourceCompanyId === selectedCompanyId ? 34 : 26, relationship.targetCompanyId === selectedCompanyId ? 34 : 26);
+              const edge = shortenEdge(source, target, relationship.sourceCompanyId === centerCompanyId ? 34 : 26, relationship.targetCompanyId === centerCompanyId ? 34 : 26);
               const selected = selectedRelationId === relationship.relationId;
-              return (
-                <g key={relationship.relationId} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget}>
-                  <line
-                    x1={edge.x1}
-                    y1={edge.y1}
-                    x2={edge.x2}
-                    y2={edge.y2}
-                    stroke={CATEGORY_COLOR[relationship.relationCategory]}
-                    strokeWidth={selected ? 3.2 : 1.8}
-                    strokeOpacity={selected ? 1 : 0.78}
-                    strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
-                    markerEnd="url(#company-radial-arrow)"
-                    color={CATEGORY_COLOR[relationship.relationCategory]}
-                  />
-                  <text x={edge.midX} y={edge.midY - 7} textAnchor="middle" className={styles.svgEdgeLabel}>
-                    {relationLabel(relationship.relationType, relationship.ownershipPct)}
-                  </text>
-                </g>
-              );
+              return <g key={relationship.relationId} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget}>
+                <line x1={edge.x1} y1={edge.y1} x2={edge.x2} y2={edge.y2} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.2 : 1.8} strokeOpacity={selected ? 1 : 0.78} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-radial-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} />
+                <text x={edge.midX} y={edge.midY - 7} textAnchor="middle" className={styles.svgEdgeLabel}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text>
+              </g>;
             })}
-
             {visibleMemberships.map((membership) => {
               const source = positions.get(membership.companyId);
               const target = groups.get(membership.groupId);
               if (!source || !target) return null;
-              return (
-                <line
-                  key={membership.membershipId}
-                  x1={source.x}
-                  y1={source.y}
-                  x2={target.x}
-                  y2={target.y}
-                  className={styles.membershipLine}
-                />
-              );
+              return <line key={membership.membershipId} x1={source.x} y1={source.y} x2={target.x} y2={target.y} className={styles.membershipLine} />;
             })}
-
             {[...network.depthByCompany.entries()].map(([companyId, depth]) => {
               const company = companyById.get(companyId);
               const point = positions.get(companyId);
               if (!company || !point) return null;
+              const isCenter = companyId === centerCompanyId;
               const selected = companyId === selectedCompanyId;
               const queryDim = normalizedQuery.length > 0 && !company.name.toLocaleLowerCase("ja").includes(normalizedQuery);
-              const radius = selected ? 34 : 26;
-              return (
-                <g
-                  key={companyId}
-                  transform={`translate(${point.x} ${point.y})`}
-                  className={queryDim ? styles.svgNodeDim : undefined}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => { if (!panZoom.didPan()) onSelectCompany(companyId); }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      onSelectCompany(companyId);
-                    }
-                  }}
-                  style={{ cursor: "pointer" }}
-                >
-                  {selected ? <circle className={styles.pulse} r={radius + 9} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
-                  <circle r={radius} fill={selected ? "#2554ff" : "var(--color-bg-card)"} stroke="#2554ff" strokeWidth={selected ? 3 : 2} />
-                  <text textAnchor="middle" y="-2" className={selected ? styles.radialCenterLabel : styles.radialNodeLabel}>{truncate(company.name, 11)}</text>
-                  <text textAnchor="middle" y="13" className={selected ? styles.radialCenterMeta : styles.radialNodeMeta}>{depth === 0 ? "center" : `${depth}-hop`}</text>
-                </g>
-              );
+              const radius = isCenter ? 34 : selected ? 30 : 26;
+              return <g key={companyId} transform={`translate(${point.x} ${point.y})`} className={queryDim ? styles.svgNodeDim : undefined} role="button" tabIndex={0} onClick={() => { if (!panZoom.didPan()) onSelectCompany(companyId); }} onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); onSelectCompany(companyId); } }} style={{ cursor: "pointer" }}>
+                {selected ? <circle className={styles.pulse} r={radius + 9} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
+                <circle r={radius} fill={isCenter ? "#2554ff" : "var(--color-bg-card)"} stroke="#2554ff" strokeWidth={selected || isCenter ? 3 : 2} />
+                <text textAnchor="middle" y="-2" className={isCenter ? styles.radialCenterLabel : styles.radialNodeLabel}>{truncate(company.name, 11)}</text>
+                <text textAnchor="middle" y="13" className={isCenter ? styles.radialCenterMeta : styles.radialNodeMeta}>{depth === 0 ? "center" : `${depth}-hop`}</text>
+              </g>;
             })}
-
             {[...new Map(visibleMemberships.map((membership) => [membership.groupId, membership])).values()].map((membership) => {
               const point = groups.get(membership.groupId);
               if (!point) return null;
-              return (
-                <g key={membership.groupId} transform={`translate(${point.x} ${point.y})`}>
-                  <rect x="-60" y="-25" width="120" height="50" rx="14" className={styles.radialGroupNode} />
-                  <text textAnchor="middle" y="-2" className={styles.radialGroupLabel}>{truncate(membership.groupName, 13)}</text>
-                  <text textAnchor="middle" y="13" className={styles.radialGroupMeta}>{groupTypeLabel(membership.groupType)}</text>
-                </g>
-              );
+              return <g key={membership.groupId} transform={`translate(${point.x} ${point.y})`}><rect x="-60" y="-25" width="120" height="50" rx="14" className={styles.radialGroupNode} /><text textAnchor="middle" y="-2" className={styles.radialGroupLabel}>{truncate(membership.groupName, 13)}</text><text textAnchor="middle" y="13" className={styles.radialGroupMeta}>{groupTypeLabel(membership.groupType)}</text></g>;
             })}
           </g>
         </svg>


### PR DESCRIPTION
Closes #510

## 変更概要
- 初期表示でrelationship/membership全件を取得しない
- 初期は企業グループ＋その所属企業ID＋outbound relation sourceの軽量情報だけ取得
- 選択した中心企業の1/2-hopを `/api/premium/company-network` からオンデマンド取得
- 中心企業の所属グループがある場合、そのグループmemberだけ追加取得
- RPCで得たrelation IDだけViewから再取得し、source type / checked_at / note等の根拠メタデータを維持
- ノード選択と中心企業変更を分離
- ノード選択では詳細・強調のみ変更し、force layoutを再計算しない
- 詳細パネルに `この企業を中心に見る` を追加
- 非入口企業を中心表示した場合はプルダウンに一時optionとして維持
- `再配置` は同じノード集合に対してのみ実行
- 関係/放射/系列ビューで center と selected を別stateとして扱う
- 全relation categoryをOFFにした場合はRPCを呼ばず、0件として扱う

## DB
- schema変更なし
- 既存 `stock_notes_company_network` RPCを利用

## 確認
- [x] lint
- [x] test
- [x] build
- CI #987 success