### PR TITLE
feat(company-network): 企業グループノードを選択可能にする

### DIFF
--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -7,6 +7,7 @@ import { CATEGORY_LABEL, VIEWS, type CompanyNetworkViewMode } from "./presentati
 import type {
   CompanyNetworkBootstrapResult,
   CompanyNetworkData,
+  CompanyNetworkNodeSelection,
   CompanyNetworkScopeResult,
   RelationCategory,
 } from "./types";
@@ -20,6 +21,7 @@ const ALL_CATEGORIES: readonly RelationCategory[] = ["capital", "control", "hist
 
 type ScopedState = { key: string; data: CompanyNetworkData };
 type ScopedError = { key: string; message: string };
+type ScopedSelection = CompanyNetworkNodeSelection & { key: string };
 
 function StateScreen({ title, body }: { title: string; body: string }) {
   return (
@@ -42,7 +44,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
   const [view, setView] = useState<CompanyNetworkViewMode>("network");
   const [centerCompanyId, setCenterCompanyId] = useState(defaultCompanyId);
-  const [selectedCompanyId, setSelectedCompanyId] = useState(defaultCompanyId);
+  const [selection, setSelection] = useState<ScopedSelection | null>(null);
   const [selectedRelationId, setSelectedRelationId] = useState<string | null>(null);
   const [hops, setHops] = useState<1 | 2>(2);
   const [categories, setCategories] = useState<Set<RelationCategory>>(() => new Set(ALL_CATEGORIES));
@@ -57,6 +59,10 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const scope = scopedState?.key === requestKey ? scopedState.data : null;
   const loadError = scopedError?.key === requestKey ? scopedError.message : null;
   const loading = Boolean(centerCompanyId) && scope === null && loadError === null;
+  const activeSelection: CompanyNetworkNodeSelection | null = selection?.key === requestKey
+    ? { kind: selection.kind, id: selection.id }
+    : null;
+  const selectedCompanyId = activeSelection?.kind === "company" ? activeSelection.id : "";
   const entryCompanyIds = useMemo(() => new Set(entryCompanies.map((company) => company.id)), [entryCompanies]);
   const temporaryCenter = entryCompanyIds.has(centerCompanyId)
     ? null
@@ -92,7 +98,13 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         setScopedState({ key, data });
         setScopedError(null);
         setSelectedRelationId(null);
-        setSelectedCompanyId((current) => data.companies.some((company) => company.id === current) ? current : centerCompanyId);
+        setSelection((current) => {
+          if (current?.key === key) {
+            if (current.kind === "company" && data.companies.some((company) => company.id === current.id)) return current;
+            if (current.kind === "group" && data.memberships.some((membership) => membership.groupId === current.id)) return current;
+          }
+          return { key, kind: "company", id: centerCompanyId };
+        });
       })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
@@ -104,20 +116,24 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
   const relationships = scope?.relationships ?? [];
   const memberships = scope?.memberships ?? [];
-  const selectedCompany = scope?.companies.find((company) => company.id === selectedCompanyId) ?? null;
   const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
   const showHopControl = view === "radial" || view === "hierarchy";
   const showGroupControl = view === "network" || view === "radial";
 
-  const selectNode = (companyId: string) => {
-    setSelectedCompanyId(companyId);
+  const selectCompany = (companyId: string) => {
+    setSelection({ key: requestKey, kind: "company", id: companyId });
+    setSelectedRelationId(null);
+  };
+
+  const selectGroup = (groupId: string) => {
+    setSelection({ key: requestKey, kind: "group", id: groupId });
     setSelectedRelationId(null);
   };
 
   const changeCenter = (companyId: string) => {
     setCenterCompanyId(companyId);
-    setSelectedCompanyId(companyId);
+    setSelection(null);
     setSelectedRelationId(null);
   };
 
@@ -147,7 +163,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.heroHead}>
           <div>
             <h1 className={styles.heroTitle}>企業関係マップ</h1>
-            <p className={styles.heroLead}>企業グループと入口企業だけを先に読み込み、選択した企業の周辺データを必要な時だけ取得します。閲覧専用です。</p>
+            <p className={styles.heroLead}>企業・企業グループを選択しながら、中心企業の周辺データを必要な時だけ取得して確認します。閲覧専用です。</p>
           </div>
           <span className={styles.versionBadge}>company-network v3</span>
         </div>
@@ -219,16 +235,16 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           {loading ? <p className={styles.empty}>選択企業の関係を読み込んでいます…</p> : null}
           {loadError ? <p className={styles.empty}>{loadError}</p> : null}
           {!loading && scope && relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在の条件では表示できる関係がありません。</p> : null}
-          {scope && view === "network" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}
-          {scope && view === "radial" ? <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}
-          {scope && view === "hierarchy" ? <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} /> : null}
-          {scope && view === "table" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectNode} /> : null}
+          {scope && view === "network" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "radial" ? <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "hierarchy" ? <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "table" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} /> : null}
         </section>
 
-        <DetailPanel company={selectedCompany} centerCompanyId={centerCompanyId} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectNode} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
+        <DetailPanel groups={bootstrap.groups} companies={scope?.companies ?? []} selection={activeSelection} centerCompanyId={centerCompanyId} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
       </div>
 
-      <p className={styles.note}>ノード選択は詳細と強調だけを変え、配置は動かしません。中心企業を変える場合だけ周辺データを再取得し、「再配置」は同じノード集合の位置だけを計算し直します。</p>
+      <p className={styles.note}>企業・企業グループの選択は詳細と強調だけを変え、配置は動かしません。中心企業を変える場合だけ周辺データを再取得し、「再配置」は同じノード集合の位置だけを計算し直します。</p>
     </main>
   );
 }

--- a/app/premium/company-network/node-selection.test.ts
+++ b/app/premium/company-network/node-selection.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildSelectedNeighbourIds, groupGraphNodeId, selectedGraphNodeId } from "./node-selection";
+import type { CompanyGroupMembership, CompanyRelationship } from "./types";
+
+const relationships: CompanyRelationship[] = [
+  {
+    relationId: "toyota-woven",
+    sourceCompanyId: "toyota",
+    sourceCompanyName: "Toyota",
+    targetCompanyId: "woven",
+    targetCompanyName: "Woven",
+    relationCategory: "capital",
+    relationType: "equity_ownership",
+    ownershipPct: 100,
+    votingRightsPct: null,
+    isConsolidated: null,
+    note: "",
+    verificationStatus: "verified",
+    confidence: "high",
+    sourceTitle: null,
+    sourceUrl: null,
+    sourceType: null,
+    sourceAsOf: null,
+    checkedAt: null,
+  },
+];
+
+const memberships: CompanyGroupMembership[] = [
+  {
+    membershipId: "m-toyota",
+    companyId: "toyota",
+    companyName: "Toyota",
+    groupId: "toyota-group",
+    groupSlug: "toyota-group",
+    groupName: "Toyota Group",
+    groupType: "corporate_group",
+    membershipRole: "core",
+    membershipBasis: "official_group_member",
+    note: "",
+    verificationStatus: "verified",
+    confidence: "high",
+    sourceTitle: null,
+    sourceUrl: null,
+    sourceType: null,
+    sourceAsOf: null,
+  },
+  {
+    membershipId: "m-woven",
+    companyId: "woven",
+    companyName: "Woven",
+    groupId: "toyota-group",
+    groupSlug: "toyota-group",
+    groupName: "Toyota Group",
+    groupType: "corporate_group",
+    membershipRole: "member",
+    membershipBasis: "official_group_member",
+    note: "",
+    verificationStatus: "verified",
+    confidence: "high",
+    sourceTitle: null,
+    sourceUrl: null,
+    sourceType: null,
+    sourceAsOf: null,
+  },
+];
+
+describe("company-network node selection", () => {
+  it("company selection highlights direct companies and its groups", () => {
+    const ids = buildSelectedNeighbourIds({ kind: "company", id: "toyota" }, relationships, memberships);
+    expect([...ids ?? []].sort()).toEqual([groupGraphNodeId("toyota-group"), "toyota", "woven"].sort());
+  });
+
+  it("group selection highlights every visible member without changing the center", () => {
+    const ids = buildSelectedNeighbourIds({ kind: "group", id: "toyota-group" }, relationships, memberships);
+    expect([...ids ?? []].sort()).toEqual([groupGraphNodeId("toyota-group"), "toyota", "woven"].sort());
+    expect(selectedGraphNodeId({ kind: "group", id: "toyota-group" })).toBe(groupGraphNodeId("toyota-group"));
+  });
+});

--- a/app/premium/company-network/node-selection.ts
+++ b/app/premium/company-network/node-selection.ts
@@ -1,0 +1,40 @@
+import type {
+  CompanyGroupMembership,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "./types";
+
+export function groupGraphNodeId(groupId: string) {
+  return `group:${groupId}`;
+}
+
+export function selectedGraphNodeId(selection: CompanyNetworkNodeSelection | null) {
+  if (!selection) return null;
+  return selection.kind === "group" ? groupGraphNodeId(selection.id) : selection.id;
+}
+
+export function buildSelectedNeighbourIds(
+  selection: CompanyNetworkNodeSelection | null,
+  relationships: CompanyRelationship[],
+  memberships: CompanyGroupMembership[],
+) {
+  if (!selection) return null;
+
+  if (selection.kind === "group") {
+    const ids = new Set<string>([groupGraphNodeId(selection.id)]);
+    for (const membership of memberships) {
+      if (membership.groupId === selection.id) ids.add(membership.companyId);
+    }
+    return ids;
+  }
+
+  const ids = new Set<string>([selection.id]);
+  for (const relationship of relationships) {
+    if (relationship.sourceCompanyId === selection.id) ids.add(relationship.targetCompanyId);
+    if (relationship.targetCompanyId === selection.id) ids.add(relationship.sourceCompanyId);
+  }
+  for (const membership of memberships) {
+    if (membership.companyId === selection.id) ids.add(groupGraphNodeId(membership.groupId));
+  }
+  return ids;
+}

--- a/app/premium/company-network/types.ts
+++ b/app/premium/company-network/types.ts
@@ -1,6 +1,12 @@
 export type RelationCategory = "capital" | "control" | "historical";
 export type VerificationStatus = "proposed" | "verified" | "rejected" | "superseded";
 export type Confidence = "high" | "medium" | "low";
+export type CompanyNetworkNodeKind = "company" | "group";
+
+export type CompanyNetworkNodeSelection = {
+  kind: CompanyNetworkNodeKind;
+  id: string;
+};
 
 export type CompanyNetworkCompany = {
   id: string;

--- a/app/premium/company-network/views/DetailPanel.tsx
+++ b/app/premium/company-network/views/DetailPanel.tsx
@@ -67,12 +67,12 @@ export default function DetailPanel({
             <span>{groupMemberships.length}社</span>
           </div>
           {groupMemberships.length > 0 ? (
-            <div className={styles.groupMemberList}>
+            <div className={styles.detailRelations}>
               {groupMemberships.map((membership) => (
                 <button
                   type="button"
                   key={membership.membershipId}
-                  className={styles.groupMemberButton}
+                  className={styles.detailRelationButton}
                   onClick={() => onSelectCompany(membership.companyId)}
                 >
                   <strong>{membership.companyName}</strong>
@@ -165,7 +165,11 @@ export default function DetailPanel({
           <div className={styles.groupList}>
             {companyMemberships.map((membership) => (
               <article key={membership.membershipId}>
-                <button type="button" className={styles.groupSelectButton} onClick={() => onSelectGroup(membership.groupId)}>
+                <button
+                  type="button"
+                  onClick={() => onSelectGroup(membership.groupId)}
+                  style={{ display: "grid", gap: 3, width: "100%", border: 0, padding: 0, background: "transparent", color: "inherit", textAlign: "left", font: "inherit", cursor: "pointer" }}
+                >
                   <strong>{membership.groupName}</strong>
                   <span>{groupTypeLabel(membership.groupType)} / {membership.membershipBasis}</span>
                   <small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>

--- a/app/premium/company-network/views/DetailPanel.tsx
+++ b/app/premium/company-network/views/DetailPanel.tsx
@@ -2,22 +2,106 @@
 
 import styles from "../CompanyNetwork.module.css";
 import { CATEGORY_LABEL, formatAsOf, groupTypeLabel, relationLabel } from "../presentation";
-import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship } from "../types";
+import type {
+  CompanyGroupMembership,
+  CompanyNetworkCompany,
+  CompanyNetworkGroup,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "../types";
 
 type Props = {
-  company: CompanyNetworkCompany | null;
+  groups: CompanyNetworkGroup[];
+  companies: CompanyNetworkCompany[];
+  selection: CompanyNetworkNodeSelection | null;
   centerCompanyId: string;
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
   selectedRelation: CompanyRelationship | null;
   onSelectCompany: (companyId: string) => void;
+  onSelectGroup: (groupId: string) => void;
   onSelectRelation: (relationId: string) => void;
   onMakeCenter: (companyId: string) => void;
 };
 
-export default function DetailPanel({ company, centerCompanyId, relationships, memberships, selectedRelation, onSelectCompany, onSelectRelation, onMakeCenter }: Props) {
+export default function DetailPanel({
+  groups,
+  companies,
+  selection,
+  centerCompanyId,
+  relationships,
+  memberships,
+  selectedRelation,
+  onSelectCompany,
+  onSelectGroup,
+  onSelectRelation,
+  onMakeCenter,
+}: Props) {
+  const company = selection?.kind === "company"
+    ? companies.find((item) => item.id === selection.id) ?? null
+    : null;
+  const group = selection?.kind === "group"
+    ? groups.find((item) => item.id === selection.id) ?? null
+    : null;
+
+  if (selection?.kind === "group" && group) {
+    const groupMemberships = memberships
+      .filter((membership) => membership.groupId === group.id)
+      .sort((a, b) => a.companyName.localeCompare(b.companyName, "ja"));
+    const evidence = groupMemberships.find((membership) => membership.sourceUrl || membership.sourceTitle) ?? groupMemberships[0] ?? null;
+
+    return (
+      <aside className={styles.detailPanel}>
+        <section className={styles.detailSection}>
+          <span className={styles.detailKicker}>SELECTED GROUP</span>
+          <h2>{group.name}</h2>
+          <div className={styles.badges}>
+            <span>{groupTypeLabel(group.groupType)}</span>
+            <span>所属 {groupMemberships.length}社</span>
+          </div>
+        </section>
+
+        <section className={styles.detailSection}>
+          <div className={styles.detailSectionHead}>
+            <h3>所属企業</h3>
+            <span>{groupMemberships.length}社</span>
+          </div>
+          {groupMemberships.length > 0 ? (
+            <div className={styles.groupMemberList}>
+              {groupMemberships.map((membership) => (
+                <button
+                  type="button"
+                  key={membership.membershipId}
+                  className={styles.groupMemberButton}
+                  onClick={() => onSelectCompany(membership.companyId)}
+                >
+                  <strong>{membership.companyName}</strong>
+                  <span>{membership.membershipRole} · {membership.membershipBasis}</span>
+                  <small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>
+                </button>
+              ))}
+            </div>
+          ) : <p className={styles.empty}>現在の条件で表示できる所属企業はありません。</p>}
+        </section>
+
+        {evidence ? (
+          <section className={styles.detailSection}>
+            <div className={styles.detailSectionHead}><h3>所属の根拠</h3><span>{evidence.confidence}</span></div>
+            <dl className={styles.detailList}>
+              <div><dt>basis</dt><dd>{evidence.membershipBasis}</dd></div>
+              <div><dt>基準日</dt><dd>{formatAsOf(evidence.sourceAsOf)}</dd></div>
+              <div><dt>source type</dt><dd>{evidence.sourceType ?? "—"}</dd></div>
+            </dl>
+            {evidence.note ? <p className={styles.detailNote}>{evidence.note}</p> : null}
+            {evidence.sourceUrl ? <a className={styles.sourceLink} href={evidence.sourceUrl} target="_blank" rel="noreferrer">{evidence.sourceTitle ?? "根拠を開く"} ↗</a> : null}
+          </section>
+        ) : null}
+      </aside>
+    );
+  }
+
   if (!company) {
-    return <aside className={styles.detailPanel}><p className={styles.empty}>企業を選択すると詳細を表示します。</p></aside>;
+    return <aside className={styles.detailPanel}><p className={styles.empty}>企業または企業グループを選択すると詳細を表示します。</p></aside>;
   }
 
   const related = relationships.filter((relationship) => relationship.sourceCompanyId === company.id || relationship.targetCompanyId === company.id);
@@ -78,7 +162,18 @@ export default function DetailPanel({ company, centerCompanyId, relationships, m
       <section className={styles.detailSection}>
         <div className={styles.detailSectionHead}><h3>企業グループ所属</h3><span>{companyMemberships.length}件</span></div>
         {companyMemberships.length > 0 ? (
-          <div className={styles.groupList}>{companyMemberships.map((membership) => <article key={membership.membershipId}><strong>{membership.groupName}</strong><span>{groupTypeLabel(membership.groupType)} / {membership.membershipBasis}</span><small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>{membership.sourceUrl ? <a href={membership.sourceUrl} target="_blank" rel="noreferrer">根拠 ↗</a> : null}</article>)}</div>
+          <div className={styles.groupList}>
+            {companyMemberships.map((membership) => (
+              <article key={membership.membershipId}>
+                <button type="button" className={styles.groupSelectButton} onClick={() => onSelectGroup(membership.groupId)}>
+                  <strong>{membership.groupName}</strong>
+                  <span>{groupTypeLabel(membership.groupType)} / {membership.membershipBasis}</span>
+                  <small>{membership.verificationStatus} · {formatAsOf(membership.sourceAsOf)}</small>
+                </button>
+                {membership.sourceUrl ? <a href={membership.sourceUrl} target="_blank" rel="noreferrer">根拠 ↗</a> : null}
+              </article>
+            ))}
+          </div>
         ) : <p className={styles.empty}>現在の条件で確認できるグループ所属はありません。</p>}
       </section>
     </aside>

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -4,8 +4,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { usePanZoom } from "../../industry-map/use-pan-zoom";
 import styles from "../CompanyNetwork.module.css";
 import { seedSimNodes, simExtent, stepForce, type SimLink, type SimNode, type VisualNode } from "../graph-layout";
+import { buildSelectedNeighbourIds, groupGraphNodeId, selectedGraphNodeId } from "../node-selection";
 import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
-import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship } from "../types";
+import type {
+  CompanyGroupMembership,
+  CompanyNetworkCompany,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "../types";
 
 const TOTAL_STEPS = 300;
 const STEPS_PER_FRAME = 3;
@@ -22,10 +28,11 @@ type Props = {
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
   centerCompanyId: string;
-  selectedCompanyId: string;
+  selection: CompanyNetworkNodeSelection | null;
   selectedRelationId: string | null;
   query: string;
   onSelectCompany: (companyId: string) => void;
+  onSelectGroup: (groupId: string) => void;
   onSelectRelation: (relationId: string) => void;
 };
 
@@ -34,10 +41,11 @@ export default function NetworkView({
   relationships,
   memberships,
   centerCompanyId,
-  selectedCompanyId,
+  selection,
   selectedRelationId,
   query,
   onSelectCompany,
+  onSelectGroup,
   onSelectRelation,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
@@ -50,11 +58,11 @@ export default function NetworkView({
     const nodes: VisualNode[] = companies.map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
     const groupById = new Map(memberships.map((membership) => [membership.groupId, membership]));
     for (const membership of groupById.values()) {
-      nodes.push({ id: `group:${membership.groupId}`, label: membership.groupName, kind: "group" as const, groupId: membership.groupId, groupType: membership.groupType });
+      nodes.push({ id: groupGraphNodeId(membership.groupId), label: membership.groupName, kind: "group" as const, groupId: membership.groupId, groupType: membership.groupType });
     }
     const links: SimLink[] = [
       ...relationships.map((relationship) => ({ id: relationship.relationId, sourceId: relationship.sourceCompanyId, targetId: relationship.targetCompanyId, kind: "relationship" as const })),
-      ...memberships.map((membership) => ({ id: membership.membershipId, sourceId: membership.companyId, targetId: `group:${membership.groupId}`, kind: "membership" as const })),
+      ...memberships.map((membership) => ({ id: membership.membershipId, sourceId: membership.companyId, targetId: groupGraphNodeId(membership.groupId), kind: "membership" as const })),
     ];
     return { nodes, links };
   }, [companies, memberships, relationships]);
@@ -83,18 +91,11 @@ export default function NetworkView({
   const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, 240);
   const size = VIEWBOX_HALF * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
-
-  const selectedNeighbours = useMemo(() => {
-    const ids = new Set<string>(selectedCompanyId ? [selectedCompanyId] : []);
-    relationships.forEach((relationship) => {
-      if (relationship.sourceCompanyId === selectedCompanyId) ids.add(relationship.targetCompanyId);
-      if (relationship.targetCompanyId === selectedCompanyId) ids.add(relationship.sourceCompanyId);
-    });
-    memberships.forEach((membership) => {
-      if (membership.companyId === selectedCompanyId) ids.add(`group:${membership.groupId}`);
-    });
-    return ids;
-  }, [memberships, relationships, selectedCompanyId]);
+  const selectedNodeId = selectedGraphNodeId(selection);
+  const selectedNeighbours = useMemo(
+    () => buildSelectedNeighbourIds(selection, relationships, memberships),
+    [memberships, relationships, selection],
+  );
 
   return (
     <div className={styles.viewFade}>
@@ -116,7 +117,7 @@ export default function NetworkView({
               const target = positions.get(relationship.targetCompanyId);
               if (!source || !target) return null;
               const selected = relationship.relationId === selectedRelationId;
-              const focused = selectedNeighbours.has(relationship.sourceCompanyId) && selectedNeighbours.has(relationship.targetCompanyId);
+              const focused = selectedNeighbours === null || (selectedNeighbours.has(relationship.sourceCompanyId) && selectedNeighbours.has(relationship.targetCompanyId));
               return <g key={relationship.relationId}>
                 <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.2 : focused ? 1.8 : 1} strokeOpacity={selected ? 1 : focused ? 0.85 : 0.2} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
                 {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - 7} textAnchor="middle" className={styles.svgEdgeLabel}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
@@ -124,23 +125,45 @@ export default function NetworkView({
             })}
             {memberships.map((membership) => {
               const source = positions.get(membership.companyId);
-              const target = positions.get(`group:${membership.groupId}`);
+              const target = positions.get(groupGraphNodeId(membership.groupId));
               if (!source || !target) return null;
-              const focused = membership.companyId === selectedCompanyId;
-              return <line key={membership.membershipId} x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} className={styles.membershipLine} strokeOpacity={focused ? 0.9 : 0.25} />;
+              const focused = selection?.kind === "group"
+                ? selection.id === membership.groupId
+                : selection?.kind === "company"
+                  ? selection.id === membership.companyId
+                  : true;
+              return <line key={membership.membershipId} x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} className={styles.membershipLine} strokeOpacity={focused ? 0.9 : 0.2} />;
             })}
             {nodes.map((node) => {
-              const selected = node.id === selectedCompanyId;
-              const center = node.id === centerCompanyId;
+              const selected = node.id === selectedNodeId;
+              const center = node.kind === "company" && node.id === centerCompanyId;
               const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
-              const neighbourDimmed = selectedCompanyId.length > 0 && !selectedNeighbours.has(node.id);
+              const neighbourDimmed = selectedNeighbours !== null && !selectedNeighbours.has(node.id);
               const dimmed = queryDimmed || neighbourDimmed;
-              const radius = node.kind === "group" ? 9 : center ? 11 : selected ? 10 : 8;
+              const radius = node.kind === "group" ? (selected ? 11 : 9) : center ? 11 : selected ? 10 : 8;
               const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
-              return <g key={node.id} transform={`translate(${node.x * fit} ${node.y * fit})`} className={dimmed ? styles.svgNodeDim : undefined} style={{ cursor: node.kind === "company" ? "pointer" : "default" }} onClick={() => { if (node.kind === "company" && !panZoom.didPan()) onSelectCompany(node.id); }} role={node.kind === "company" ? "button" : undefined} tabIndex={node.kind === "company" ? 0 : undefined} onKeyDown={(event) => { if (node.kind === "company" && (event.key === "Enter" || event.key === " ")) { event.preventDefault(); onSelectCompany(node.id); } }}>
+              return <g
+                key={node.id}
+                transform={`translate(${node.x * fit} ${node.y * fit})`}
+                className={dimmed ? styles.svgNodeDim : undefined}
+                style={{ cursor: "pointer" }}
+                onClick={() => {
+                  if (panZoom.didPan()) return;
+                  if (node.kind === "company") onSelectCompany(node.id);
+                  else if (node.groupId) onSelectGroup(node.groupId);
+                }}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  if (node.kind === "company") onSelectCompany(node.id);
+                  else if (node.groupId) onSelectGroup(node.groupId);
+                }}
+              >
                 <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
-                {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
+                {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke={stroke} strokeWidth={2} /> : null}
                 <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected || center ? 3 : 2} />
                 <text className={styles.svgLabel} x={radius + 6} dominantBaseline="middle">{truncate(node.label)}</text>
               </g>;

--- a/app/premium/company-network/views/RadialView.tsx
+++ b/app/premium/company-network/views/RadialView.tsx
@@ -5,7 +5,12 @@ import { usePanZoom } from "../../industry-map/use-pan-zoom";
 import { buildReachableNetwork } from "../graph";
 import styles from "../CompanyNetwork.module.css";
 import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
-import type { CompanyGroupMembership, CompanyNetworkCompany, CompanyRelationship } from "../types";
+import type {
+  CompanyGroupMembership,
+  CompanyNetworkCompany,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "../types";
 
 type Point = { x: number; y: number };
 
@@ -66,11 +71,12 @@ type Props = {
   relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
   centerCompanyId: string;
-  selectedCompanyId: string;
+  selection: CompanyNetworkNodeSelection | null;
   selectedRelationId: string | null;
   hops: 1 | 2;
   query: string;
   onSelectCompany: (companyId: string) => void;
+  onSelectGroup: (groupId: string) => void;
   onSelectRelation: (relationId: string) => void;
 };
 
@@ -79,11 +85,12 @@ export default function RadialView({
   relationships,
   memberships,
   centerCompanyId,
-  selectedCompanyId,
+  selection,
   selectedRelationId,
   hops,
   query,
   onSelectCompany,
+  onSelectGroup,
   onSelectRelation,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
@@ -141,17 +148,24 @@ export default function RadialView({
               const source = positions.get(membership.companyId);
               const target = groups.get(membership.groupId);
               if (!source || !target) return null;
-              return <line key={membership.membershipId} x1={source.x} y1={source.y} x2={target.x} y2={target.y} className={styles.membershipLine} />;
+              const focused = selection?.kind === "group"
+                ? selection.id === membership.groupId
+                : selection?.kind === "company"
+                  ? selection.id === membership.companyId
+                  : true;
+              return <line key={membership.membershipId} x1={source.x} y1={source.y} x2={target.x} y2={target.y} className={styles.membershipLine} strokeOpacity={focused ? 0.9 : 0.2} />;
             })}
             {[...network.depthByCompany.entries()].map(([companyId, depth]) => {
               const company = companyById.get(companyId);
               const point = positions.get(companyId);
               if (!company || !point) return null;
               const isCenter = companyId === centerCompanyId;
-              const selected = companyId === selectedCompanyId;
+              const selected = selection?.kind === "company" && companyId === selection.id;
+              const groupSelected = selection?.kind === "group" && visibleMemberships.some((membership) => membership.groupId === selection.id && membership.companyId === companyId);
               const queryDim = normalizedQuery.length > 0 && !company.name.toLocaleLowerCase("ja").includes(normalizedQuery);
+              const neighbourDim = selection?.kind === "group" && !groupSelected;
               const radius = isCenter ? 34 : selected ? 30 : 26;
-              return <g key={companyId} transform={`translate(${point.x} ${point.y})`} className={queryDim ? styles.svgNodeDim : undefined} role="button" tabIndex={0} onClick={() => { if (!panZoom.didPan()) onSelectCompany(companyId); }} onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); onSelectCompany(companyId); } }} style={{ cursor: "pointer" }}>
+              return <g key={companyId} transform={`translate(${point.x} ${point.y})`} className={queryDim || neighbourDim ? styles.svgNodeDim : undefined} role="button" tabIndex={0} onClick={() => { if (!panZoom.didPan()) onSelectCompany(companyId); }} onKeyDown={(event) => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); onSelectCompany(companyId); } }} style={{ cursor: "pointer" }}>
                 {selected ? <circle className={styles.pulse} r={radius + 9} fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
                 <circle r={radius} fill={isCenter ? "#2554ff" : "var(--color-bg-card)"} stroke="#2554ff" strokeWidth={selected || isCenter ? 3 : 2} />
                 <text textAnchor="middle" y="-2" className={isCenter ? styles.radialCenterLabel : styles.radialNodeLabel}>{truncate(company.name, 11)}</text>
@@ -161,7 +175,28 @@ export default function RadialView({
             {[...new Map(visibleMemberships.map((membership) => [membership.groupId, membership])).values()].map((membership) => {
               const point = groups.get(membership.groupId);
               if (!point) return null;
-              return <g key={membership.groupId} transform={`translate(${point.x} ${point.y})`}><rect x="-60" y="-25" width="120" height="50" rx="14" className={styles.radialGroupNode} /><text textAnchor="middle" y="-2" className={styles.radialGroupLabel}>{truncate(membership.groupName, 13)}</text><text textAnchor="middle" y="13" className={styles.radialGroupMeta}>{groupTypeLabel(membership.groupType)}</text></g>;
+              const selected = selection?.kind === "group" && selection.id === membership.groupId;
+              const dimmed = selection !== null && !selected && selection.kind === "group";
+              return <g
+                key={membership.groupId}
+                transform={`translate(${point.x} ${point.y})`}
+                className={dimmed ? styles.svgNodeDim : undefined}
+                role="button"
+                tabIndex={0}
+                style={{ cursor: "pointer" }}
+                onClick={() => { if (!panZoom.didPan()) onSelectGroup(membership.groupId); }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    onSelectGroup(membership.groupId);
+                  }
+                }}
+              >
+                {selected ? <rect x="-68" y="-33" width="136" height="66" rx="18" className={styles.radialGroupPulse} /> : null}
+                <rect x="-60" y="-25" width="120" height="50" rx="14" className={styles.radialGroupNode} />
+                <text textAnchor="middle" y="-2" className={styles.radialGroupLabel}>{truncate(membership.groupName, 13)}</text>
+                <text textAnchor="middle" y="13" className={styles.radialGroupMeta}>{groupTypeLabel(membership.groupType)}</text>
+              </g>;
             })}
           </g>
         </svg>

--- a/app/premium/company-network/views/RadialView.tsx
+++ b/app/premium/company-network/views/RadialView.tsx
@@ -192,7 +192,7 @@ export default function RadialView({
                   }
                 }}
               >
-                {selected ? <rect x="-68" y="-33" width="136" height="66" rx="18" className={styles.radialGroupPulse} /> : null}
+                {selected ? <rect x="-68" y="-33" width="136" height="66" rx="18" className={styles.pulse} fill="none" stroke="#d97706" strokeWidth="2" /> : null}
                 <rect x="-60" y="-25" width="120" height="50" rx="14" className={styles.radialGroupNode} />
                 <text textAnchor="middle" y="-2" className={styles.radialGroupLabel}>{truncate(membership.groupName, 13)}</text>
                 <text textAnchor="middle" y="13" className={styles.radialGroupMeta}>{groupTypeLabel(membership.groupType)}</text>


### PR DESCRIPTION
Closes #512

## 変更概要
- Claude Code製業界マップの選択モデルを参考に、company / group を共通の選択対象へ変更
- selectionを現在のscope/request keyに紐づけ、scope変更時に古い選択を無効化
- NetworkViewの企業グループノードをクリック / Enter / Spaceで選択可能に変更
- グループ選択時は配置を変えず、所属企業とmembership edgeを強調
- RadialViewの企業グループノードも選択可能に変更
- DetailPanelに企業グループ詳細を追加
  - group type
  - 所属企業数
  - 所属企業一覧
  - membership role / basis / verification / source_as_of
  - 所属根拠
- グループ詳細の企業から企業選択へ移動可能
- 企業詳細のグループ所属からグループ選択へ移動可能
- `この企業を中心に見る` と `再配置` の分離は維持
- group/company選択近傍の単体テストを追加

## DB
- schema変更なし
- 既存company/group/membershipデータのみ利用

## 確認
- [x] lint
- [x] test
- [x] build
- CI #989 success