### PR TITLE
feat(company-network): 企業グループを主入口に変更

### DIFF
--- a/app/api/premium/company-network/route.ts
+++ b/app/api/premium/company-network/route.ts
@@ -3,7 +3,10 @@ import { cookies } from "next/headers";
 import { PREMIUM_COOKIE_NAME, verifyPremiumSession } from "@/lib/premium-auth";
 import { isSyncConfigured } from "@/lib/supabase/config";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { loadCompanyNetworkScope } from "@/app/premium/company-network/data-loader";
+import {
+  loadCompanyGroupScope,
+  loadCompanyNetworkScope,
+} from "@/app/premium/company-network/data-loader";
 import type { RelationCategory } from "@/app/premium/company-network/types";
 
 const VALID_CATEGORIES = new Set<RelationCategory>(["capital", "control", "historical"]);
@@ -19,6 +22,7 @@ export async function GET(request: Request) {
   }
 
   const url = new URL(request.url);
+  const groupId = url.searchParams.get("groupId")?.trim() ?? "";
   const companyId = url.searchParams.get("companyId")?.trim() ?? "";
   const hops = url.searchParams.get("hops") === "1" ? 1 : 2;
   const verifiedOnly = url.searchParams.get("verifiedOnly") !== "false";
@@ -27,8 +31,8 @@ export async function GET(request: Request) {
     .split(",")
     .filter((value): value is RelationCategory => VALID_CATEGORIES.has(value as RelationCategory));
 
-  if (!companyId) {
-    return NextResponse.json({ status: "error", data: null, message: "companyIdが必要です。" }, { status: 400 });
+  if (!groupId && !companyId) {
+    return NextResponse.json({ status: "error", data: null, message: "groupIdまたはcompanyIdが必要です。" }, { status: 400 });
   }
 
   const supabase = await createSupabaseServerClient();
@@ -37,12 +41,19 @@ export async function GET(request: Request) {
     return NextResponse.json({ status: "unauthenticated", data: null, message: "Supabaseにログインしてください。" }, { status: 401 });
   }
 
-  const result = await loadCompanyNetworkScope(supabase, {
-    companyId,
-    hops,
-    verifiedOnly,
-    categories,
-    includeGroups,
-  });
+  const result = groupId
+    ? await loadCompanyGroupScope(supabase, {
+        groupId,
+        verifiedOnly,
+        categories,
+      })
+    : await loadCompanyNetworkScope(supabase, {
+        companyId,
+        hops,
+        verifiedOnly,
+        categories,
+        includeGroups,
+      });
+
   return NextResponse.json(result, { status: result.status === "error" ? 500 : 200 });
 }

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -8,10 +8,13 @@ import type {
   CompanyNetworkBootstrapResult,
   CompanyNetworkData,
   CompanyNetworkNodeSelection,
+  CompanyNetworkScopeMode,
   CompanyNetworkScopeResult,
   RelationCategory,
 } from "./types";
 import DetailPanel from "./views/DetailPanel";
+import GroupRadialView from "./views/GroupRadialView";
+import GroupTableView from "./views/GroupTableView";
 import HierarchyView from "./views/HierarchyView";
 import NetworkView from "./views/NetworkView";
 import RadialView from "./views/RadialView";
@@ -39,11 +42,13 @@ function StateScreen({ title, body }: { title: string; body: string }) {
 
 export default function CompanyNetworkClient({ result }: { result: CompanyNetworkBootstrapResult }) {
   const bootstrap = result.data;
-  const entryCompanies = bootstrap?.entryCompanies ?? [];
-  const defaultCompanyId = bootstrap?.defaultCompanyId ?? "";
+  const groups = bootstrap?.groups ?? [];
+  const defaultGroupId = bootstrap?.defaultGroupId ?? groups[0]?.id ?? "";
 
   const [view, setView] = useState<CompanyNetworkViewMode>("network");
-  const [centerCompanyId, setCenterCompanyId] = useState(defaultCompanyId);
+  const [scopeMode, setScopeMode] = useState<CompanyNetworkScopeMode>("group");
+  const [selectedGroupId, setSelectedGroupId] = useState(defaultGroupId);
+  const [centerCompanyId, setCenterCompanyId] = useState("");
   const [selection, setSelection] = useState<ScopedSelection | null>(null);
   const [selectedRelationId, setSelectedRelationId] = useState<string | null>(null);
   const [hops, setHops] = useState<1 | 2>(2);
@@ -55,30 +60,34 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const [scopedError, setScopedError] = useState<ScopedError | null>(null);
 
   const categoryKey = useMemo(() => [...categories].sort().join(","), [categories]);
-  const requestKey = `${centerCompanyId}|${hops}|${verifiedOnly ? "v" : "all"}|${showGroups ? "g" : "nog"}|${categoryKey}`;
+  const targetId = scopeMode === "group" ? selectedGroupId : centerCompanyId;
+  const requestKey = scopeMode === "group"
+    ? `group|${selectedGroupId}|${verifiedOnly ? "v" : "all"}|${categoryKey}`
+    : `company|${centerCompanyId}|${hops}|${verifiedOnly ? "v" : "all"}|${showGroups ? "g" : "nog"}|${categoryKey}`;
   const scope = scopedState?.key === requestKey ? scopedState.data : null;
   const loadError = scopedError?.key === requestKey ? scopedError.message : null;
-  const loading = Boolean(centerCompanyId) && scope === null && loadError === null;
+  const loading = Boolean(targetId) && scope === null && loadError === null;
   const activeSelection: CompanyNetworkNodeSelection | null = selection?.key === requestKey
     ? { kind: selection.kind, id: selection.id }
     : null;
   const selectedCompanyId = activeSelection?.kind === "company" ? activeSelection.id : "";
-  const entryCompanyIds = useMemo(() => new Set(entryCompanies.map((company) => company.id)), [entryCompanies]);
-  const temporaryCenter = entryCompanyIds.has(centerCompanyId)
-    ? null
-    : scopedState?.data.companies.find((company) => company.id === centerCompanyId) ?? null;
-  const dropdownCompanies = temporaryCenter ? [...entryCompanies, temporaryCenter] : entryCompanies;
+  const activeGroup = groups.find((group) => group.id === selectedGroupId) ?? groups[0] ?? null;
+  const centerCompany = scope?.companies.find((company) => company.id === centerCompanyId) ?? null;
 
   useEffect(() => {
-    if (!centerCompanyId) return;
+    if (!targetId) return;
     const controller = new AbortController();
     const params = new URLSearchParams({
-      companyId: centerCompanyId,
-      hops: String(hops),
       verifiedOnly: String(verifiedOnly),
-      includeGroups: String(showGroups),
       categories: categoryKey,
     });
+    if (scopeMode === "group") {
+      params.set("groupId", selectedGroupId);
+    } else {
+      params.set("companyId", centerCompanyId);
+      params.set("hops", String(hops));
+      params.set("includeGroups", String(showGroups));
+    }
     const key = requestKey;
 
     fetch(`/api/premium/company-network?${params.toString()}`, {
@@ -103,7 +112,9 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
             if (current.kind === "company" && data.companies.some((company) => company.id === current.id)) return current;
             if (current.kind === "group" && data.memberships.some((membership) => membership.groupId === current.id)) return current;
           }
-          return { key, kind: "company", id: centerCompanyId };
+          return scopeMode === "group"
+            ? { key, kind: "group", id: selectedGroupId }
+            : { key, kind: "company", id: centerCompanyId };
         });
       })
       .catch((error: unknown) => {
@@ -112,14 +123,15 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
       });
 
     return () => controller.abort();
-  }, [categoryKey, centerCompanyId, hops, requestKey, showGroups, verifiedOnly]);
+  }, [categoryKey, centerCompanyId, hops, requestKey, scopeMode, selectedGroupId, showGroups, targetId, verifiedOnly]);
 
   const relationships = scope?.relationships ?? [];
   const memberships = scope?.memberships ?? [];
   const selectedRelation = relationships.find((relationship) => relationship.relationId === selectedRelationId) ?? null;
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
-  const showHopControl = view === "radial" || view === "hierarchy";
-  const showGroupControl = view === "network" || view === "radial";
+  const showHopControl = scopeMode === "company" && (view === "radial" || view === "hierarchy");
+  const showGroupControl = scopeMode === "company" && (view === "network" || view === "radial");
+  const hierarchyCenterId = scopeMode === "company" ? centerCompanyId : selectedCompanyId;
 
   const selectCompany = (companyId: string) => {
     setSelection({ key: requestKey, kind: "company", id: companyId });
@@ -131,8 +143,24 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
     setSelectedRelationId(null);
   };
 
+  const changeGroup = (groupId: string) => {
+    setSelectedGroupId(groupId);
+    setScopeMode("group");
+    setCenterCompanyId("");
+    setSelection(null);
+    setSelectedRelationId(null);
+  };
+
   const changeCenter = (companyId: string) => {
+    setScopeMode("company");
     setCenterCompanyId(companyId);
+    setSelection(null);
+    setSelectedRelationId(null);
+  };
+
+  const returnToGroup = () => {
+    setScopeMode("group");
+    setCenterCompanyId("");
     setSelection(null);
     setSelectedRelationId(null);
   };
@@ -150,7 +178,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   if (result.status === "unconfigured") return <StateScreen title="Supabase 連携が未設定です" body={result.message} />;
   if (result.status === "unauthenticated") return <StateScreen title="Supabase にログインしてください" body={result.message} />;
   if (result.status === "error") return <StateScreen title="企業関係マップを取得できませんでした" body={`${result.message} 0件ではなく取得失敗です。`} />;
-  if (!bootstrap || entryCompanies.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "中心企業候補を登録するとここに表示されます。"} />;
+  if (!bootstrap || groups.length === 0) return <StateScreen title="企業関係データがまだありません" body={result.message ?? "企業グループを登録するとここに表示されます。"} />;
 
   return (
     <main className={styles.page}>
@@ -163,42 +191,47 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.heroHead}>
           <div>
             <h1 className={styles.heroTitle}>企業関係マップ</h1>
-            <p className={styles.heroLead}>企業・企業グループを選択しながら、中心企業の周辺データを必要な時だけ取得して確認します。閲覧専用です。</p>
+            <p className={styles.heroLead}>企業グループを入口に全体像を確認し、必要な企業だけ1-hop / 2-hopで深掘りします。閲覧専用です。</p>
           </div>
-          <span className={styles.versionBadge}>company-network v3</span>
+          <span className={styles.versionBadge}>company-network v4</span>
         </div>
         <div className={styles.statRow}>
-          <div className={styles.stat}><span>入口企業</span><strong>{entryCompanies.length}</strong><small>社</small></div>
-          <div className={styles.stat}><span>企業グループ</span><strong>{bootstrap.groups.length}</strong><small>件</small></div>
-          <div className={styles.stat}><span>表示企業</span><strong>{scope?.companies.length ?? 0}</strong><small>社</small></div>
-          <div className={styles.stat}><span>表示関係</span><strong>{relationships.length}</strong><small>件</small></div>
+          <div className={styles.stat}><span>企業グループ</span><strong>{groups.length}</strong><small>件</small></div>
+          <div className={styles.stat}><span>{scopeMode === "group" ? "所属企業" : "表示企業"}</span><strong>{scope?.companies.length ?? 0}</strong><small>社</small></div>
+          <div className={styles.stat}><span>企業間関係</span><strong>{relationships.length}</strong><small>件</small></div>
+          <div className={styles.stat}><span>表示モード</span><strong className={styles.statText}>{scopeMode === "group" ? "GROUP" : "DEEP"}</strong></div>
         </div>
       </header>
 
       <section className={styles.toolbar} aria-label="企業関係マップの表示条件">
         <div className={styles.controlRow}>
           <label className={styles.companySelect}>
-            <span>中心企業（入口）</span>
-            <select value={centerCompanyId} onChange={(event) => changeCenter(event.target.value)}>
-              {dropdownCompanies.map((company) => (
-                <option key={company.id} value={company.id}>
-                  {company.name}{entryCompanyIds.has(company.id) ? "" : "（中心表示中）"}
-                </option>
+            <span>企業グループ</span>
+            <select value={selectedGroupId} onChange={(event) => changeGroup(event.target.value)}>
+              {groups.map((group) => (
+                <option key={group.id} value={group.id}>{group.name}</option>
               ))}
             </select>
           </label>
           <input className={styles.search} type="search" value={query} placeholder="企業名・関係を検索" aria-label="企業関係を検索" onChange={(event) => setQuery(event.target.value)} />
         </div>
 
-        <details style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: "0 10px", background: "var(--color-bg-input)" }}>
-          <summary style={{ minHeight: 38, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, cursor: "pointer", fontSize: 11, fontWeight: 800, color: "var(--color-text-sub)" }}>
+        {scopeMode === "company" ? (
+          <div className={styles.deepDiveBar}>
+            <span>企業深掘り中: <strong>{centerCompany?.name ?? "読み込み中"}</strong></span>
+            <button type="button" className={styles.smallButton} onClick={returnToGroup}>← {activeGroup?.name ?? "企業グループ"}に戻る</button>
+          </div>
+        ) : null}
+
+        <details className={styles.filterDetails}>
+          <summary className={styles.filterSummary}>
             <span>絞り込み・表示設定</span>
-            <span style={{ color: "var(--color-text-muted)", fontWeight: 700 }}>{verifiedOnly ? "verified" : "全状態"} · {categories.size}種別</span>
+            <span>{verifiedOnly ? "verified" : "全状態"} · {categories.size}種別</span>
           </summary>
-          <div style={{ display: "grid", gap: 10, padding: "4px 0 10px" }}>
+          <div className={styles.filterDetailsBody}>
             {showHopControl ? (
               <div className={styles.controlRow}>
-                <span style={{ fontSize: 10, fontWeight: 800, color: "var(--color-text-muted)" }}>探索範囲</span>
+                <span className={styles.controlLabel}>探索範囲</span>
                 <div className={styles.hopControl} aria-label="探索の深さ">
                   {[1, 2].map((value) => (
                     <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>{value}-hop</button>
@@ -232,19 +265,103 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
       <div className={styles.workspace}>
         <section className={styles.canvas} aria-busy={loading}>
-          {loading ? <p className={styles.empty}>選択企業の関係を読み込んでいます…</p> : null}
+          {loading ? <p className={styles.empty}>{scopeMode === "group" ? "企業グループを読み込んでいます…" : "選択企業の関係を読み込んでいます…"}</p> : null}
           {loadError ? <p className={styles.empty}>{loadError}</p> : null}
           {!loading && scope && relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在の条件では表示できる関係がありません。</p> : null}
-          {scope && view === "network" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
-          {scope && view === "radial" ? <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
-          {scope && view === "hierarchy" ? <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
-          {scope && view === "table" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} /> : null}
+
+          {scope && view === "network" ? (
+            <NetworkView
+              companies={scope.companies}
+              relationships={relationships}
+              memberships={memberships}
+              centerCompanyId={scopeMode === "company" ? centerCompanyId : ""}
+              selection={activeSelection}
+              selectedRelationId={selectedRelationId}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectGroup={selectGroup}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+
+          {scope && view === "radial" && scopeMode === "group" && activeGroup ? (
+            <GroupRadialView
+              group={activeGroup}
+              companies={scope.companies}
+              relationships={relationships}
+              memberships={memberships}
+              selection={activeSelection}
+              selectedRelationId={selectedRelationId}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectGroup={selectGroup}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+
+          {scope && view === "radial" && scopeMode === "company" ? (
+            <RadialView
+              companies={scope.companies}
+              relationships={relationships}
+              memberships={memberships}
+              centerCompanyId={centerCompanyId}
+              selection={activeSelection}
+              selectedRelationId={selectedRelationId}
+              hops={hops}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectGroup={selectGroup}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+
+          {scope && view === "hierarchy" ? (
+            <HierarchyView
+              companies={scope.companies}
+              relationships={relationships}
+              centerCompanyId={hierarchyCenterId}
+              selectedCompanyId={selectedCompanyId}
+              selectedRelationId={selectedRelationId}
+              hops={hops}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectRelation={setSelectedRelationId}
+            />
+          ) : null}
+
+          {scope && view === "table" && scopeMode === "group" && activeGroup ? (
+            <GroupTableView
+              group={activeGroup}
+              companies={scope.companies}
+              memberships={memberships}
+              relationships={relationships}
+              selection={activeSelection}
+              query={query}
+              onSelectCompany={selectCompany}
+            />
+          ) : null}
+
+          {scope && view === "table" && scopeMode === "company" ? (
+            <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} />
+          ) : null}
         </section>
 
-        <DetailPanel groups={bootstrap.groups} companies={scope?.companies ?? []} selection={activeSelection} centerCompanyId={centerCompanyId} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
+        <DetailPanel
+          groups={groups}
+          companies={scope?.companies ?? []}
+          selection={activeSelection}
+          centerCompanyId={scopeMode === "company" ? centerCompanyId : ""}
+          relationships={relationships}
+          memberships={memberships}
+          selectedRelation={selectedRelation}
+          onSelectCompany={selectCompany}
+          onSelectGroup={selectGroup}
+          onSelectRelation={setSelectedRelationId}
+          onMakeCenter={changeCenter}
+        />
       </div>
 
-      <p className={styles.note}>企業・企業グループの選択は詳細と強調だけを変え、配置は動かしません。中心企業を変える場合だけ周辺データを再取得し、「再配置」は同じノード集合の位置だけを計算し直します。</p>
+      <p className={styles.note}>企業グループが主入口です。企業ノードの選択は詳細と強調だけを変え、配置は動かしません。「この企業を中心に見る」を押した場合だけ1-hop / 2-hopの企業深掘りへ切り替わります。</p>
     </main>
   );
 }

--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -199,7 +199,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           <div className={styles.stat}><span>企業グループ</span><strong>{groups.length}</strong><small>件</small></div>
           <div className={styles.stat}><span>{scopeMode === "group" ? "所属企業" : "表示企業"}</span><strong>{scope?.companies.length ?? 0}</strong><small>社</small></div>
           <div className={styles.stat}><span>企業間関係</span><strong>{relationships.length}</strong><small>件</small></div>
-          <div className={styles.stat}><span>表示モード</span><strong className={styles.statText}>{scopeMode === "group" ? "GROUP" : "DEEP"}</strong></div>
+          <div className={styles.stat}><span>表示モード</span><strong style={{ fontSize: 13 }}>{scopeMode === "group" ? "GROUP" : "DEEP"}</strong></div>
         </div>
       </header>
 
@@ -217,21 +217,21 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         </div>
 
         {scopeMode === "company" ? (
-          <div className={styles.deepDiveBar}>
-            <span>企業深掘り中: <strong>{centerCompany?.name ?? "読み込み中"}</strong></span>
+          <div className={styles.controlRow} style={{ justifyContent: "space-between", padding: "8px 10px", border: "1px solid var(--color-border)", borderRadius: 10, background: "var(--color-bg-input)" }}>
+            <span style={{ fontSize: 11, color: "var(--color-text-sub)" }}>企業深掘り中: <strong>{centerCompany?.name ?? "読み込み中"}</strong></span>
             <button type="button" className={styles.smallButton} onClick={returnToGroup}>← {activeGroup?.name ?? "企業グループ"}に戻る</button>
           </div>
         ) : null}
 
-        <details className={styles.filterDetails}>
-          <summary className={styles.filterSummary}>
+        <details style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: "0 10px", background: "var(--color-bg-input)" }}>
+          <summary style={{ minHeight: 38, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, cursor: "pointer", fontSize: 11, fontWeight: 800, color: "var(--color-text-sub)" }}>
             <span>絞り込み・表示設定</span>
-            <span>{verifiedOnly ? "verified" : "全状態"} · {categories.size}種別</span>
+            <span style={{ color: "var(--color-text-muted)", fontWeight: 700 }}>{verifiedOnly ? "verified" : "全状態"} · {categories.size}種別</span>
           </summary>
-          <div className={styles.filterDetailsBody}>
+          <div style={{ display: "grid", gap: 10, padding: "4px 0 10px" }}>
             {showHopControl ? (
               <div className={styles.controlRow}>
-                <span className={styles.controlLabel}>探索範囲</span>
+                <span style={{ fontSize: 10, fontWeight: 800, color: "var(--color-text-muted)" }}>探索範囲</span>
                 <div className={styles.hopControl} aria-label="探索の深さ">
                   {[1, 2].map((value) => (
                     <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>{value}-hop</button>
@@ -270,75 +270,23 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           {!loading && scope && relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在の条件では表示できる関係がありません。</p> : null}
 
           {scope && view === "network" ? (
-            <NetworkView
-              companies={scope.companies}
-              relationships={relationships}
-              memberships={memberships}
-              centerCompanyId={scopeMode === "company" ? centerCompanyId : ""}
-              selection={activeSelection}
-              selectedRelationId={selectedRelationId}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectGroup={selectGroup}
-              onSelectRelation={setSelectedRelationId}
-            />
+            <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={scopeMode === "company" ? centerCompanyId : ""} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
           ) : null}
 
           {scope && view === "radial" && scopeMode === "group" && activeGroup ? (
-            <GroupRadialView
-              group={activeGroup}
-              companies={scope.companies}
-              relationships={relationships}
-              memberships={memberships}
-              selection={activeSelection}
-              selectedRelationId={selectedRelationId}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectGroup={selectGroup}
-              onSelectRelation={setSelectedRelationId}
-            />
+            <GroupRadialView group={activeGroup} companies={scope.companies} relationships={relationships} memberships={memberships} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
           ) : null}
 
           {scope && view === "radial" && scopeMode === "company" ? (
-            <RadialView
-              companies={scope.companies}
-              relationships={relationships}
-              memberships={memberships}
-              centerCompanyId={centerCompanyId}
-              selection={activeSelection}
-              selectedRelationId={selectedRelationId}
-              hops={hops}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectGroup={selectGroup}
-              onSelectRelation={setSelectedRelationId}
-            />
+            <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
           ) : null}
 
           {scope && view === "hierarchy" ? (
-            <HierarchyView
-              companies={scope.companies}
-              relationships={relationships}
-              centerCompanyId={hierarchyCenterId}
-              selectedCompanyId={selectedCompanyId}
-              selectedRelationId={selectedRelationId}
-              hops={hops}
-              query={query}
-              onSelectCompany={selectCompany}
-              onSelectRelation={setSelectedRelationId}
-            />
+            <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={hierarchyCenterId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} />
           ) : null}
 
           {scope && view === "table" && scopeMode === "group" && activeGroup ? (
-            <GroupTableView
-              group={activeGroup}
-              companies={scope.companies}
-              memberships={memberships}
-              relationships={relationships}
-              selection={activeSelection}
-              query={query}
-              onSelectCompany={selectCompany}
-            />
+            <GroupTableView group={activeGroup} companies={scope.companies} memberships={memberships} relationships={relationships} selection={activeSelection} query={query} onSelectCompany={selectCompany} />
           ) : null}
 
           {scope && view === "table" && scopeMode === "company" ? (
@@ -346,19 +294,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           ) : null}
         </section>
 
-        <DetailPanel
-          groups={groups}
-          companies={scope?.companies ?? []}
-          selection={activeSelection}
-          centerCompanyId={scopeMode === "company" ? centerCompanyId : ""}
-          relationships={relationships}
-          memberships={memberships}
-          selectedRelation={selectedRelation}
-          onSelectCompany={selectCompany}
-          onSelectGroup={selectGroup}
-          onSelectRelation={setSelectedRelationId}
-          onMakeCenter={changeCenter}
-        />
+        <DetailPanel groups={groups} companies={scope?.companies ?? []} selection={activeSelection} centerCompanyId={scopeMode === "company" ? centerCompanyId : ""} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
       </div>
 
       <p className={styles.note}>企業グループが主入口です。企業ノードの選択は詳細と強調だけを変え、配置は動かしません。「この企業を中心に見る」を押した場合だけ1-hop / 2-hopの企業深掘りへ切り替わります。</p>

--- a/app/premium/company-network/data-loader.ts
+++ b/app/premium/company-network/data-loader.ts
@@ -144,6 +144,20 @@ function parseGroup(row: Row): CompanyNetworkGroup | null {
   return { id, name, groupType: stringValue(row, "group_type") };
 }
 
+async function loadCompaniesByIds(supabase: SupabaseClient, companyIds: string[]) {
+  if (companyIds.length === 0) return [] as CompanyNetworkCompany[];
+  const result = await supabase
+    .from("stock_notes_company_entities")
+    .select(COMPANY_SELECT)
+    .in("id", companyIds)
+    .neq("status", "archived")
+    .order("display_name", { ascending: true });
+  if (result.error) return null;
+  return ((result.data ?? []) as unknown as Row[])
+    .map(parseCompany)
+    .filter((row): row is CompanyNetworkCompany => row !== null);
+}
+
 export function companyNetworkUnconfigured(): CompanyNetworkBootstrapResult {
   return { status: "unconfigured", data: null, message: "Supabase 連携が未設定のため企業関係マップを取得できません。" };
 }
@@ -153,72 +167,97 @@ export function companyNetworkAuthRequired(): CompanyNetworkBootstrapResult {
 }
 
 export async function loadCompanyNetworkBootstrap(supabase: SupabaseClient): Promise<CompanyNetworkBootstrapResult> {
-  const [outboundResult, membershipIdsResult, groupsResult] = await Promise.all([
-    supabase
-      .from("stock_notes_company_relationship_edges_v")
-      .select("source_company_id")
-      .is("valid_to", null)
-      .in("verification_status", ["verified", "proposed"])
-      .limit(ROW_LIMIT),
-    supabase
-      .from("stock_notes_company_group_memberships_v")
-      .select("company_entity_id")
-      .is("valid_to", null)
-      .in("verification_status", ["verified", "proposed"])
-      .limit(ROW_LIMIT),
-    supabase
-      .from("stock_notes_corporate_groups")
-      .select("id,display_name,group_type")
-      .eq("status", "active")
-      .is("valid_to", null)
-      .in("verification_status", ["verified", "proposed"])
-      .order("display_name", { ascending: true })
-      .limit(ROW_LIMIT),
-  ]);
+  const groupsResult = await supabase
+    .from("stock_notes_corporate_groups")
+    .select("id,display_name,group_type")
+    .eq("status", "active")
+    .is("valid_to", null)
+    .in("verification_status", ["verified", "proposed"])
+    .order("display_name", { ascending: true })
+    .limit(ROW_LIMIT);
 
-  if (outboundResult.error || membershipIdsResult.error || groupsResult.error) {
-    return { status: "error", data: null, message: "企業関係マップの入口一覧を取得できませんでした。" };
+  if (groupsResult.error) {
+    return { status: "error", data: null, message: "企業グループ一覧を取得できませんでした。" };
   }
 
-  const outboundIds = new Set(
-    ((outboundResult.data ?? []) as unknown as Row[])
-      .map((row) => nullableString(row, "source_company_id"))
-      .filter((id): id is string => Boolean(id)),
-  );
-  const membershipIds = ((membershipIdsResult.data ?? []) as unknown as Row[])
-    .map((row) => nullableString(row, "company_entity_id"))
-    .filter((id): id is string => Boolean(id));
-  const candidateIds = [...new Set([...outboundIds, ...membershipIds])];
-
-  let candidates: CompanyNetworkCompany[] = [];
-  if (candidateIds.length > 0) {
-    const candidatesResult = await supabase
-      .from("stock_notes_company_entities")
-      .select(COMPANY_SELECT)
-      .in("id", candidateIds)
-      .neq("status", "archived")
-      .order("display_name", { ascending: true });
-    if (candidatesResult.error) {
-      return { status: "error", data: null, message: "中心企業候補を取得できませんでした。" };
-    }
-    candidates = ((candidatesResult.data ?? []) as unknown as Row[])
-      .map(parseCompany)
-      .filter((row): row is CompanyNetworkCompany => row !== null);
-  }
-
-  const entryCompanies = candidates
-    .filter((company) => company.listingStatus === "domestic_listed" || outboundIds.has(company.id))
-    .sort((a, b) => a.name.localeCompare(b.name, "ja"));
   const groups = ((groupsResult.data ?? []) as unknown as Row[])
     .map(parseGroup)
     .filter((row): row is CompanyNetworkGroup => row !== null);
 
-  if (entryCompanies.length === 0) {
-    return { status: "empty", data: { entryCompanies: [], groups, defaultCompanyId: "" }, message: "中心企業候補がまだありません。" };
+  if (groups.length === 0) {
+    return {
+      status: "empty",
+      data: { entryCompanies: [], groups: [], defaultCompanyId: "", defaultGroupId: "" },
+      message: "企業グループがまだありません。",
+    };
   }
 
-  const defaultCompanyId = entryCompanies.find((company) => company.name === "トヨタ自動車")?.id ?? entryCompanies[0].id;
-  return { status: "ok", data: { entryCompanies, groups, defaultCompanyId }, message: null };
+  const defaultGroupId = groups.find((group) => group.name === "トヨタグループ")?.id ?? groups[0].id;
+  return {
+    status: "ok",
+    data: { entryCompanies: [], groups, defaultCompanyId: "", defaultGroupId },
+    message: null,
+  };
+}
+
+export async function loadCompanyGroupScope(
+  supabase: SupabaseClient,
+  options: {
+    groupId: string;
+    verifiedOnly: boolean;
+    categories: RelationCategory[];
+  },
+): Promise<CompanyNetworkScopeResult> {
+  const statuses = options.verifiedOnly ? ["verified"] : ["verified", "proposed"];
+  const membershipResult = await supabase
+    .from("stock_notes_company_group_memberships_v")
+    .select(MEMBERSHIP_SELECT)
+    .eq("group_id", options.groupId)
+    .is("valid_to", null)
+    .in("verification_status", statuses)
+    .order("company_name", { ascending: true })
+    .limit(ROW_LIMIT);
+
+  if (membershipResult.error) {
+    return { status: "error", data: null, message: "選択した企業グループの所属企業を取得できませんでした。" };
+  }
+
+  const memberships = ((membershipResult.data ?? []) as unknown as Row[])
+    .map(parseMembership)
+    .filter((row): row is CompanyGroupMembership => row !== null);
+  const companyIds = [...new Set(memberships.map((membership) => membership.companyId))];
+  const companyIdSet = new Set(companyIds);
+
+  let relationships: CompanyRelationship[] = [];
+  if (companyIds.length > 0 && options.categories.length > 0) {
+    const relationshipResult = await supabase
+      .from("stock_notes_company_relationship_edges_v")
+      .select(RELATIONSHIP_SELECT)
+      .in("source_company_id", companyIds)
+      .in("relation_category", options.categories)
+      .is("valid_to", null)
+      .in("verification_status", statuses)
+      .order("source_company_name", { ascending: true })
+      .limit(ROW_LIMIT);
+    if (relationshipResult.error) {
+      return { status: "error", data: null, message: "グループ内の企業間関係を取得できませんでした。" };
+    }
+    relationships = ((relationshipResult.data ?? []) as unknown as Row[])
+      .map(parseRelationship)
+      .filter((row): row is CompanyRelationship => row !== null && companyIdSet.has(row.targetCompanyId));
+  }
+
+  const companies = await loadCompaniesByIds(supabase, companyIds);
+  if (companies === null) {
+    return { status: "error", data: null, message: "グループ所属企業の情報を取得できませんでした。" };
+  }
+
+  const data: CompanyNetworkData = { companies, relationships, memberships };
+  return {
+    status: memberships.length === 0 ? "empty" : "ok",
+    data,
+    message: memberships.length === 0 ? "このグループには現在の条件で表示できる所属企業がありません。" : null,
+  };
 }
 
 export async function loadCompanyNetworkScope(
@@ -313,20 +352,11 @@ export async function loadCompanyNetworkScope(
   });
   memberships.forEach((membership) => companyIds.add(membership.companyId));
 
-  const companiesResult = await supabase
-    .from("stock_notes_company_entities")
-    .select(COMPANY_SELECT)
-    .in("id", [...companyIds])
-    .neq("status", "archived")
-    .order("display_name", { ascending: true });
-
-  if (companiesResult.error) {
+  const companies = await loadCompaniesByIds(supabase, [...companyIds]);
+  if (companies === null) {
     return { status: "error", data: null, message: "表示対象企業の情報を取得できませんでした。" };
   }
 
-  const companies = ((companiesResult.data ?? []) as unknown as Row[])
-    .map(parseCompany)
-    .filter((row): row is CompanyNetworkCompany => row !== null);
   const data: CompanyNetworkData = { companies, relationships, memberships };
   const empty = relationships.length === 0 && memberships.length === 0;
   return { status: empty ? "empty" : "ok", data, message: empty ? "この企業には現在の条件で表示できる関係がありません。" : null };

--- a/app/premium/company-network/types.ts
+++ b/app/premium/company-network/types.ts
@@ -2,6 +2,7 @@ export type RelationCategory = "capital" | "control" | "historical";
 export type VerificationStatus = "proposed" | "verified" | "rejected" | "superseded";
 export type Confidence = "high" | "medium" | "low";
 export type CompanyNetworkNodeKind = "company" | "group";
+export type CompanyNetworkScopeMode = "group" | "company";
 
 export type CompanyNetworkNodeSelection = {
   kind: CompanyNetworkNodeKind;
@@ -69,9 +70,12 @@ export type CompanyNetworkData = {
 };
 
 export type CompanyNetworkBootstrapData = {
+  /** @deprecated group-first UIでは使用しない。互換性のため残す。 */
   entryCompanies: CompanyNetworkCompany[];
   groups: CompanyNetworkGroup[];
+  /** @deprecated group-first UIでは使用しない。互換性のため残す。 */
   defaultCompanyId: string;
+  defaultGroupId: string;
 };
 
 export type CompanyNetworkBootstrapResult =

--- a/app/premium/company-network/views/GroupRadialView.tsx
+++ b/app/premium/company-network/views/GroupRadialView.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { usePanZoom } from "../../industry-map/use-pan-zoom";
+import { buildSelectedNeighbourIds, groupGraphNodeId, selectedGraphNodeId } from "../node-selection";
+import styles from "../CompanyNetwork.module.css";
+import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
+import type {
+  CompanyGroupMembership,
+  CompanyNetworkCompany,
+  CompanyNetworkGroup,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "../types";
+
+type Point = { x: number; y: number };
+
+function truncate(value: string, max = 12) {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function placeMembers(memberships: CompanyGroupMembership[]): Map<string, Point> {
+  const result = new Map<string, Point>();
+  const sorted = [...memberships].sort((a, b) => a.companyName.localeCompare(b.companyName, "ja"));
+  const innerCount = sorted.length <= 12 ? sorted.length : Math.ceil(sorted.length / 2);
+  sorted.forEach((membership, index) => {
+    const inner = index < innerCount;
+    const ringIndex = inner ? index : index - innerCount;
+    const ringSize = inner ? innerCount : sorted.length - innerCount;
+    const radius = sorted.length <= 12 ? 300 : inner ? 245 : 405;
+    const angle = -Math.PI / 2 + (Math.PI * 2 * ringIndex) / Math.max(ringSize, 1);
+    result.set(membership.companyId, { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
+  });
+  return result;
+}
+
+type Props = {
+  group: CompanyNetworkGroup;
+  companies: CompanyNetworkCompany[];
+  relationships: CompanyRelationship[];
+  memberships: CompanyGroupMembership[];
+  selection: CompanyNetworkNodeSelection | null;
+  selectedRelationId: string | null;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+  onSelectGroup: (groupId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+};
+
+export default function GroupRadialView({
+  group,
+  companies,
+  relationships,
+  memberships,
+  selection,
+  selectedRelationId,
+  query,
+  onSelectCompany,
+  onSelectGroup,
+  onSelectRelation,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const panZoom = usePanZoom(svgRef, `group:${group.id}`);
+  const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
+  const groupMemberships = useMemo(
+    () => memberships.filter((membership) => membership.groupId === group.id),
+    [group.id, memberships],
+  );
+  const positions = useMemo(() => placeMembers(groupMemberships), [groupMemberships]);
+  const neighbourIds = useMemo(
+    () => buildSelectedNeighbourIds(selection, relationships, groupMemberships),
+    [groupMemberships, relationships, selection],
+  );
+  const selectedNodeId = selectedGraphNodeId(selection);
+  const normalizedQuery = query.trim().toLocaleLowerCase("ja");
+  const groupNodeId = groupGraphNodeId(group.id);
+
+  return (
+    <div className={styles.viewFade}>
+      <div className={styles.viewTools}>
+        <span>{group.name}の所属企業</span>
+        <span>{groupMemberships.length}社 / {relationships.length}企業間関係</span>
+      </div>
+      <div className={styles.svgWrap}>
+        <div className={styles.zoomControls}>
+          <button type="button" onClick={panZoom.zoomIn} aria-label="拡大">＋</button>
+          <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
+          <button type="button" onClick={panZoom.reset} disabled={!panZoom.canReset}>戻す</button>
+        </div>
+        <svg
+          ref={svgRef}
+          className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
+          style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
+          viewBox="-520 -520 1040 1040"
+          role="img"
+          aria-label={`${group.name}を中心にした企業グループ放射マップ`}
+          onPointerDown={panZoom.onPointerDown}
+          onDoubleClick={panZoom.onDoubleClick}
+        >
+          <defs>
+            <marker id="group-radial-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+              <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
+            </marker>
+          </defs>
+          <g transform={panZoom.transform}>
+            {groupMemberships.length > 12 ? <circle r="405" className={styles.radialGroupRing} /> : null}
+            <circle r={groupMemberships.length > 12 ? 245 : 300} className={styles.radialGroupRing} />
+
+            {groupMemberships.map((membership) => {
+              const point = positions.get(membership.companyId);
+              if (!point) return null;
+              const focused = neighbourIds === null || (neighbourIds.has(groupNodeId) && neighbourIds.has(membership.companyId));
+              return (
+                <line
+                  key={membership.membershipId}
+                  x1={0}
+                  y1={0}
+                  x2={point.x}
+                  y2={point.y}
+                  className={styles.membershipLine}
+                  strokeOpacity={focused ? 0.72 : 0.12}
+                />
+              );
+            })}
+
+            {relationships.map((relationship) => {
+              const source = positions.get(relationship.sourceCompanyId);
+              const target = positions.get(relationship.targetCompanyId);
+              if (!source || !target) return null;
+              const selected = relationship.relationId === selectedRelationId;
+              const focused = neighbourIds === null || (neighbourIds.has(relationship.sourceCompanyId) && neighbourIds.has(relationship.targetCompanyId));
+              return (
+                <g key={relationship.relationId} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget}>
+                  <line
+                    x1={source.x}
+                    y1={source.y}
+                    x2={target.x}
+                    y2={target.y}
+                    stroke={CATEGORY_COLOR[relationship.relationCategory]}
+                    strokeWidth={selected ? 3.2 : focused ? 1.8 : 1}
+                    strokeOpacity={selected ? 1 : focused ? 0.8 : 0.14}
+                    strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
+                    markerEnd="url(#group-radial-arrow)"
+                    color={CATEGORY_COLOR[relationship.relationCategory]}
+                  />
+                  {(selected || focused) ? (
+                    <text x={(source.x + target.x) / 2} y={(source.y + target.y) / 2 - 7} textAnchor="middle" className={styles.svgEdgeLabel}>
+                      {relationLabel(relationship.relationType, relationship.ownershipPct)}
+                    </text>
+                  ) : null}
+                </g>
+              );
+            })}
+
+            {groupMemberships.map((membership) => {
+              const company = companyById.get(membership.companyId);
+              const point = positions.get(membership.companyId);
+              if (!company || !point) return null;
+              const selected = selectedNodeId === company.id;
+              const queryDimmed = normalizedQuery.length > 0 && !company.name.toLocaleLowerCase("ja").includes(normalizedQuery);
+              const neighbourDimmed = neighbourIds !== null && !neighbourIds.has(company.id);
+              return (
+                <g
+                  key={company.id}
+                  transform={`translate(${point.x} ${point.y})`}
+                  className={queryDimmed || neighbourDimmed ? styles.svgNodeDim : undefined}
+                  role="button"
+                  tabIndex={0}
+                  style={{ cursor: "pointer" }}
+                  onClick={() => { if (!panZoom.didPan()) onSelectCompany(company.id); }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onSelectCompany(company.id);
+                    }
+                  }}
+                >
+                  {selected ? <circle className={styles.pulse} r="35" fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
+                  <circle r="25" fill="var(--color-bg-card)" stroke="#2554ff" strokeWidth={selected ? 3 : 2} />
+                  <text textAnchor="middle" y="-2" className={styles.radialNodeLabel}>{truncate(company.name)}</text>
+                  <text textAnchor="middle" y="13" className={styles.radialNodeMeta}>{company.listingStatus || membership.membershipRole}</text>
+                </g>
+              );
+            })}
+
+            <g
+              role="button"
+              tabIndex={0}
+              style={{ cursor: "pointer" }}
+              onClick={() => { if (!panZoom.didPan()) onSelectGroup(group.id); }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelectGroup(group.id);
+                }
+              }}
+            >
+              {selectedNodeId === groupNodeId ? <circle className={styles.pulse} r="78" fill="none" stroke="#d97706" strokeWidth={2} /> : null}
+              <circle r="64" fill="#fff7ed" stroke="#d97706" strokeWidth={selectedNodeId === groupNodeId ? 4 : 3} />
+              <text textAnchor="middle" y="-4" className={styles.radialGroupLabel}>{truncate(group.name, 14)}</text>
+              <text textAnchor="middle" y="14" className={styles.radialGroupMeta}>{groupTypeLabel(group.groupType)}</text>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/app/premium/company-network/views/GroupTableView.tsx
+++ b/app/premium/company-network/views/GroupTableView.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo } from "react";
+import styles from "../CompanyNetwork.module.css";
+import { formatAsOf, groupTypeLabel } from "../presentation";
+import type {
+  CompanyGroupMembership,
+  CompanyNetworkCompany,
+  CompanyNetworkGroup,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "../types";
+
+type Props = {
+  group: CompanyNetworkGroup;
+  companies: CompanyNetworkCompany[];
+  memberships: CompanyGroupMembership[];
+  relationships: CompanyRelationship[];
+  selection: CompanyNetworkNodeSelection | null;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+};
+
+export default function GroupTableView({
+  group,
+  companies,
+  memberships,
+  relationships,
+  selection,
+  query,
+  onSelectCompany,
+}: Props) {
+  const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
+  const relationCountByCompany = useMemo(() => {
+    const counts = new Map<string, number>();
+    relationships.forEach((relationship) => {
+      counts.set(relationship.sourceCompanyId, (counts.get(relationship.sourceCompanyId) ?? 0) + 1);
+      counts.set(relationship.targetCompanyId, (counts.get(relationship.targetCompanyId) ?? 0) + 1);
+    });
+    return counts;
+  }, [relationships]);
+  const normalized = query.trim().toLocaleLowerCase("ja");
+  const visible = useMemo(
+    () => memberships
+      .filter((membership) => membership.groupId === group.id)
+      .filter((membership) => {
+        if (!normalized) return true;
+        return [membership.companyName, membership.membershipRole, membership.membershipBasis]
+          .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+      })
+      .sort((a, b) => a.companyName.localeCompare(b.companyName, "ja")),
+    [group.id, memberships, normalized],
+  );
+
+  if (visible.length === 0) {
+    return <p className={`${styles.empty} ${styles.viewFade}`}>条件に一致するグループ所属企業がありません。</p>;
+  }
+
+  return (
+    <div className={`${styles.tableScroll} ${styles.viewFade}`}>
+      <table className={styles.table}>
+        <caption>{group.name}（{groupTypeLabel(group.groupType)}）の所属 {visible.length}社を表示</caption>
+        <thead>
+          <tr>
+            <th>企業</th>
+            <th>上場区分</th>
+            <th>role</th>
+            <th>membership basis</th>
+            <th>グループ内関係</th>
+            <th>検証</th>
+            <th>基準日</th>
+            <th>根拠</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map((membership) => {
+            const company = companyById.get(membership.companyId);
+            const selected = selection?.kind === "company" && selection.id === membership.companyId;
+            return (
+              <tr
+                key={membership.membershipId}
+                className={selected ? styles.tableRowSelected : undefined}
+                onClick={() => onSelectCompany(membership.companyId)}
+              >
+                <td>
+                  <button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(membership.companyId); }}>
+                    {membership.companyName}
+                  </button>
+                </td>
+                <td>{company?.listingStatus || "—"}</td>
+                <td>{membership.membershipRole || "—"}</td>
+                <td>{membership.membershipBasis || "—"}</td>
+                <td>{relationCountByCompany.get(membership.companyId) ?? 0}件</td>
+                <td>{membership.verificationStatus}</td>
+                <td>{formatAsOf(membership.sourceAsOf)}</td>
+                <td className={styles.tableSource}>{membership.sourceTitle ?? membership.sourceType ?? "—"}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #514

## 変更概要
- 企業関係マップの主入口を「中心企業」から「企業グループ」へ変更
- 初期ロードは企業グループ一覧だけに簡素化
- APIに `groupId` モードを追加し、選択グループのcurrent membership全体をオンデマンド取得
- グループ内で確認済みの企業間relationだけを併せて取得
- Networkはグループ全体を表示し、企業/グループ選択では配置を変更しない
- グループ用RadialViewを追加し、グループを中心に所属企業を放射表示
- グループ用TableViewを追加し、所属企業・role・basis・検証・根拠を一覧表示
- 系列ビューはグループ表示中に企業を選択した場合、その企業の資本/支配関係を表示
- `この企業を中心に見る` で既存のcompany 1-hop/2-hop深掘りへ明示的に切替
- 深掘り中は `グループに戻る` で元のグループ表示へ復帰
- DB schema変更なし

## 実データ確認
- トヨタグループ: verified/current 17社、グループ内relation 5件
- 三井グループ: verified/current 22社、グループ内relation 0件

## 確認
- [x] lint
- [x] test
- [x] build
- CI #991 success

## Follow-up
本番スマホ確認で4ビューの役割不整合が見つかったため #516 で継続対応。