### PR TITLE
refactor(company-network): 4ビューの役割と表示基点を整理

### DIFF
--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -13,6 +13,7 @@ import type {
   RelationCategory,
 } from "./types";
 import DetailPanel from "./views/DetailPanel";
+import GroupHierarchyView from "./views/GroupHierarchyView";
 import GroupRadialView from "./views/GroupRadialView";
 import GroupTableView from "./views/GroupTableView";
 import HierarchyView from "./views/HierarchyView";
@@ -29,13 +30,8 @@ type ScopedSelection = CompanyNetworkNodeSelection & { key: string };
 function StateScreen({ title, body }: { title: string; body: string }) {
   return (
     <main className={styles.page}>
-      <nav className={styles.topNav}>
-        <Link href="/premium" className={styles.topNavLink}>← Premium ホーム</Link>
-      </nav>
-      <section className={styles.state}>
-        <h1>{title}</h1>
-        <p>{body}</p>
-      </section>
+      <nav className={styles.topNav}><Link href="/premium" className={styles.topNavLink}>← Premium ホーム</Link></nav>
+      <section className={styles.state}><h1>{title}</h1><p>{body}</p></section>
     </main>
   );
 }
@@ -48,6 +44,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const [view, setView] = useState<CompanyNetworkViewMode>("network");
   const [scopeMode, setScopeMode] = useState<CompanyNetworkScopeMode>("group");
   const [selectedGroupId, setSelectedGroupId] = useState(defaultGroupId);
+  const [displayBaseCompanyId, setDisplayBaseCompanyId] = useState("");
   const [centerCompanyId, setCenterCompanyId] = useState("");
   const [selection, setSelection] = useState<ScopedSelection | null>(null);
   const [selectedRelationId, setSelectedRelationId] = useState<string | null>(null);
@@ -73,33 +70,25 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const selectedCompanyId = activeSelection?.kind === "company" ? activeSelection.id : "";
   const activeGroup = groups.find((group) => group.id === selectedGroupId) ?? groups[0] ?? null;
   const centerCompany = scope?.companies.find((company) => company.id === centerCompanyId) ?? null;
+  const displayBaseCompany = scope?.companies.find((company) => company.id === displayBaseCompanyId) ?? null;
+  const groupNetworkSelection = scopeMode === "group" && activeSelection?.kind === "group" ? null : activeSelection;
 
   useEffect(() => {
     if (!targetId) return;
     const controller = new AbortController();
-    const params = new URLSearchParams({
-      verifiedOnly: String(verifiedOnly),
-      categories: categoryKey,
-    });
-    if (scopeMode === "group") {
-      params.set("groupId", selectedGroupId);
-    } else {
+    const params = new URLSearchParams({ verifiedOnly: String(verifiedOnly), categories: categoryKey });
+    if (scopeMode === "group") params.set("groupId", selectedGroupId);
+    else {
       params.set("companyId", centerCompanyId);
       params.set("hops", String(hops));
       params.set("includeGroups", String(showGroups));
     }
     const key = requestKey;
 
-    fetch(`/api/premium/company-network?${params.toString()}`, {
-      credentials: "same-origin",
-      signal: controller.signal,
-      cache: "no-store",
-    })
+    fetch(`/api/premium/company-network?${params.toString()}`, { credentials: "same-origin", signal: controller.signal, cache: "no-store" })
       .then(async (response) => {
         const payload = await response.json() as CompanyNetworkScopeResult;
-        if (!response.ok || payload.status === "error" || payload.status === "unauthenticated" || payload.status === "unconfigured") {
-          throw new Error(payload.message);
-        }
+        if (!response.ok || payload.status === "error" || payload.status === "unauthenticated" || payload.status === "unconfigured") throw new Error(payload.message);
         return payload.data;
       })
       .then((data) => {
@@ -108,13 +97,9 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         setScopedError(null);
         setSelectedRelationId(null);
         setSelection((current) => {
-          if (current?.key === key) {
-            if (current.kind === "company" && data.companies.some((company) => company.id === current.id)) return current;
-            if (current.kind === "group" && data.memberships.some((membership) => membership.groupId === current.id)) return current;
-          }
-          return scopeMode === "group"
-            ? { key, kind: "group", id: selectedGroupId }
-            : { key, kind: "company", id: centerCompanyId };
+          if (current?.kind === "company" && data.companies.some((company) => company.id === current.id)) return { key, kind: "company", id: current.id };
+          if (current?.kind === "group" && data.memberships.some((membership) => membership.groupId === current.id)) return { key, kind: "group", id: current.id };
+          return scopeMode === "group" ? { key, kind: "group", id: selectedGroupId } : { key, kind: "company", id: centerCompanyId };
         });
       })
       .catch((error: unknown) => {
@@ -131,45 +116,45 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
   const viewIndex = VIEWS.findIndex((item) => item.mode === view);
   const showHopControl = scopeMode === "company" && (view === "radial" || view === "hierarchy");
   const showGroupControl = scopeMode === "company" && (view === "network" || view === "radial");
-  const hierarchyCenterId = scopeMode === "company" ? centerCompanyId : selectedCompanyId;
+  const showRelationFilters = scopeMode === "company" || view !== "radial";
 
   const selectCompany = (companyId: string) => {
     setSelection({ key: requestKey, kind: "company", id: companyId });
     setSelectedRelationId(null);
   };
-
   const selectGroup = (groupId: string) => {
     setSelection({ key: requestKey, kind: "group", id: groupId });
     setSelectedRelationId(null);
   };
-
   const changeGroup = (groupId: string) => {
     setSelectedGroupId(groupId);
     setScopeMode("group");
+    setDisplayBaseCompanyId("");
     setCenterCompanyId("");
     setSelection(null);
     setSelectedRelationId(null);
   };
-
+  const changeDisplayBase = (companyId: string) => {
+    setDisplayBaseCompanyId(companyId);
+    setSelectedRelationId(null);
+    setSelection(companyId ? { key: requestKey, kind: "company", id: companyId } : { key: requestKey, kind: "group", id: selectedGroupId });
+  };
   const changeCenter = (companyId: string) => {
     setScopeMode("company");
     setCenterCompanyId(companyId);
     setSelection(null);
     setSelectedRelationId(null);
   };
-
   const returnToGroup = () => {
     setScopeMode("group");
     setCenterCompanyId("");
     setSelection(null);
     setSelectedRelationId(null);
   };
-
   const toggleCategory = (category: RelationCategory) => {
     setCategories((current) => {
       const next = new Set(current);
-      if (next.has(category)) next.delete(category);
-      else next.add(category);
+      if (next.has(category)) next.delete(category); else next.add(category);
       return next;
     });
     setSelectedRelationId(null);
@@ -189,17 +174,14 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
       <header className={styles.hero}>
         <div className={styles.heroHead}>
-          <div>
-            <h1 className={styles.heroTitle}>企業関係マップ</h1>
-            <p className={styles.heroLead}>企業グループを入口に全体像を確認し、必要な企業だけ1-hop / 2-hopで深掘りします。閲覧専用です。</p>
-          </div>
-          <span className={styles.versionBadge}>company-network v4</span>
+          <div><h1 className={styles.heroTitle}>企業関係マップ</h1><p className={styles.heroLead}>企業グループを入口に、所属・企業間関係・資本系列を目的別に切り替えて確認します。閲覧専用です。</p></div>
+          <span className={styles.versionBadge}>company-network v5</span>
         </div>
         <div className={styles.statRow}>
           <div className={styles.stat}><span>企業グループ</span><strong>{groups.length}</strong><small>件</small></div>
           <div className={styles.stat}><span>{scopeMode === "group" ? "所属企業" : "表示企業"}</span><strong>{scope?.companies.length ?? 0}</strong><small>社</small></div>
           <div className={styles.stat}><span>企業間関係</span><strong>{relationships.length}</strong><small>件</small></div>
-          <div className={styles.stat}><span>表示モード</span><strong style={{ fontSize: 13 }}>{scopeMode === "group" ? "GROUP" : "DEEP"}</strong></div>
+          <div className={styles.stat}><span>表示基点</span><strong style={{ fontSize: 12 }}>{scopeMode === "company" ? centerCompany?.name ?? "読込中" : displayBaseCompany?.name ?? "グループ全体"}</strong></div>
         </div>
       </header>
 
@@ -207,12 +189,17 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <div className={styles.controlRow}>
           <label className={styles.companySelect}>
             <span>企業グループ</span>
-            <select value={selectedGroupId} onChange={(event) => changeGroup(event.target.value)}>
-              {groups.map((group) => (
-                <option key={group.id} value={group.id}>{group.name}</option>
-              ))}
-            </select>
+            <select value={selectedGroupId} onChange={(event) => changeGroup(event.target.value)}>{groups.map((group) => <option key={group.id} value={group.id}>{group.name}</option>)}</select>
           </label>
+          {scopeMode === "group" ? (
+            <label className={styles.companySelect}>
+              <span>表示基点</span>
+              <select value={displayBaseCompanyId} onChange={(event) => changeDisplayBase(event.target.value)}>
+                <option value="">グループ全体</option>
+                {(scope?.companies ?? []).map((company) => <option key={company.id} value={company.id}>{company.name}</option>)}
+              </select>
+            </label>
+          ) : null}
           <input className={styles.search} type="search" value={query} placeholder="企業名・関係を検索" aria-label="企業関係を検索" onChange={(event) => setQuery(event.target.value)} />
         </div>
 
@@ -225,41 +212,21 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
 
         <details style={{ border: "1px solid var(--color-border)", borderRadius: 10, padding: "0 10px", background: "var(--color-bg-input)" }}>
           <summary style={{ minHeight: 38, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, cursor: "pointer", fontSize: 11, fontWeight: 800, color: "var(--color-text-sub)" }}>
-            <span>絞り込み・表示設定</span>
-            <span style={{ color: "var(--color-text-muted)", fontWeight: 700 }}>{verifiedOnly ? "verified" : "全状態"} · {categories.size}種別</span>
+            <span>絞り込み・表示設定</span><span style={{ color: "var(--color-text-muted)", fontWeight: 700 }}>{verifiedOnly ? "確認済み" : "全状態"}{showRelationFilters ? ` · ${categories.size}種別` : ""}</span>
           </summary>
           <div style={{ display: "grid", gap: 10, padding: "4px 0 10px" }}>
-            {showHopControl ? (
-              <div className={styles.controlRow}>
-                <span style={{ fontSize: 10, fontWeight: 800, color: "var(--color-text-muted)" }}>探索範囲</span>
-                <div className={styles.hopControl} aria-label="探索の深さ">
-                  {[1, 2].map((value) => (
-                    <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>{value}-hop</button>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+            {showHopControl ? <div className={styles.controlRow}><span style={{ fontSize: 10, fontWeight: 800, color: "var(--color-text-muted)" }}>探索範囲</span><div className={styles.hopControl} aria-label="探索の深さ">{[1, 2].map((value) => <button key={value} type="button" className={hops === value ? styles.toggleOn : styles.toggle} onClick={() => setHops(value as 1 | 2)}>{value}-hop</button>)}</div></div> : null}
             <div className={styles.filterRow}>
-              {ALL_CATEGORIES.map((category) => (
-                <button key={category} type="button" className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`} aria-pressed={categories.has(category)} onClick={() => toggleCategory(category)}>
-                  <span className={styles.toggleDot} />{CATEGORY_LABEL[category]}
-                </button>
-              ))}
-              <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>verifiedのみ</button>
-              {showGroupControl ? (
-                <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>グループ表示</button>
-              ) : null}
+              {showRelationFilters ? ALL_CATEGORIES.map((category) => <button key={category} type="button" className={`${styles.toggle} ${categories.has(category) ? styles.toggleOn : ""}`} aria-pressed={categories.has(category)} onClick={() => toggleCategory(category)}><span className={styles.toggleDot} />{CATEGORY_LABEL[category]}</button>) : null}
+              <button type="button" className={`${styles.toggle} ${verifiedOnly ? styles.toggleOn : ""}`} aria-pressed={verifiedOnly} onClick={() => { setVerifiedOnly((value) => !value); setSelectedRelationId(null); }}>確認済みのみ</button>
+              {showGroupControl ? <button type="button" className={`${styles.toggle} ${showGroups ? styles.toggleOn : ""}`} aria-pressed={showGroups} onClick={() => setShowGroups((value) => !value)}>グループ表示</button> : null}
             </div>
           </div>
         </details>
 
         <div className={styles.segmented} role="tablist" aria-label="表現の切り替え">
           <span className={styles.segmentedIndicator} style={{ left: `calc(3px + (100% - 6px) * ${Math.max(viewIndex, 0)} / ${VIEWS.length})`, width: `calc((100% - 6px) / ${VIEWS.length})` }} aria-hidden />
-          {VIEWS.map((item) => (
-            <button key={item.mode} type="button" role="tab" aria-selected={item.mode === view} className={`${styles.segmentButton} ${item.mode === view ? styles.segmentButtonActive : ""}`} onClick={() => setView(item.mode)} title={item.question}>
-              <span aria-hidden>{item.icon}</span><span>{item.label}</span>
-            </button>
-          ))}
+          {VIEWS.map((item) => <button key={item.mode} type="button" role="tab" aria-selected={item.mode === view} className={`${styles.segmentButton} ${item.mode === view ? styles.segmentButtonActive : ""}`} onClick={() => setView(item.mode)} title={item.question}><span aria-hidden>{item.icon}</span><span>{item.label}</span></button>)}
         </div>
       </section>
 
@@ -267,37 +234,29 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <section className={styles.canvas} aria-busy={loading}>
           {loading ? <p className={styles.empty}>{scopeMode === "group" ? "企業グループを読み込んでいます…" : "選択企業の関係を読み込んでいます…"}</p> : null}
           {loadError ? <p className={styles.empty}>{loadError}</p> : null}
-          {!loading && scope && relationships.length === 0 && memberships.length === 0 ? <p className={styles.empty}>現在の条件では表示できる関係がありません。</p> : null}
 
-          {scope && view === "network" ? (
-            <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={scopeMode === "company" ? centerCompanyId : ""} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
+          {scope && view === "network" && scopeMode === "group" && activeGroup ? (
+            relationships.length === 0
+              ? <p className={styles.empty}><strong>{activeGroup.name}</strong>の所属 {memberships.length}社は確認済みですが、グループ内の企業間relationは現在未登録です。</p>
+              : <NetworkView title={`${activeGroup.name}の企業間関係`} companies={scope.companies} relationships={relationships} memberships={[]} centerCompanyId="" selection={groupNetworkSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
           ) : null}
+          {scope && view === "network" && scopeMode === "company" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
 
-          {scope && view === "radial" && scopeMode === "group" && activeGroup ? (
-            <GroupRadialView group={activeGroup} companies={scope.companies} relationships={relationships} memberships={memberships} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
-          ) : null}
+          {scope && view === "radial" && scopeMode === "group" && activeGroup ? <GroupRadialView group={activeGroup} companies={scope.companies} memberships={memberships} selection={activeSelection} focusCompanyId={displayBaseCompanyId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} /> : null}
+          {scope && view === "radial" && scopeMode === "company" ? <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
 
-          {scope && view === "radial" && scopeMode === "company" ? (
-            <RadialView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
-          ) : null}
+          {scope && view === "hierarchy" && scopeMode === "group" && activeGroup && !displayBaseCompanyId ? <GroupHierarchyView groupName={activeGroup.name} companies={scope.companies} relationships={relationships} query={query} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "hierarchy" && scopeMode === "group" && displayBaseCompanyId ? <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={displayBaseCompanyId} selectedCompanyId={selectedCompanyId || displayBaseCompanyId} selectedRelationId={selectedRelationId} hops={2} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "hierarchy" && scopeMode === "company" ? <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={centerCompanyId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
 
-          {scope && view === "hierarchy" ? (
-            <HierarchyView companies={scope.companies} relationships={relationships} centerCompanyId={hierarchyCenterId} selectedCompanyId={selectedCompanyId} selectedRelationId={selectedRelationId} hops={hops} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} />
-          ) : null}
-
-          {scope && view === "table" && scopeMode === "group" && activeGroup ? (
-            <GroupTableView group={activeGroup} companies={scope.companies} memberships={memberships} relationships={relationships} selection={activeSelection} query={query} onSelectCompany={selectCompany} />
-          ) : null}
-
-          {scope && view === "table" && scopeMode === "company" ? (
-            <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} />
-          ) : null}
+          {scope && view === "table" && scopeMode === "group" && activeGroup ? <GroupTableView group={activeGroup} companies={scope.companies} memberships={memberships} relationships={relationships} selection={activeSelection} selectedRelationId={selectedRelationId} focusCompanyId={displayBaseCompanyId} query={query} onSelectCompany={selectCompany} onSelectRelation={setSelectedRelationId} /> : null}
+          {scope && view === "table" && scopeMode === "company" ? <TableView relationships={relationships} selectedRelationId={selectedRelationId} query={query} onSelectRelation={setSelectedRelationId} onSelectCompany={selectCompany} /> : null}
         </section>
 
         <DetailPanel groups={groups} companies={scope?.companies ?? []} selection={activeSelection} centerCompanyId={scopeMode === "company" ? centerCompanyId : ""} relationships={relationships} memberships={memberships} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
       </div>
 
-      <p className={styles.note}>企業グループが主入口です。企業ノードの選択は詳細と強調だけを変え、配置は動かしません。「この企業を中心に見る」を押した場合だけ1-hop / 2-hopの企業深掘りへ切り替わります。</p>
+      <p className={styles.note}>関係＝企業間relation、放射＝グループ所属、系列＝資本・支配構造、表＝人が読む確認一覧です。企業ノードのクリックは詳細選択だけで、配置やデータ取得範囲は変えません。</p>
     </main>
   );
 }

--- a/app/premium/company-network/presentation.ts
+++ b/app/premium/company-network/presentation.ts
@@ -44,25 +44,25 @@ export const VIEWS: readonly {
     mode: "network",
     icon: "🕸",
     label: "関係",
-    question: "企業・企業グループのつながりを全体ネットワークで見る。",
+    question: "グループ内で確認済みの企業間relationだけを見る。",
   },
   {
     mode: "radial",
     icon: "🌐",
     label: "放射",
-    question: "選択した企業を中心に、1-hop / 2-hopの広がりを見る。",
+    question: "企業グループに誰が所属しているかを見る。",
   },
   {
     mode: "hierarchy",
     icon: "🗂",
     label: "系列",
-    question: "親会社・支配・出資の向きを保ったまま上位 / 下位をたどる。",
+    question: "出資・親会社・支配・持分法の上下構造を見る。",
   },
   {
     mode: "table",
     icon: "☰",
     label: "表",
-    question: "関係種別・比率・検証状態・根拠日を正確に確認する。",
+    question: "構成企業と確認済み事実を人が読みやすい一覧で確認する。",
   },
 ];
 

--- a/app/premium/company-network/views/GroupHierarchyView.tsx
+++ b/app/premium/company-network/views/GroupHierarchyView.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useMemo } from "react";
+import styles from "../CompanyNetwork.module.css";
+import { relationLabel } from "../presentation";
+import type { CompanyNetworkCompany, CompanyRelationship } from "../types";
+
+const SERIES_TYPES = new Set(["equity_ownership", "parent_of", "controls", "equity_method_investment"]);
+
+type TreeRow = {
+  relationship: CompanyRelationship;
+  depth: number;
+};
+
+type Props = {
+  groupName: string;
+  companies: CompanyNetworkCompany[];
+  relationships: CompanyRelationship[];
+  query: string;
+  selectedCompanyId: string;
+  selectedRelationId: string | null;
+  onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
+};
+
+export default function GroupHierarchyView({
+  groupName,
+  companies,
+  relationships,
+  query,
+  selectedCompanyId,
+  selectedRelationId,
+  onSelectCompany,
+  onSelectRelation,
+}: Props) {
+  const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
+  const normalized = query.trim().toLocaleLowerCase("ja");
+  const seriesRelationships = useMemo(
+    () => relationships.filter((relationship) => SERIES_TYPES.has(relationship.relationType)),
+    [relationships],
+  );
+
+  const forest = useMemo(() => {
+    const children = new Map<string, CompanyRelationship[]>();
+    const sourceIds = new Set<string>();
+    const targetIds = new Set<string>();
+    seriesRelationships.forEach((relationship) => {
+      sourceIds.add(relationship.sourceCompanyId);
+      targetIds.add(relationship.targetCompanyId);
+      children.set(relationship.sourceCompanyId, [...(children.get(relationship.sourceCompanyId) ?? []), relationship]);
+    });
+    const roots = [...sourceIds].filter((id) => !targetIds.has(id));
+    const rootIds = roots.length > 0 ? roots : [...sourceIds].slice(0, 1);
+    const used = new Set<string>();
+
+    const walk = (companyId: string, depth: number, path: Set<string>, rows: TreeRow[]) => {
+      for (const relationship of children.get(companyId) ?? []) {
+        if (used.has(relationship.relationId)) continue;
+        used.add(relationship.relationId);
+        rows.push({ relationship, depth });
+        if (!path.has(relationship.targetCompanyId)) {
+          walk(relationship.targetCompanyId, depth + 1, new Set([...path, relationship.targetCompanyId]), rows);
+        }
+      }
+    };
+
+    const trees = rootIds.map((rootId) => {
+      const rows: TreeRow[] = [];
+      walk(rootId, 1, new Set([rootId]), rows);
+      return { rootId, rows };
+    });
+
+    const leftovers = seriesRelationships.filter((relationship) => !used.has(relationship.relationId));
+    if (leftovers.length > 0) {
+      const rows = leftovers.map((relationship) => ({ relationship, depth: 1 }));
+      trees.push({ rootId: leftovers[0].sourceCompanyId, rows });
+    }
+    return trees;
+  }, [seriesRelationships]);
+
+  if (seriesRelationships.length === 0) {
+    return (
+      <div className={`${styles.seriesView} ${styles.viewFade}`}>
+        <p className={styles.seriesIntro}><strong>{groupName}</strong>の所属企業は確認済みですが、グループ内の資本・支配関係はまだ登録されていません。表示不具合ではなく、企業間relationのデータが未登録です。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${styles.seriesView} ${styles.viewFade}`}>
+      <p className={styles.seriesIntro}><strong>{groupName}</strong>内で確認済みの出資・親会社・支配・持分法関係を、グループ全体の系列として表示します。グループ所属そのものは親子関係として扱いません。</p>
+      {forest.map((tree, treeIndex) => {
+        const root = companyById.get(tree.rootId);
+        if (!root) return null;
+        return (
+          <section key={`${tree.rootId}:${treeIndex}`} className={styles.seriesSection}>
+            <button type="button" className={styles.seriesCenter} onClick={() => onSelectCompany(root.id)}>
+              <span>ROOT</span><strong>{root.name}</strong><small>確認済み資本構造の起点</small>
+            </button>
+            <div className={styles.seriesRows}>
+              {tree.rows.map(({ relationship, depth }) => {
+                const target = companyById.get(relationship.targetCompanyId);
+                if (!target) return null;
+                const dimmed = normalized.length > 0 && ![relationship.sourceCompanyName, relationship.targetCompanyName]
+                  .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+                return (
+                  <div key={relationship.relationId} className={`${styles.seriesRow} ${dimmed ? styles.seriesRowDim : ""}`} style={{ marginLeft: Math.min(depth - 1, 4) * 18 }}>
+                    <button type="button" className={styles.seriesCompany} onClick={() => onSelectCompany(target.id)} aria-pressed={selectedCompanyId === target.id}>
+                      <span className={styles.seriesDepth}>L{depth}</span><strong>{target.name}</strong>
+                    </button>
+                    <button type="button" className={`${styles.seriesRelation} ${selectedRelationId === relationship.relationId ? styles.seriesRelationActive : ""}`} onClick={() => onSelectRelation(relationship.relationId)}>
+                      <span>{relationship.sourceCompanyName} → {relationship.targetCompanyName}</span>
+                      <strong>{relationLabel(relationship.relationType, relationship.ownershipPct)}</strong>
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/premium/company-network/views/GroupRadialView.tsx
+++ b/app/premium/company-network/views/GroupRadialView.tsx
@@ -2,21 +2,27 @@
 
 import { useMemo, useRef } from "react";
 import { usePanZoom } from "../../industry-map/use-pan-zoom";
-import { buildSelectedNeighbourIds, groupGraphNodeId, selectedGraphNodeId } from "../node-selection";
+import { groupGraphNodeId, selectedGraphNodeId } from "../node-selection";
 import styles from "../CompanyNetwork.module.css";
-import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
+import { groupTypeLabel } from "../presentation";
 import type {
   CompanyGroupMembership,
   CompanyNetworkCompany,
   CompanyNetworkGroup,
   CompanyNetworkNodeSelection,
-  CompanyRelationship,
 } from "../types";
 
 type Point = { x: number; y: number };
 
 function truncate(value: string, max = 12) {
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function listingLabel(value: string) {
+  if (value === "domestic_listed") return "上場";
+  if (value === "foreign_listed") return "海外上場";
+  if (value === "private") return "非上場";
+  return "未確認";
 }
 
 function placeMembers(memberships: CompanyGroupMembership[]): Map<string, Point> {
@@ -37,27 +43,23 @@ function placeMembers(memberships: CompanyGroupMembership[]): Map<string, Point>
 type Props = {
   group: CompanyNetworkGroup;
   companies: CompanyNetworkCompany[];
-  relationships: CompanyRelationship[];
   memberships: CompanyGroupMembership[];
   selection: CompanyNetworkNodeSelection | null;
-  selectedRelationId: string | null;
+  focusCompanyId: string;
   query: string;
   onSelectCompany: (companyId: string) => void;
   onSelectGroup: (groupId: string) => void;
-  onSelectRelation: (relationId: string) => void;
 };
 
 export default function GroupRadialView({
   group,
   companies,
-  relationships,
   memberships,
   selection,
-  selectedRelationId,
+  focusCompanyId,
   query,
   onSelectCompany,
   onSelectGroup,
-  onSelectRelation,
 }: Props) {
   const svgRef = useRef<SVGSVGElement>(null);
   const panZoom = usePanZoom(svgRef, `group:${group.id}`);
@@ -67,10 +69,6 @@ export default function GroupRadialView({
     [group.id, memberships],
   );
   const positions = useMemo(() => placeMembers(groupMemberships), [groupMemberships]);
-  const neighbourIds = useMemo(
-    () => buildSelectedNeighbourIds(selection, relationships, groupMemberships),
-    [groupMemberships, relationships, selection],
-  );
   const selectedNodeId = selectedGraphNodeId(selection);
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
   const groupNodeId = groupGraphNodeId(group.id);
@@ -79,7 +77,7 @@ export default function GroupRadialView({
     <div className={styles.viewFade}>
       <div className={styles.viewTools}>
         <span>{group.name}の所属企業</span>
-        <span>{groupMemberships.length}社 / {relationships.length}企業間関係</span>
+        <span>{groupMemberships.length}社</span>
       </div>
       <div className={styles.svgWrap}>
         <div className={styles.zoomControls}>
@@ -93,15 +91,10 @@ export default function GroupRadialView({
           style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
           viewBox="-520 -520 1040 1040"
           role="img"
-          aria-label={`${group.name}を中心にした企業グループ放射マップ`}
+          aria-label={`${group.name}の所属企業を示す放射マップ`}
           onPointerDown={panZoom.onPointerDown}
           onDoubleClick={panZoom.onDoubleClick}
         >
-          <defs>
-            <marker id="group-radial-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse">
-              <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
-            </marker>
-          </defs>
           <g transform={panZoom.transform}>
             {groupMemberships.length > 12 ? <circle r="405" className={styles.radialGroupRing} /> : null}
             <circle r={groupMemberships.length > 12 ? 245 : 300} className={styles.radialGroupRing} />
@@ -109,7 +102,7 @@ export default function GroupRadialView({
             {groupMemberships.map((membership) => {
               const point = positions.get(membership.companyId);
               if (!point) return null;
-              const focused = neighbourIds === null || (neighbourIds.has(groupNodeId) && neighbourIds.has(membership.companyId));
+              const focused = !focusCompanyId || focusCompanyId === membership.companyId;
               return (
                 <line
                   key={membership.membershipId}
@@ -118,37 +111,8 @@ export default function GroupRadialView({
                   x2={point.x}
                   y2={point.y}
                   className={styles.membershipLine}
-                  strokeOpacity={focused ? 0.72 : 0.12}
+                  strokeOpacity={focused ? 0.72 : 0.22}
                 />
-              );
-            })}
-
-            {relationships.map((relationship) => {
-              const source = positions.get(relationship.sourceCompanyId);
-              const target = positions.get(relationship.targetCompanyId);
-              if (!source || !target) return null;
-              const selected = relationship.relationId === selectedRelationId;
-              const focused = neighbourIds === null || (neighbourIds.has(relationship.sourceCompanyId) && neighbourIds.has(relationship.targetCompanyId));
-              return (
-                <g key={relationship.relationId} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget}>
-                  <line
-                    x1={source.x}
-                    y1={source.y}
-                    x2={target.x}
-                    y2={target.y}
-                    stroke={CATEGORY_COLOR[relationship.relationCategory]}
-                    strokeWidth={selected ? 3.2 : focused ? 1.8 : 1}
-                    strokeOpacity={selected ? 1 : focused ? 0.8 : 0.14}
-                    strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"}
-                    markerEnd="url(#group-radial-arrow)"
-                    color={CATEGORY_COLOR[relationship.relationCategory]}
-                  />
-                  {(selected || focused) ? (
-                    <text x={(source.x + target.x) / 2} y={(source.y + target.y) / 2 - 7} textAnchor="middle" className={styles.svgEdgeLabel}>
-                      {relationLabel(relationship.relationType, relationship.ownershipPct)}
-                    </text>
-                  ) : null}
-                </g>
               );
             })}
 
@@ -157,13 +121,13 @@ export default function GroupRadialView({
               const point = positions.get(membership.companyId);
               if (!company || !point) return null;
               const selected = selectedNodeId === company.id;
+              const focused = !focusCompanyId || focusCompanyId === company.id;
               const queryDimmed = normalizedQuery.length > 0 && !company.name.toLocaleLowerCase("ja").includes(normalizedQuery);
-              const neighbourDimmed = neighbourIds !== null && !neighbourIds.has(company.id);
               return (
                 <g
                   key={company.id}
                   transform={`translate(${point.x} ${point.y})`}
-                  className={queryDimmed || neighbourDimmed ? styles.svgNodeDim : undefined}
+                  className={queryDimmed || !focused ? styles.svgNodeDim : undefined}
                   role="button"
                   tabIndex={0}
                   style={{ cursor: "pointer" }}
@@ -176,9 +140,9 @@ export default function GroupRadialView({
                   }}
                 >
                   {selected ? <circle className={styles.pulse} r="35" fill="none" stroke="#2554ff" strokeWidth={2} /> : null}
-                  <circle r="25" fill="var(--color-bg-card)" stroke="#2554ff" strokeWidth={selected ? 3 : 2} />
+                  <circle r="25" fill="var(--color-bg-card)" stroke="#2554ff" strokeWidth={selected || focusCompanyId === company.id ? 3 : 2} />
                   <text textAnchor="middle" y="-2" className={styles.radialNodeLabel}>{truncate(company.name)}</text>
-                  <text textAnchor="middle" y="13" className={styles.radialNodeMeta}>{company.listingStatus || membership.membershipRole}</text>
+                  <text textAnchor="middle" y="13" className={styles.radialNodeMeta}>{listingLabel(company.listingStatus)}</text>
                 </g>
               );
             })}

--- a/app/premium/company-network/views/GroupTableView.tsx
+++ b/app/premium/company-network/views/GroupTableView.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import styles from "../CompanyNetwork.module.css";
-import { formatAsOf, groupTypeLabel } from "../presentation";
+import { formatAsOf, relationLabel } from "../presentation";
 import type {
   CompanyGroupMembership,
   CompanyNetworkCompany,
@@ -17,9 +17,34 @@ type Props = {
   memberships: CompanyGroupMembership[];
   relationships: CompanyRelationship[];
   selection: CompanyNetworkNodeSelection | null;
+  selectedRelationId: string | null;
+  focusCompanyId: string;
   query: string;
   onSelectCompany: (companyId: string) => void;
+  onSelectRelation: (relationId: string) => void;
 };
+
+type TableMode = "companies" | "relations";
+
+function listingLabel(value: string) {
+  if (value === "domestic_listed") return "上場";
+  if (value === "foreign_listed") return "海外上場";
+  if (value === "private") return "非上場";
+  return "未確認";
+}
+
+function relationSentence(relationship: CompanyRelationship, companyId: string) {
+  const inbound = relationship.targetCompanyId === companyId;
+  const other = inbound ? relationship.sourceCompanyName : relationship.targetCompanyName;
+  if (relationship.relationType === "equity_ownership") {
+    const pct = relationship.ownershipPct === null ? "" : `${relationship.ownershipPct}%`;
+    return inbound ? `${other}が${pct}出資` : `${other}へ${pct}出資`;
+  }
+  if (relationship.relationType === "parent_of") return inbound ? `${other}が親会社` : `${other}の親会社`;
+  if (relationship.relationType === "controls") return inbound ? `${other}が支配` : `${other}を支配`;
+  if (relationship.relationType === "equity_method_investment") return inbound ? `${other}の持分法対象` : `${other}へ持分法投資`;
+  return `${other}と${relationLabel(relationship.relationType, relationship.ownershipPct)}`;
+}
 
 export default function GroupTableView({
   group,
@@ -27,78 +52,126 @@ export default function GroupTableView({
   memberships,
   relationships,
   selection,
+  selectedRelationId,
+  focusCompanyId,
   query,
   onSelectCompany,
+  onSelectRelation,
 }: Props) {
+  const [mode, setMode] = useState<TableMode>("companies");
   const companyById = useMemo(() => new Map(companies.map((company) => [company.id, company])), [companies]);
-  const relationCountByCompany = useMemo(() => {
-    const counts = new Map<string, number>();
+  const relationshipsByCompany = useMemo(() => {
+    const result = new Map<string, CompanyRelationship[]>();
     relationships.forEach((relationship) => {
-      counts.set(relationship.sourceCompanyId, (counts.get(relationship.sourceCompanyId) ?? 0) + 1);
-      counts.set(relationship.targetCompanyId, (counts.get(relationship.targetCompanyId) ?? 0) + 1);
+      result.set(relationship.sourceCompanyId, [...(result.get(relationship.sourceCompanyId) ?? []), relationship]);
+      result.set(relationship.targetCompanyId, [...(result.get(relationship.targetCompanyId) ?? []), relationship]);
     });
-    return counts;
+    return result;
   }, [relationships]);
   const normalized = query.trim().toLocaleLowerCase("ja");
-  const visible = useMemo(
+
+  const visibleMemberships = useMemo(
     () => memberships
       .filter((membership) => membership.groupId === group.id)
       .filter((membership) => {
-        if (!normalized) return true;
-        return [membership.companyName, membership.membershipRole, membership.membershipBasis]
-          .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+        const companyRelations = relationshipsByCompany.get(membership.companyId) ?? [];
+        const searchable = [
+          membership.companyName,
+          listingLabel(companyById.get(membership.companyId)?.listingStatus ?? ""),
+          ...companyRelations.map((relationship) => relationSentence(relationship, membership.companyId)),
+        ].join(" ").toLocaleLowerCase("ja");
+        return !normalized || searchable.includes(normalized);
       })
-      .sort((a, b) => a.companyName.localeCompare(b.companyName, "ja")),
-    [group.id, memberships, normalized],
+      .sort((a, b) => {
+        if (focusCompanyId) {
+          if (a.companyId === focusCompanyId) return -1;
+          if (b.companyId === focusCompanyId) return 1;
+        }
+        return a.companyName.localeCompare(b.companyName, "ja");
+      }),
+    [companyById, focusCompanyId, group.id, memberships, normalized, relationshipsByCompany],
   );
 
-  if (visible.length === 0) {
-    return <p className={`${styles.empty} ${styles.viewFade}`}>条件に一致するグループ所属企業がありません。</p>;
-  }
+  const visibleRelationships = useMemo(
+    () => relationships.filter((relationship) => {
+      if (focusCompanyId && relationship.sourceCompanyId !== focusCompanyId && relationship.targetCompanyId !== focusCompanyId) return false;
+      if (!normalized) return true;
+      return [relationship.sourceCompanyName, relationship.targetCompanyName, relationLabel(relationship.relationType, relationship.ownershipPct)]
+        .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+    }),
+    [focusCompanyId, normalized, relationships],
+  );
 
   return (
-    <div className={`${styles.tableScroll} ${styles.viewFade}`}>
-      <table className={styles.table}>
-        <caption>{group.name}（{groupTypeLabel(group.groupType)}）の所属 {visible.length}社を表示</caption>
-        <thead>
-          <tr>
-            <th>企業</th>
-            <th>上場区分</th>
-            <th>role</th>
-            <th>membership basis</th>
-            <th>グループ内関係</th>
-            <th>検証</th>
-            <th>基準日</th>
-            <th>根拠</th>
-          </tr>
-        </thead>
-        <tbody>
-          {visible.map((membership) => {
-            const company = companyById.get(membership.companyId);
-            const selected = selection?.kind === "company" && selection.id === membership.companyId;
-            return (
-              <tr
-                key={membership.membershipId}
-                className={selected ? styles.tableRowSelected : undefined}
-                onClick={() => onSelectCompany(membership.companyId)}
-              >
-                <td>
-                  <button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(membership.companyId); }}>
-                    {membership.companyName}
-                  </button>
-                </td>
-                <td>{company?.listingStatus || "—"}</td>
-                <td>{membership.membershipRole || "—"}</td>
-                <td>{membership.membershipBasis || "—"}</td>
-                <td>{relationCountByCompany.get(membership.companyId) ?? 0}件</td>
-                <td>{membership.verificationStatus}</td>
-                <td>{formatAsOf(membership.sourceAsOf)}</td>
-                <td className={styles.tableSource}>{membership.sourceTitle ?? membership.sourceType ?? "—"}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+    <div className={styles.viewFade}>
+      <div className={styles.viewTools}>
+        <div className={styles.hopControl} aria-label="表の内容">
+          <button type="button" className={mode === "companies" ? styles.toggleOn : styles.toggle} onClick={() => setMode("companies")}>企業一覧</button>
+          <button type="button" className={mode === "relations" ? styles.toggleOn : styles.toggle} onClick={() => setMode("relations")}>企業間関係</button>
+        </div>
+        <span>{group.name}</span>
+      </div>
+
+      {mode === "companies" ? (
+        visibleMemberships.length === 0 ? <p className={styles.empty}>条件に一致する所属企業がありません。</p> : (
+          <div className={styles.tableScroll}>
+            <table className={styles.table} style={{ minWidth: 720 }}>
+              <caption>所属 {visibleMemberships.length}社。DB内部コードではなく、判断に使う情報だけを表示しています。</caption>
+              <thead>
+                <tr>
+                  <th>企業</th>
+                  <th>上場</th>
+                  <th>グループ内の主な関係</th>
+                  <th>基準日</th>
+                  <th>根拠</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleMemberships.map((membership) => {
+                  const company = companyById.get(membership.companyId);
+                  const companyRelations = relationshipsByCompany.get(membership.companyId) ?? [];
+                  const selected = selection?.kind === "company" && selection.id === membership.companyId;
+                  const summary = companyRelations.length === 0
+                    ? "企業間関係は未登録"
+                    : companyRelations.slice(0, 2).map((relationship) => relationSentence(relationship, membership.companyId)).join(" / ") + (companyRelations.length > 2 ? ` ほか${companyRelations.length - 2}件` : "");
+                  return (
+                    <tr key={membership.membershipId} className={selected || focusCompanyId === membership.companyId ? styles.tableRowSelected : undefined} onClick={() => onSelectCompany(membership.companyId)}>
+                      <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(membership.companyId); }}>{membership.companyName}</button></td>
+                      <td>{listingLabel(company?.listingStatus ?? "")}</td>
+                      <td className={styles.tableRelation}>{summary}</td>
+                      <td>{formatAsOf(membership.sourceAsOf)}</td>
+                      <td className={styles.tableSource}>
+                        {membership.sourceUrl ? <a className={styles.sourceLink} href={membership.sourceUrl} target="_blank" rel="noreferrer">公式根拠</a> : membership.sourceTitle ?? "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )
+      ) : visibleRelationships.length === 0 ? (
+        <p className={styles.empty}>{group.name}内の確認済み企業間関係は現在登録されていません。所属企業データとは別レイヤーです。</p>
+      ) : (
+        <div className={styles.tableScroll}>
+          <table className={styles.table} style={{ minWidth: 760 }}>
+            <caption>{visibleRelationships.length}件の企業間関係を表示</caption>
+            <thead><tr><th>起点企業</th><th>関係</th><th>相手企業</th><th>比率</th><th>基準日</th><th>根拠</th></tr></thead>
+            <tbody>
+              {visibleRelationships.map((relationship) => (
+                <tr key={relationship.relationId} className={selectedRelationId === relationship.relationId ? styles.tableRowSelected : undefined} onClick={() => onSelectRelation(relationship.relationId)}>
+                  <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.sourceCompanyId); }}>{relationship.sourceCompanyName}</button></td>
+                  <td className={styles.tableRelation}>{relationLabel(relationship.relationType, null)}</td>
+                  <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.targetCompanyId); }}>{relationship.targetCompanyName}</button></td>
+                  <td>{relationship.ownershipPct === null ? "—" : `${relationship.ownershipPct}%`}</td>
+                  <td>{formatAsOf(relationship.sourceAsOf)}</td>
+                  <td className={styles.tableSource}>{relationship.sourceUrl ? <a className={styles.sourceLink} href={relationship.sourceUrl} target="_blank" rel="noreferrer">公式根拠</a> : relationship.sourceTitle ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -31,6 +31,7 @@ type Props = {
   selection: CompanyNetworkNodeSelection | null;
   selectedRelationId: string | null;
   query: string;
+  title?: string;
   onSelectCompany: (companyId: string) => void;
   onSelectGroup: (groupId: string) => void;
   onSelectRelation: (relationId: string) => void;
@@ -44,6 +45,7 @@ export default function NetworkView({
   selection,
   selectedRelationId,
   query,
+  title = "中心企業の関係ネットワーク",
   onSelectCompany,
   onSelectGroup,
   onSelectRelation,
@@ -100,7 +102,7 @@ export default function NetworkView({
   return (
     <div className={styles.viewFade}>
       <div className={styles.viewTools}>
-        <span>中心企業の関係ネットワーク</span>
+        <span>{title}</span>
         <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button>
       </div>
       <div className={styles.svgWrap}>


### PR DESCRIPTION
Closes #516

## 変更概要
- グループ表示に「表示基点（グループ全体 / 所属企業）」を追加
- 表示基点は同じグループデータ内の表示・強調条件で、再取得条件にはしない
- 関係ビュー（グループモード）からgroup node / membership edgeを除外し、企業間relationだけを表示
- グループ内relationが0件の場合はデータ未登録であることを明示
- 放射ビューをmembership専用に変更し、企業間relationを描画しない
- グループ全体の系列ビューを追加し、資本・支配構造を中心企業なしでも表示
- 表示基点に企業を指定した場合は既存HierarchyViewでその企業の上下関係へフォーカス
- 表ビューをDB内部コードの直出しから、人間向けの企業一覧へ再設計
  - 企業
  - 上場 / 非上場
  - グループ内の主な関係（文章化）
  - 基準日
  - 公式根拠
- 表内に「企業一覧 / 企業間関係」の切替を追加
- verified表記をUIでは「確認済み」に変更
- DB schema変更なし

## 確認
- [x] lint
- [x] test
- [x] build
- [x] CI #993 success
- [x] 関係: グループモードではmembershipをNetworkViewへ渡さないため所属線なし
- [x] 放射: relationship描画を削除しmembership専用
- [x] 系列: グループ全体用GroupHierarchyViewを追加。relation 0件は未登録メッセージ
- [x] 表: role / membership_basis / verification_status / listing_status内部コードの直表示を廃止

## 本番確認ポイント
- トヨタグループ: 関係で青い企業間relationだけが見えること
- トヨタグループ: 放射で所属17社だけを確認できること
- トヨタグループ: 系列を「グループ全体」で開いて5件の資本関係が見えること
- 三井グループ: 関係/系列で企業間relation未登録と明示されること
- 表: 企業一覧 / 企業間関係が人間向けラベルで表示されること