### PR TITLE
feat(company-network): Toyota/Mitsui向け情報密度を改善

### DIFF
--- a/app/premium/company-network/FunctionViews.module.css
+++ b/app/premium/company-network/FunctionViews.module.css
@@ -11,6 +11,24 @@
   line-height: 1.7;
 }
 
+.functionSummary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.functionSummary > div {
+  display: grid;
+  gap: 2px;
+  padding: 9px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg-input);
+}
+
+.functionSummary strong { font-size: 16px; line-height: 1.1; }
+.functionSummary span { color: var(--color-text-muted); font-size: 8px; font-weight: 800; }
+
 .functionClusterGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -32,6 +50,7 @@
 .functionTone2 { --function-accent: #7c3aed; --function-soft: rgba(124, 58, 237, 0.07); }
 .functionTone3 { --function-accent: #d97706; --function-soft: rgba(217, 119, 6, 0.07); }
 .functionTone4 { --function-accent: #64748b; --function-soft: rgba(100, 116, 139, 0.08); }
+.functionTone5 { --function-accent: #be123c; --function-soft: rgba(190, 18, 60, 0.06); }
 
 .functionClusterHead {
   display: flex;
@@ -51,49 +70,24 @@
   letter-spacing: .08em;
 }
 
-.functionClusterHead h3 {
-  margin: 2px 0 0;
-  font-size: 15px;
-}
+.functionClusterHead h3 { margin: 2px 0 0; font-size: 15px; }
+.functionClusterHead small { display: block; margin-top: 4px; color: var(--color-text-muted); font-size: 8px; font-weight: 700; }
+.functionClusterHead > strong { color: var(--function-accent); font-size: 12px; }
 
-.functionClusterHead > strong {
-  color: var(--function-accent);
-  font-size: 12px;
-}
-
-.functionRows {
-  display: grid;
-  gap: 10px;
-  padding-top: 10px;
-}
-
-.functionRow {
-  display: grid;
-  gap: 6px;
-}
-
-.functionRowHead {
-  display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  align-items: center;
-}
-
+.functionRows { display: grid; gap: 10px; padding-top: 10px; }
+.functionRow { display: grid; gap: 6px; }
+.functionRowHead { display: flex; justify-content: space-between; gap: 8px; align-items: center; }
 .functionRowHead strong { font-size: 12px; }
 .functionRowHead span { color: var(--color-text-muted); font-size: 9px; font-weight: 800; }
 
-.functionCompanies {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
+.functionCompanies { display: flex; flex-wrap: wrap; gap: 6px; }
 
 .functionCompany {
   display: grid;
   gap: 2px;
-  min-width: 118px;
+  min-width: 132px;
   max-width: 100%;
-  padding: 7px 9px;
+  padding: 8px 10px;
   border-radius: 10px;
   color: var(--color-text);
   text-align: left;
@@ -106,122 +100,56 @@
 .functionCompanyCore { border: 1px solid var(--function-accent); background: var(--function-soft); }
 .functionCompanySupporting { border: 1px dashed var(--function-accent); background: var(--color-bg-card); }
 .functionCompanySelected { box-shadow: 0 0 0 2px var(--color-accent); }
-.functionCompany strong { font-size: 10px; }
+.functionCompany strong { font-size: 10px; line-height: 1.35; }
 .functionCompany span { color: var(--color-text-muted); font-size: 8px; }
 .functionCompany small { color: var(--function-accent); font-size: 7px; font-weight: 800; }
 
-.unmappedBox {
-  display: grid;
-  gap: 5px;
-  padding: 10px 12px;
-  border: 1px dashed var(--color-border);
-  border-radius: 12px;
-  color: var(--color-text-muted);
-  font-size: 10px;
-}
-
+.unmappedBox { display: grid; gap: 5px; padding: 10px 12px; border: 1px dashed var(--color-border); border-radius: 12px; color: var(--color-text-muted); font-size: 10px; }
 .unmappedBox > div { display: flex; justify-content: space-between; gap: 8px; }
 .unmappedBox p { margin: 0; line-height: 1.6; }
 
-.matrixScroll {
-  overflow: auto;
-  width: 100%;
+.matrixLegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  align-items: center;
+  padding: 8px 10px;
   border: 1px solid var(--color-border);
-  border-radius: 12px;
-}
-
-.matrixTable {
-  border-collapse: separate;
-  border-spacing: 0;
-  min-width: 100%;
-  width: max-content;
-  font-size: 10px;
-}
-
-.matrixTable th,
-.matrixTable td {
-  min-width: 82px;
-  padding: 8px 7px;
-  border-right: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  text-align: center;
-  background: var(--color-bg-card);
-}
-
-.matrixTable thead th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
+  border-radius: 10px;
   background: var(--color-bg-input);
+  color: var(--color-text-muted);
+  font-size: 9px;
+  line-height: 1.5;
 }
+.matrixLegend span { display: inline-flex; align-items: center; gap: 5px; }
+.legendCore { color: var(--color-accent); }
+.legendSupporting { color: var(--color-accent); }
+.matrixScrollHint { display: none; color: var(--color-text-muted); font-size: 9px; text-align: center; }
 
-.matrixTable thead button {
-  border: 0;
-  background: transparent;
-  color: var(--color-text-sub);
-  font: inherit;
-  font-weight: 800;
-  cursor: pointer;
-  writing-mode: vertical-rl;
-  max-height: 115px;
-}
-
-.matrixSticky {
-  position: sticky !important;
-  left: 0;
-  z-index: 3 !important;
-  min-width: 150px !important;
-  text-align: left !important;
-}
-
+.matrixScroll { overflow: auto; width: 100%; border: 1px solid var(--color-border); border-radius: 12px; box-shadow: inset -18px 0 18px -20px rgba(15, 23, 42, .35); }
+.matrixTable { border-collapse: separate; border-spacing: 0; min-width: 100%; width: max-content; font-size: 10px; }
+.matrixTable th,
+.matrixTable td { min-width: 82px; padding: 8px 7px; border-right: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); text-align: center; background: var(--color-bg-card); }
+.matrixTable thead th { position: sticky; top: 0; z-index: 2; background: var(--color-bg-input); }
+.matrixTable thead button { border: 0; background: transparent; color: var(--color-text-sub); font: inherit; font-weight: 800; cursor: pointer; writing-mode: vertical-rl; max-height: 115px; }
+.matrixSticky { position: sticky !important; left: 0; z-index: 3 !important; min-width: 158px !important; text-align: left !important; box-shadow: 5px 0 10px -9px rgba(15, 23, 42, .45); }
 .matrixSticky strong { display: block; margin-top: 3px; font-size: 10px; }
+.matrixSticky small { display: block; margin-top: 3px; color: var(--color-text-muted); font-size: 8px; font-weight: 700; }
 .matrixClass { color: var(--color-text-muted); }
+.matrixClassStart > th,
+.matrixClassStart > td { border-top: 2px solid var(--color-border); }
 .matrixFocusColumn { background: var(--color-accent-sub) !important; }
 
 .matrixCore,
-.matrixSupporting {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  font: inherit;
-  font-weight: 900;
-  cursor: pointer;
-}
-
-.matrixCore {
-  border: 1px solid var(--color-accent);
-  background: var(--color-accent);
-  color: white;
-}
-
-.matrixSupporting {
-  border: 1px solid var(--color-accent);
-  background: var(--color-bg-card);
-  color: var(--color-accent);
-}
-
+.matrixSupporting { width: 28px; height: 28px; border-radius: 8px; font: inherit; font-weight: 900; cursor: pointer; }
+.matrixCore { border: 1px solid var(--color-accent); background: var(--color-accent); color: white; }
+.matrixSupporting { border: 1px solid var(--color-accent); background: var(--color-bg-card); color: var(--color-accent); }
 .matrixEmpty { color: var(--color-border); }
 
-.tableFunction {
-  min-width: 190px;
-  color: var(--color-text-sub);
-  font-weight: 700;
-  line-height: 1.6;
-}
-
-.functionDetailList {
-  display: grid;
-  gap: 7px;
-}
-
+.tableFunction { min-width: 190px; color: var(--color-text-sub); font-weight: 700; line-height: 1.6; }
+.functionDetailList { display: grid; gap: 7px; }
 .functionDetailCore,
-.functionDetailSupporting {
-  display: grid;
-  gap: 4px;
-  padding: 9px;
-  border-radius: 10px;
-}
-
+.functionDetailSupporting { display: grid; gap: 4px; padding: 9px; border-radius: 10px; }
 .functionDetailCore { border: 1px solid var(--color-accent); background: var(--color-accent-sub); }
 .functionDetailSupporting { border: 1px dashed var(--color-border); background: var(--color-bg-card); }
 .functionDetailCore > div,
@@ -236,8 +164,11 @@
 .functionDetailSupporting p { margin: 0; color: var(--color-text-sub); font-size: 9px; line-height: 1.6; overflow-wrap: anywhere; }
 
 @media (max-width: 760px) {
+  .functionSummary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .functionClusterGrid { grid-template-columns: 1fr; }
   .functionCompany { min-width: min(150px, 100%); flex: 1 1 130px; }
-  .matrixSticky { min-width: 126px !important; }
-  .matrixTable th, .matrixTable td { min-width: 68px; padding: 7px 5px; }
+  .matrixScrollHint { display: block; }
+  .matrixSticky { min-width: 128px !important; }
+  .matrixTable th, .matrixTable td { min-width: 64px; padding: 7px 5px; }
+  .matrixTable thead button { max-height: 96px; font-size: 9px; }
 }

--- a/app/premium/company-network/function-order.ts
+++ b/app/premium/company-network/function-order.ts
@@ -1,0 +1,61 @@
+export const FUNCTION_CLASS_ORDER = [
+  "mobility-manufacturing",
+  "technology-rd",
+  "materials-industrial",
+  "infrastructure-logistics",
+  "commerce-services",
+  "property-living",
+] as const;
+
+export const FUNCTION_ORDER = [
+  "finished-vehicles",
+  "vehicle-body-production",
+  "automotive-components",
+  "electrification-powertrain",
+  "software",
+  "advanced-mobility",
+  "research-development",
+  "materials",
+  "chemicals",
+  "fibers-composites",
+  "paper-packaging",
+  "industrial-machinery",
+  "building-systems",
+  "plant-engineering",
+  "logistics",
+  "marine-transport",
+  "trading",
+  "banking",
+  "insurance",
+  "leasing-finance",
+  "finance",
+  "retail",
+  "food-services",
+  "beverages",
+  "real-estate",
+  "housing",
+] as const;
+
+function rank(value: string | null, order: readonly string[]): number {
+  if (!value) return order.length + 1;
+  const index = order.indexOf(value);
+  return index === -1 ? order.length : index;
+}
+
+export function compareFunctionClass(
+  a: { classificationSlug: string | null; classificationName: string | null },
+  b: { classificationSlug: string | null; classificationName: string | null },
+): number {
+  const byRank = rank(a.classificationSlug, FUNCTION_CLASS_ORDER) - rank(b.classificationSlug, FUNCTION_CLASS_ORDER);
+  if (byRank !== 0) return byRank;
+  return (a.classificationName ?? "").localeCompare(b.classificationName ?? "", "ja");
+}
+
+export function compareFunction(
+  a: { functionSlug: string; functionName: string },
+  b: { functionSlug: string; functionName: string },
+): number {
+  const byRank = rank(a.functionSlug, FUNCTION_ORDER) - rank(b.functionSlug, FUNCTION_ORDER);
+  if (byRank !== 0) return byRank;
+  return a.functionName.localeCompare(b.functionName, "ja");
+}

--- a/app/premium/company-network/views/FunctionClusterView.tsx
+++ b/app/premium/company-network/views/FunctionClusterView.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import styles from "../CompanyNetwork.module.css";
 import functionStyles from "../FunctionViews.module.css";
+import { compareFunction, compareFunctionClass } from "../function-order";
 import type {
   CompanyFunctionLink,
   CompanyNetworkCompany,
@@ -52,23 +53,36 @@ export default function FunctionClusterView({
   }, [relationships]);
 
   const mappedCompanyIds = useMemo(() => new Set(functions.map((link) => link.companyId)), [functions]);
+  const multiFunctionCompanies = useMemo(() => {
+    const counts = new Map<string, number>();
+    functions.forEach((link) => counts.set(link.companyId, (counts.get(link.companyId) ?? 0) + 1));
+    return [...counts.values()].filter((count) => count > 1).length;
+  }, [functions]);
+
   const clusters = useMemo(() => {
-    const byClassification = new Map<string, Map<string, CompanyFunctionLink[]>>();
+    const byClassification = new Map<string, { slug: string | null; links: CompanyFunctionLink[] }>();
     functions.forEach((link) => {
-      const className = link.classificationName ?? "その他";
-      const functionsInClass = byClassification.get(className) ?? new Map<string, CompanyFunctionLink[]>();
-      functionsInClass.set(link.functionName, [...(functionsInClass.get(link.functionName) ?? []), link]);
-      byClassification.set(className, functionsInClass);
+      const key = link.classificationId ?? "other";
+      const current = byClassification.get(key) ?? { slug: link.classificationSlug, links: [] };
+      current.links.push(link);
+      byClassification.set(key, current);
     });
 
     return [...byClassification.entries()]
-      .map(([classificationName, functionMap]) => ({
-        classificationName,
-        functions: [...functionMap.entries()]
-          .map(([functionName, links]) => ({ functionName, links }))
-          .sort((a, b) => a.functionName.localeCompare(b.functionName, "ja")),
-      }))
-      .sort((a, b) => a.classificationName.localeCompare(b.classificationName, "ja"));
+      .map(([classificationId, value]) => {
+        const functionMap = new Map<string, CompanyFunctionLink[]>();
+        value.links.forEach((link) => functionMap.set(link.nodeId, [...(functionMap.get(link.nodeId) ?? []), link]));
+        const first = value.links[0];
+        return {
+          classificationId,
+          classificationSlug: value.slug,
+          classificationName: first?.classificationName ?? "その他",
+          functions: [...functionMap.values()]
+            .map((links) => ({ functionSlug: links[0].functionSlug, functionName: links[0].functionName, links }))
+            .sort(compareFunction),
+        };
+      })
+      .sort(compareFunctionClass);
   }, [functions]);
 
   const unmapped = companies.filter((company) => !mappedCompanyIds.has(company.id));
@@ -88,17 +102,24 @@ export default function FunctionClusterView({
         <span>{groupName}の事業・機能構成</span>
         <span>{mappedCompanyIds.size}/{companies.length}社 · {functions.length}機能リンク</span>
       </div>
-      <p className={functionStyles.functionIntro}>企業を単純に並べず、公式情報から確認した「何を担う会社か」でまとめています。濃いバッジは主要機能、薄いバッジは追加機能です。</p>
+      <p className={functionStyles.functionIntro}>企業名簿ではなく「何を担う会社か」で整理しています。同じ会社が複数領域に現れる場合、それは複数の公式事業機能を持つことを示します。</p>
+      <div className={functionStyles.functionSummary}>
+        <div><strong>{clusters.length}</strong><span>大分類</span></div>
+        <div><strong>{new Set(functions.map((link) => link.nodeId)).size}</strong><span>機能領域</span></div>
+        <div><strong>{multiFunctionCompanies}</strong><span>複数機能を担う企業</span></div>
+        <div><strong>{relationships.filter((relationship) => relationship.relationType === "equity_ownership" && relationship.ownershipPct === 100).length}</strong><span>100%出資関係</span></div>
+      </div>
 
       <div className={functionStyles.functionClusterGrid}>
         {clusters.map((cluster, clusterIndex) => {
           const classLinks = cluster.functions.flatMap((item) => item.links);
           const classCompanyCount = new Set(classLinks.map((link) => link.companyId)).size;
-          const toneClass = functionStyles[`functionTone${clusterIndex % 5}`] ?? "";
+          const coreCount = classLinks.filter((link) => link.role === "core").length;
+          const toneClass = functionStyles[`functionTone${clusterIndex % 6}`] ?? "";
           return (
-            <section key={cluster.classificationName} className={`${functionStyles.functionCluster} ${toneClass}`}>
+            <section key={cluster.classificationId} className={`${functionStyles.functionCluster} ${toneClass}`}>
               <header className={functionStyles.functionClusterHead}>
-                <div><span>FUNCTION CLASS</span><h3>{cluster.classificationName}</h3></div>
+                <div><span>FUNCTION CLASS</span><h3>{cluster.classificationName}</h3><small>{cluster.functions.length}領域 · 主要機能 {coreCount}件</small></div>
                 <strong>{classCompanyCount}社</strong>
               </header>
 
@@ -113,10 +134,10 @@ export default function FunctionClusterView({
                   });
                   if (visibleLinks.length === 0) return null;
                   return (
-                    <div key={item.functionName} className={functionStyles.functionRow}>
+                    <div key={item.functionSlug} className={functionStyles.functionRow}>
                       <div className={functionStyles.functionRowHead}>
                         <strong>{item.functionName}</strong>
-                        <span>{visibleLinks.length}社</span>
+                        <span>{new Set(visibleLinks.map((link) => link.companyId)).size}社</span>
                       </div>
                       <div className={functionStyles.functionCompanies}>
                         {visibleLinks
@@ -138,7 +159,7 @@ export default function FunctionClusterView({
                                 onClick={() => onSelectCompany(company.id)}
                               >
                                 <strong>{company.name}</strong>
-                                <span>{listingLabel(company.listingStatus)}</span>
+                                <span>{link.role === "core" ? "主要機能" : "追加機能"} · {listingLabel(company.listingStatus)}</span>
                                 {whollyOwnedParent ? <small>{whollyOwnedParent} 100%出資</small> : null}
                               </button>
                             );

--- a/app/premium/company-network/views/FunctionCoverageMatrixView.tsx
+++ b/app/premium/company-network/views/FunctionCoverageMatrixView.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import styles from "../CompanyNetwork.module.css";
 import functionStyles from "../FunctionViews.module.css";
+import { compareFunction, compareFunctionClass } from "../function-order";
 import type { CompanyFunctionLink, CompanyNetworkCompany } from "../types";
 
 type Props = {
@@ -23,24 +24,29 @@ export default function FunctionCoverageMatrixView({
   onSelectCompany,
 }: Props) {
   const normalized = query.trim().toLocaleLowerCase("ja");
-  const companiesSorted = useMemo(
-    () => [...companies].sort((a, b) => {
+  const companiesSorted = useMemo(() => {
+    const functionCounts = new Map<string, number>();
+    functions.forEach((link) => functionCounts.set(link.companyId, (functionCounts.get(link.companyId) ?? 0) + 1));
+    return [...companies].sort((a, b) => {
       if (focusCompanyId) {
         if (a.id === focusCompanyId) return -1;
         if (b.id === focusCompanyId) return 1;
       }
+      const countDiff = (functionCounts.get(b.id) ?? 0) - (functionCounts.get(a.id) ?? 0);
+      if (countDiff !== 0) return countDiff;
       return a.name.localeCompare(b.name, "ja");
-    }),
-    [companies, focusCompanyId],
-  );
+    });
+  }, [companies, focusCompanyId, functions]);
 
   const rows = useMemo(() => {
     const byFunction = new Map<string, CompanyFunctionLink[]>();
-    functions.forEach((link) => byFunction.set(link.functionName, [...(byFunction.get(link.functionName) ?? []), link]));
-    return [...byFunction.entries()]
-      .map(([functionName, links]) => ({
-        functionName,
-        classificationName: links[0]?.classificationName ?? "その他",
+    functions.forEach((link) => byFunction.set(link.nodeId, [...(byFunction.get(link.nodeId) ?? []), link]));
+    return [...byFunction.values()]
+      .map((links) => ({
+        functionSlug: links[0].functionSlug,
+        functionName: links[0].functionName,
+        classificationSlug: links[0].classificationSlug,
+        classificationName: links[0].classificationName ?? "その他",
         links,
       }))
       .filter((row) => {
@@ -49,14 +55,14 @@ export default function FunctionCoverageMatrixView({
           .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
       })
       .sort((a, b) => {
-        const byClass = a.classificationName.localeCompare(b.classificationName, "ja");
-        return byClass !== 0 ? byClass : a.functionName.localeCompare(b.functionName, "ja");
+        const byClass = compareFunctionClass(a, b);
+        return byClass !== 0 ? byClass : compareFunction(a, b);
       });
   }, [companies, functions, normalized]);
 
   const linkByCell = useMemo(() => {
     const result = new Map<string, CompanyFunctionLink>();
-    functions.forEach((link) => result.set(`${link.functionName}:${link.companyId}`, link));
+    functions.forEach((link) => result.set(`${link.nodeId}:${link.companyId}`, link));
     return result;
   }, [functions]);
 
@@ -70,7 +76,12 @@ export default function FunctionCoverageMatrixView({
         <span>{groupName} 機能カバレッジ</span>
         <span>{rows.length}領域 × {companiesSorted.length}社</span>
       </div>
-      <p className={functionStyles.functionIntro}>行は事業・機能、列は企業です。●は主要機能、○は追加機能。横にスクロールするとグループ内の重なりと空白を比較できます。</p>
+      <div className={functionStyles.matrixLegend}>
+        <span><b className={functionStyles.legendCore}>●</b> 主要機能</span>
+        <span><b className={functionStyles.legendSupporting}>○</b> 追加機能</span>
+        <span>企業は担当機能数が多い順。表示基点を選ぶと先頭列へ固定します。</span>
+      </div>
+      <div className={functionStyles.matrixScrollHint}>← 横スクロールで全社を比較 →</div>
       <div className={functionStyles.matrixScroll}>
         <table className={functionStyles.matrixTable}>
           <thead>
@@ -86,14 +97,16 @@ export default function FunctionCoverageMatrixView({
           <tbody>
             {rows.map((row, index) => {
               const previousClass = index > 0 ? rows[index - 1].classificationName : null;
+              const newClass = previousClass !== row.classificationName;
               return (
-                <tr key={`${row.classificationName}:${row.functionName}`}>
+                <tr key={`${row.classificationSlug}:${row.functionSlug}`} className={newClass ? functionStyles.matrixClassStart : undefined}>
                   <th className={functionStyles.matrixSticky}>
-                    {previousClass !== row.classificationName ? <span className={functionStyles.matrixClass}>{row.classificationName}</span> : null}
+                    {newClass ? <span className={functionStyles.matrixClass}>{row.classificationName}</span> : null}
                     <strong>{row.functionName}</strong>
+                    <small>{new Set(row.links.map((link) => link.companyId)).size}社</small>
                   </th>
                   {companiesSorted.map((company) => {
-                    const link = linkByCell.get(`${row.functionName}:${company.id}`);
+                    const link = linkByCell.get(`${row.links[0].nodeId}:${company.id}`);
                     return (
                       <td key={company.id} className={focusCompanyId === company.id ? functionStyles.matrixFocusColumn : undefined}>
                         {link ? (


### PR DESCRIPTION
Closes #526

## 変更概要
- company-functions の大分類/機能領域を意味順に固定（文字コード順を廃止）
- 構成ビューへ要約指標を追加
  - 大分類数
  - 機能領域数
  - 複数機能を担う企業数
  - 100%出資関係数
- 構成ビューで `core/supporting` を「主要機能/追加機能」と明示
- 大分類カードに領域数・主要機能件数を追加
- 機能表の企業列を担当機能数の多い順にし、表示基点は先頭へ固定
- 機能表に凡例、機能ごとの企業数、classification区切り、モバイル横スクロール案内を追加
- sticky first columnと横スクロールの視認性を改善
- 6分類目のvisual toneを追加

## 対象
- Toyota Group: 17社 / 22 function links
- Mitsui Group: 22社 / 32 function links

## DB
- schema/data変更なし

## 確認予定
- lint
- test
- build
- Vercel Preview
- 最終実画面UATはスクリーンショットで確認