### PR TITLE
feat(company-network): 関係をconnected表示し系列をツリー化

### DIFF
--- a/app/premium/company-network/RelationshipViews.module.css
+++ b/app/premium/company-network/RelationshipViews.module.css
@@ -1,0 +1,250 @@
+.relationIntro {
+  margin: 0 0 10px;
+  color: var(--color-text-sub);
+  font-size: 11px;
+  line-height: 1.7;
+}
+
+.relationMeta {
+  margin-left: auto;
+  margin-right: 8px;
+  color: var(--color-text-muted);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.compactGraph {
+  min-height: 420px;
+}
+
+.compactGraph svg {
+  min-height: 420px;
+}
+
+.isolatedSection {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px dashed var(--color-border);
+  border-radius: 12px;
+  background: var(--color-bg-input);
+}
+
+.isolatedHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.isolatedHead div {
+  display: grid;
+  gap: 2px;
+}
+
+.isolatedHead span {
+  color: var(--color-text-muted);
+  font-size: 8px;
+  font-weight: 900;
+  letter-spacing: .08em;
+}
+
+.isolatedHead strong {
+  font-size: 12px;
+}
+
+.isolatedHead b {
+  color: var(--color-text-sub);
+  font-size: 11px;
+}
+
+.isolatedSection p {
+  margin: 7px 0 9px;
+  color: var(--color-text-muted);
+  font-size: 9px;
+  line-height: 1.6;
+}
+
+.isolatedCompanies {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.isolatedCompanies button {
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-card);
+  color: var(--color-text-sub);
+  font: inherit;
+  font-size: 9px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.treeForest {
+  display: grid;
+  gap: 14px;
+}
+
+.treeSection {
+  padding: 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: var(--color-bg-card);
+}
+
+.treeRoot {
+  display: inline-grid;
+  gap: 2px;
+  min-width: min(280px, 100%);
+  padding: 12px 14px;
+  border: 2px solid var(--color-accent);
+  border-radius: 12px;
+  background: var(--color-accent-sub);
+  color: var(--color-text);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.treeRoot span {
+  color: var(--color-accent);
+  font-size: 8px;
+  font-weight: 900;
+  letter-spacing: .08em;
+}
+
+.treeRoot strong {
+  font-size: 15px;
+}
+
+.treeRoot small {
+  color: var(--color-text-muted);
+  font-size: 9px;
+}
+
+.treeChildren {
+  margin: 8px 0 0 16px;
+  padding-left: 18px;
+  border-left: 1px solid var(--color-border);
+}
+
+.treeBranch {
+  position: relative;
+  display: grid;
+  gap: 7px;
+  margin: 8px 0;
+}
+
+.treeBranch::before {
+  content: "";
+  position: absolute;
+  left: -18px;
+  top: 20px;
+  width: 14px;
+  border-top: 1px solid var(--color-border);
+}
+
+.treeBranchDim {
+  opacity: .22;
+}
+
+.treeNode {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  min-height: 42px;
+  padding: 7px 8px 7px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg-card);
+}
+
+.treeNodeSelected {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent-sub);
+}
+
+.treeCompany {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.treeCompany strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.treeCompany small {
+  color: var(--color-text-muted);
+  font-size: 8px;
+}
+
+.treeRelation {
+  padding: 5px 8px;
+  border: 1px solid var(--color-accent);
+  border-radius: 999px;
+  background: var(--color-bg-card);
+  color: var(--color-accent);
+  font: inherit;
+  font-size: 9px;
+  font-weight: 900;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.treeRelationActive {
+  background: var(--color-accent);
+  color: white;
+}
+
+.treeCycle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 8px;
+}
+
+@media (max-width: 760px) {
+  .compactGraph,
+  .compactGraph svg {
+    min-height: 360px;
+  }
+
+  .relationMeta {
+    display: none;
+  }
+
+  .treeSection {
+    padding: 10px;
+  }
+
+  .treeChildren {
+    margin-left: 8px;
+    padding-left: 14px;
+  }
+
+  .treeBranch::before {
+    left: -14px;
+    width: 11px;
+  }
+
+  .treeNode {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .treeRelation {
+    padding-inline: 7px;
+    font-size: 8px;
+  }
+}

--- a/app/premium/company-network/views/GroupHierarchyView.tsx
+++ b/app/premium/company-network/views/GroupHierarchyView.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import styles from "../CompanyNetwork.module.css";
+import relationStyles from "../RelationshipViews.module.css";
 import { relationLabel } from "../presentation";
 import type { CompanyNetworkCompany, CompanyRelationship } from "../types";
 
 const SERIES_TYPES = new Set(["equity_ownership", "parent_of", "controls", "equity_method_investment"]);
-
-type TreeRow = {
-  relationship: CompanyRelationship;
-  depth: number;
-};
 
 type Props = {
   groupName: string;
@@ -40,42 +36,41 @@ export default function GroupHierarchyView({
     [relationships],
   );
 
-  const forest = useMemo(() => {
+  const treeModel = useMemo(() => {
     const children = new Map<string, CompanyRelationship[]>();
     const sourceIds = new Set<string>();
     const targetIds = new Set<string>();
+
     seriesRelationships.forEach((relationship) => {
       sourceIds.add(relationship.sourceCompanyId);
       targetIds.add(relationship.targetCompanyId);
       children.set(relationship.sourceCompanyId, [...(children.get(relationship.sourceCompanyId) ?? []), relationship]);
     });
-    const roots = [...sourceIds].filter((id) => !targetIds.has(id));
-    const rootIds = roots.length > 0 ? roots : [...sourceIds].slice(0, 1);
-    const used = new Set<string>();
 
-    const walk = (companyId: string, depth: number, path: Set<string>, rows: TreeRow[]) => {
+    for (const [sourceId, links] of children) {
+      children.set(sourceId, [...links].sort((a, b) => a.targetCompanyName.localeCompare(b.targetCompanyName, "ja")));
+    }
+
+    const rootIds = [...sourceIds].filter((id) => !targetIds.has(id));
+    const visitedRelations = new Set<string>();
+    const markReachable = (companyId: string, path: Set<string>) => {
       for (const relationship of children.get(companyId) ?? []) {
-        if (used.has(relationship.relationId)) continue;
-        used.add(relationship.relationId);
-        rows.push({ relationship, depth });
+        if (visitedRelations.has(relationship.relationId)) continue;
+        visitedRelations.add(relationship.relationId);
         if (!path.has(relationship.targetCompanyId)) {
-          walk(relationship.targetCompanyId, depth + 1, new Set([...path, relationship.targetCompanyId]), rows);
+          markReachable(relationship.targetCompanyId, new Set([...path, relationship.targetCompanyId]));
         }
       }
     };
 
-    const trees = rootIds.map((rootId) => {
-      const rows: TreeRow[] = [];
-      walk(rootId, 1, new Set([rootId]), rows);
-      return { rootId, rows };
+    rootIds.forEach((rootId) => markReachable(rootId, new Set([rootId])));
+    seriesRelationships.forEach((relationship) => {
+      if (visitedRelations.has(relationship.relationId)) return;
+      if (!rootIds.includes(relationship.sourceCompanyId)) rootIds.push(relationship.sourceCompanyId);
+      markReachable(relationship.sourceCompanyId, new Set([relationship.sourceCompanyId]));
     });
 
-    const leftovers = seriesRelationships.filter((relationship) => !used.has(relationship.relationId));
-    if (leftovers.length > 0) {
-      const rows = leftovers.map((relationship) => ({ relationship, depth: 1 }));
-      trees.push({ rootId: leftovers[0].sourceCompanyId, rows });
-    }
-    return trees;
+    return { children, rootIds };
   }, [seriesRelationships]);
 
   if (seriesRelationships.length === 0) {
@@ -86,39 +81,67 @@ export default function GroupHierarchyView({
     );
   }
 
+  const renderChildren = (companyId: string, path: Set<string>): ReactNode => {
+    const links = treeModel.children.get(companyId) ?? [];
+    if (links.length === 0) return null;
+
+    return (
+      <div className={relationStyles.treeChildren}>
+        {links.map((relationship) => {
+          const target = companyById.get(relationship.targetCompanyId);
+          if (!target) return null;
+          const cycle = path.has(target.id);
+          const dimmed = normalized.length > 0 && ![
+            relationship.sourceCompanyName,
+            relationship.targetCompanyName,
+            relationLabel(relationship.relationType, relationship.ownershipPct),
+          ].some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+          const selected = selectedCompanyId === target.id;
+          const relationSelected = selectedRelationId === relationship.relationId;
+
+          return (
+            <div key={relationship.relationId} className={`${relationStyles.treeBranch} ${dimmed ? relationStyles.treeBranchDim : ""}`}>
+              <div className={`${relationStyles.treeNode} ${selected ? relationStyles.treeNodeSelected : ""}`}>
+                <button type="button" className={relationStyles.treeCompany} onClick={() => onSelectCompany(target.id)} aria-pressed={selected}>
+                  <strong>{target.name}</strong>
+                  <small>{relationship.sourceCompanyName} からの確認済み関係</small>
+                </button>
+                <button
+                  type="button"
+                  className={`${relationStyles.treeRelation} ${relationSelected ? relationStyles.treeRelationActive : ""}`}
+                  onClick={() => onSelectRelation(relationship.relationId)}
+                  aria-pressed={relationSelected}
+                >
+                  {relationLabel(relationship.relationType, relationship.ownershipPct)}
+                </button>
+              </div>
+              {cycle ? <p className={relationStyles.treeCycle}>循環参照のため、ここで展開を止めています。</p> : renderChildren(target.id, new Set([...path, target.id]))}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   return (
     <div className={`${styles.seriesView} ${styles.viewFade}`}>
-      <p className={styles.seriesIntro}><strong>{groupName}</strong>内で確認済みの出資・親会社・支配・持分法関係を、グループ全体の系列として表示します。グループ所属そのものは親子関係として扱いません。</p>
-      {forest.map((tree, treeIndex) => {
-        const root = companyById.get(tree.rootId);
-        if (!root) return null;
-        return (
-          <section key={`${tree.rootId}:${treeIndex}`} className={styles.seriesSection}>
-            <button type="button" className={styles.seriesCenter} onClick={() => onSelectCompany(root.id)}>
-              <span>ROOT</span><strong>{root.name}</strong><small>確認済み資本構造の起点</small>
-            </button>
-            <div className={styles.seriesRows}>
-              {tree.rows.map(({ relationship, depth }) => {
-                const target = companyById.get(relationship.targetCompanyId);
-                if (!target) return null;
-                const dimmed = normalized.length > 0 && ![relationship.sourceCompanyName, relationship.targetCompanyName]
-                  .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
-                return (
-                  <div key={relationship.relationId} className={`${styles.seriesRow} ${dimmed ? styles.seriesRowDim : ""}`} style={{ marginLeft: Math.min(depth - 1, 4) * 18 }}>
-                    <button type="button" className={styles.seriesCompany} onClick={() => onSelectCompany(target.id)} aria-pressed={selectedCompanyId === target.id}>
-                      <span className={styles.seriesDepth}>L{depth}</span><strong>{target.name}</strong>
-                    </button>
-                    <button type="button" className={`${styles.seriesRelation} ${selectedRelationId === relationship.relationId ? styles.seriesRelationActive : ""}`} onClick={() => onSelectRelation(relationship.relationId)}>
-                      <span>{relationship.sourceCompanyName} → {relationship.targetCompanyName}</span>
-                      <strong>{relationLabel(relationship.relationType, relationship.ownershipPct)}</strong>
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-          </section>
-        );
-      })}
+      <p className={styles.seriesIntro}><strong>{groupName}</strong>内で確認済みの出資・親会社・支配・持分法関係を、起点から枝をたどるツリーとして表示します。グループ所属そのものは親子関係として扱いません。</p>
+      <div className={relationStyles.treeForest}>
+        {treeModel.rootIds.map((rootId, treeIndex) => {
+          const root = companyById.get(rootId);
+          if (!root) return null;
+          return (
+            <section key={`${rootId}:${treeIndex}`} className={relationStyles.treeSection}>
+              <button type="button" className={relationStyles.treeRoot} onClick={() => onSelectCompany(root.id)} aria-pressed={selectedCompanyId === root.id}>
+                <span>ROOT</span>
+                <strong>{root.name}</strong>
+                <small>確認済み資本・支配構造の起点</small>
+              </button>
+              {renderChildren(root.id, new Set([root.id]))}
+            </section>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -76,6 +76,9 @@ export default function NetworkView({
     () => relationsOnly ? companies.filter((company) => !participatingCompanyIds.has(company.id)) : [],
     [companies, participatingCompanyIds, relationsOnly],
   );
+  const graphSelection = relationsOnly && selection?.kind === "company" && !participatingCompanyIds.has(selection.id)
+    ? null
+    : selection;
 
   const graphKey = `${relationsOnly ? "compact" : "full"}|${centerCompanyId}|${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
   const panZoom = usePanZoom(svgRef, graphKey);
@@ -117,10 +120,10 @@ export default function NetworkView({
   const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, relationsOnly ? 135 : 240);
   const size = VIEWBOX_HALF * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
-  const selectedNodeId = selectedGraphNodeId(selection);
+  const selectedNodeId = selectedGraphNodeId(graphSelection);
   const selectedNeighbours = useMemo(
-    () => buildSelectedNeighbourIds(selection, relationships, memberships),
-    [memberships, relationships, selection],
+    () => buildSelectedNeighbourIds(graphSelection, relationships, memberships),
+    [graphSelection, memberships, relationships],
   );
 
   return (
@@ -157,10 +160,10 @@ export default function NetworkView({
               const source = positions.get(membership.companyId);
               const target = positions.get(groupGraphNodeId(membership.groupId));
               if (!source || !target) return null;
-              const focused = selection?.kind === "group"
-                ? selection.id === membership.groupId
-                : selection?.kind === "company"
-                  ? selection.id === membership.companyId
+              const focused = graphSelection?.kind === "group"
+                ? graphSelection.id === membership.groupId
+                : graphSelection?.kind === "company"
+                  ? graphSelection.id === membership.companyId
                   : true;
               return <line key={membership.membershipId} x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} className={styles.membershipLine} strokeOpacity={focused ? 0.9 : 0.2} />;
             })}

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { usePanZoom } from "../../industry-map/use-pan-zoom";
 import styles from "../CompanyNetwork.module.css";
+import relationStyles from "../RelationshipViews.module.css";
 import { seedSimNodes, simExtent, stepForce, type SimLink, type SimNode, type VisualNode } from "../graph-layout";
 import { buildSelectedNeighbourIds, groupGraphNodeId, selectedGraphNodeId } from "../node-selection";
 import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
@@ -18,6 +19,7 @@ const STEPS_PER_FRAME = 3;
 const VIEWBOX_HALF = 500;
 const LABEL_PADDING = 120;
 const SEED_SPREAD = 270;
+const COMPACT_SEED_SPREAD = 170;
 
 function truncate(value: string, max = 16) {
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;
@@ -32,6 +34,7 @@ type Props = {
   selectedRelationId: string | null;
   query: string;
   title?: string;
+  compactRelationsOnly?: boolean;
   onSelectCompany: (companyId: string) => void;
   onSelectGroup: (groupId: string) => void;
   onSelectRelation: (relationId: string) => void;
@@ -46,6 +49,7 @@ export default function NetworkView({
   selectedRelationId,
   query,
   title = "中心企業の関係ネットワーク",
+  compactRelationsOnly = false,
   onSelectCompany,
   onSelectGroup,
   onSelectRelation,
@@ -53,11 +57,30 @@ export default function NetworkView({
   const svgRef = useRef<SVGSVGElement>(null);
   const [frame, setFrame] = useState<{ source: SimNode[]; nodes: SimNode[] } | null>(null);
   const [runId, setRunId] = useState(0);
-  const graphKey = `${centerCompanyId}|${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
+
+  const participatingCompanyIds = useMemo(() => {
+    const ids = new Set<string>();
+    relationships.forEach((relationship) => {
+      ids.add(relationship.sourceCompanyId);
+      ids.add(relationship.targetCompanyId);
+    });
+    return ids;
+  }, [relationships]);
+
+  const visibleCompanies = useMemo(
+    () => compactRelationsOnly ? companies.filter((company) => participatingCompanyIds.has(company.id)) : companies,
+    [companies, compactRelationsOnly, participatingCompanyIds],
+  );
+  const isolatedCompanies = useMemo(
+    () => compactRelationsOnly ? companies.filter((company) => !participatingCompanyIds.has(company.id)) : [],
+    [companies, compactRelationsOnly, participatingCompanyIds],
+  );
+
+  const graphKey = `${compactRelationsOnly ? "compact" : "full"}|${centerCompanyId}|${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
   const panZoom = usePanZoom(svgRef, graphKey);
 
   const graph = useMemo(() => {
-    const nodes: VisualNode[] = companies.map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
+    const nodes: VisualNode[] = visibleCompanies.map((company) => ({ id: company.id, label: company.name, kind: "company" as const, company }));
     const groupById = new Map(memberships.map((membership) => [membership.groupId, membership]));
     for (const membership of groupById.values()) {
       nodes.push({ id: groupGraphNodeId(membership.groupId), label: membership.groupName, kind: "group" as const, groupId: membership.groupId, groupType: membership.groupType });
@@ -67,12 +90,12 @@ export default function NetworkView({
       ...memberships.map((membership) => ({ id: membership.membershipId, sourceId: membership.companyId, targetId: groupGraphNodeId(membership.groupId), kind: "membership" as const })),
     ];
     return { nodes, links };
-  }, [companies, memberships, relationships]);
+  }, [memberships, relationships, visibleCompanies]);
 
   const seeded = useMemo(() => {
     void runId;
-    return seedSimNodes(graph.nodes, SEED_SPREAD);
-  }, [graph.nodes, runId]);
+    return seedSimNodes(graph.nodes, compactRelationsOnly ? COMPACT_SEED_SPREAD : SEED_SPREAD);
+  }, [compactRelationsOnly, graph.nodes, runId]);
 
   useEffect(() => {
     const working = seeded.map((node) => ({ ...node }));
@@ -90,7 +113,7 @@ export default function NetworkView({
 
   const nodes = frame?.source === seeded ? frame.nodes : seeded;
   const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
-  const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, 240);
+  const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, compactRelationsOnly ? 135 : 240);
   const size = VIEWBOX_HALF * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
   const selectedNodeId = selectedGraphNodeId(selection);
@@ -103,9 +126,13 @@ export default function NetworkView({
     <div className={styles.viewFade}>
       <div className={styles.viewTools}>
         <span>{title}</span>
+        <span className={relationStyles.relationMeta}>{visibleCompanies.length}社 · {relationships.length}関係</span>
         <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button>
       </div>
-      <div className={styles.svgWrap}>
+      {compactRelationsOnly ? (
+        <p className={relationStyles.relationIntro}>企業間relationが確認できている会社だけをグラフ本体に表示しています。所属しているだけの会社は下の「関係未登録」に分け、線の意味を読みやすくしています。</p>
+      ) : null}
+      <div className={`${styles.svgWrap} ${compactRelationsOnly ? relationStyles.compactGraph : ""}`}>
         <div className={styles.zoomControls}>
           <button type="button" onClick={panZoom.zoomIn} aria-label="拡大">＋</button>
           <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
@@ -121,8 +148,8 @@ export default function NetworkView({
               const selected = relationship.relationId === selectedRelationId;
               const focused = selectedNeighbours === null || (selectedNeighbours.has(relationship.sourceCompanyId) && selectedNeighbours.has(relationship.targetCompanyId));
               return <g key={relationship.relationId}>
-                <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.2 : focused ? 1.8 : 1} strokeOpacity={selected ? 1 : focused ? 0.85 : 0.2} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
-                {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - 7} textAnchor="middle" className={styles.svgEdgeLabel}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
+                <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.6 : focused ? 2.2 : 1.2} strokeOpacity={selected ? 1 : focused ? 0.9 : 0.22} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
+                {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - 9} textAnchor="middle" className={styles.svgEdgeLabel}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
               </g>;
             })}
             {memberships.map((membership) => {
@@ -142,7 +169,8 @@ export default function NetworkView({
               const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
               const neighbourDimmed = selectedNeighbours !== null && !selectedNeighbours.has(node.id);
               const dimmed = queryDimmed || neighbourDimmed;
-              const radius = node.kind === "group" ? (selected ? 11 : 9) : center ? 11 : selected ? 10 : 8;
+              const baseRadius = compactRelationsOnly ? 10 : 8;
+              const radius = node.kind === "group" ? (selected ? 11 : 9) : center ? 11 : selected ? baseRadius + 2 : baseRadius;
               const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
               return <g
@@ -167,12 +195,27 @@ export default function NetworkView({
                 <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
                 {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke={stroke} strokeWidth={2} /> : null}
                 <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected || center ? 3 : 2} />
-                <text className={styles.svgLabel} x={radius + 6} dominantBaseline="middle">{truncate(node.label)}</text>
+                <text className={styles.svgLabel} x={radius + 7} dominantBaseline="middle">{truncate(node.label)}</text>
               </g>;
             })}
           </g>
         </svg>
       </div>
+
+      {isolatedCompanies.length > 0 ? (
+        <section className={relationStyles.isolatedSection}>
+          <div className={relationStyles.isolatedHead}>
+            <div><span>RELATION NOT REGISTERED</span><strong>関係未登録のグループ企業</strong></div>
+            <b>{isolatedCompanies.length}社</b>
+          </div>
+          <p>グループ所属は確認済みですが、現在の企業間relationデータには参加していません。関係がないことを意味するのではなく、未登録として分離しています。</p>
+          <div className={relationStyles.isolatedCompanies}>
+            {isolatedCompanies.map((company) => (
+              <button key={company.id} type="button" onClick={() => onSelectCompany(company.id)}>{company.name}</button>
+            ))}
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -57,6 +57,7 @@ export default function NetworkView({
   const svgRef = useRef<SVGSVGElement>(null);
   const [frame, setFrame] = useState<{ source: SimNode[]; nodes: SimNode[] } | null>(null);
   const [runId, setRunId] = useState(0);
+  const relationsOnly = compactRelationsOnly || (centerCompanyId.length === 0 && memberships.length === 0);
 
   const participatingCompanyIds = useMemo(() => {
     const ids = new Set<string>();
@@ -68,15 +69,15 @@ export default function NetworkView({
   }, [relationships]);
 
   const visibleCompanies = useMemo(
-    () => compactRelationsOnly ? companies.filter((company) => participatingCompanyIds.has(company.id)) : companies,
-    [companies, compactRelationsOnly, participatingCompanyIds],
+    () => relationsOnly ? companies.filter((company) => participatingCompanyIds.has(company.id)) : companies,
+    [companies, participatingCompanyIds, relationsOnly],
   );
   const isolatedCompanies = useMemo(
-    () => compactRelationsOnly ? companies.filter((company) => !participatingCompanyIds.has(company.id)) : [],
-    [companies, compactRelationsOnly, participatingCompanyIds],
+    () => relationsOnly ? companies.filter((company) => !participatingCompanyIds.has(company.id)) : [],
+    [companies, participatingCompanyIds, relationsOnly],
   );
 
-  const graphKey = `${compactRelationsOnly ? "compact" : "full"}|${centerCompanyId}|${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
+  const graphKey = `${relationsOnly ? "compact" : "full"}|${centerCompanyId}|${relationships.map((item) => item.relationId).join(":")}|${memberships.map((item) => item.membershipId).join(":")}`;
   const panZoom = usePanZoom(svgRef, graphKey);
 
   const graph = useMemo(() => {
@@ -94,8 +95,8 @@ export default function NetworkView({
 
   const seeded = useMemo(() => {
     void runId;
-    return seedSimNodes(graph.nodes, compactRelationsOnly ? COMPACT_SEED_SPREAD : SEED_SPREAD);
-  }, [compactRelationsOnly, graph.nodes, runId]);
+    return seedSimNodes(graph.nodes, relationsOnly ? COMPACT_SEED_SPREAD : SEED_SPREAD);
+  }, [graph.nodes, relationsOnly, runId]);
 
   useEffect(() => {
     const working = seeded.map((node) => ({ ...node }));
@@ -113,7 +114,7 @@ export default function NetworkView({
 
   const nodes = frame?.source === seeded ? frame.nodes : seeded;
   const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
-  const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, compactRelationsOnly ? 135 : 240);
+  const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, relationsOnly ? 135 : 240);
   const size = VIEWBOX_HALF * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
   const selectedNodeId = selectedGraphNodeId(selection);
@@ -129,10 +130,10 @@ export default function NetworkView({
         <span className={relationStyles.relationMeta}>{visibleCompanies.length}社 · {relationships.length}関係</span>
         <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button>
       </div>
-      {compactRelationsOnly ? (
+      {relationsOnly ? (
         <p className={relationStyles.relationIntro}>企業間relationが確認できている会社だけをグラフ本体に表示しています。所属しているだけの会社は下の「関係未登録」に分け、線の意味を読みやすくしています。</p>
       ) : null}
-      <div className={`${styles.svgWrap} ${compactRelationsOnly ? relationStyles.compactGraph : ""}`}>
+      <div className={`${styles.svgWrap} ${relationsOnly ? relationStyles.compactGraph : ""}`}>
         <div className={styles.zoomControls}>
           <button type="button" onClick={panZoom.zoomIn} aria-label="拡大">＋</button>
           <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
@@ -169,7 +170,7 @@ export default function NetworkView({
               const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
               const neighbourDimmed = selectedNeighbours !== null && !selectedNeighbours.has(node.id);
               const dimmed = queryDimmed || neighbourDimmed;
-              const baseRadius = compactRelationsOnly ? 10 : 8;
+              const baseRadius = relationsOnly ? 10 : 8;
               const radius = node.kind === "group" ? (selected ? 11 : 9) : center ? 11 : selected ? baseRadius + 2 : baseRadius;
               const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";


### PR DESCRIPTION
Closes #528

## 変更概要
- グループモードの関係ビューでは、企業間relationに参加する企業だけをforce graph本体に表示
- relation未登録の所属企業は「関係未登録のグループ企業」としてグラフ下へ分離
- 小規模connected graph向けにseed spread / fit / node sizeを調整し、Toyotaの5本の100%出資を大きく表示
- company deep modeの既存NetworkView挙動は維持
- 系列ビューをROOT + L1カード反復から再帰ツリーへ変更
- 各枝は「対象企業 + relation種別/比率」を1行で表示
- 多階層、複数root、循環参照停止に対応
- Mitsuiのrelation 0件時の既存empty stateを維持

## DB
- schema/data変更なし
- 三井の上場/ticker補完は #529 で別作業

## 確認予定
- lint
- test
- build
- Vercel Preview Ready
- 反映後にToyotaの関係/系列を実画面UAT