### PR TITLE
feat(company-network): 上場ticker表示を企業グループUIへ接続

### DIFF
--- a/app/api/premium/company-network/route.ts
+++ b/app/api/premium/company-network/route.ts
@@ -7,9 +7,59 @@ import {
   loadCompanyGroupScope,
   loadCompanyNetworkScope,
 } from "@/app/premium/company-network/data-loader";
-import type { RelationCategory } from "@/app/premium/company-network/types";
+import type { CompanyNetworkScopeResult, RelationCategory } from "@/app/premium/company-network/types";
 
 const VALID_CATEGORIES = new Set<RelationCategory>(["capital", "control", "historical"]);
+
+type ListingRow = {
+  company_entity_id: string;
+  exchange_code: string | null;
+  exchange_name: string | null;
+  ticker: string | null;
+  listing_role: string | null;
+  is_preferred: boolean | null;
+};
+
+async function enrichListings(
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  result: CompanyNetworkScopeResult,
+): Promise<CompanyNetworkScopeResult> {
+  if (!result.data || result.data.companies.length === 0) return result;
+
+  const companyIds = result.data.companies.map((company) => company.id);
+  const listingResult = await supabase
+    .from("stock_notes_company_listings")
+    .select("company_entity_id,exchange_code,exchange_name,ticker,listing_role,is_preferred")
+    .in("company_entity_id", companyIds)
+    .is("valid_to", null)
+    .order("is_preferred", { ascending: false });
+
+  if (listingResult.error) return result;
+
+  const listingByCompany = new Map<string, ListingRow>();
+  for (const row of (listingResult.data ?? []) as ListingRow[]) {
+    const current = listingByCompany.get(row.company_entity_id);
+    if (!current || row.is_preferred || row.listing_role === "primary") {
+      listingByCompany.set(row.company_entity_id, row);
+    }
+  }
+
+  return {
+    ...result,
+    data: {
+      ...result.data,
+      companies: result.data.companies.map((company) => {
+        const listing = listingByCompany.get(company.id);
+        return {
+          ...company,
+          ticker: listing?.ticker ?? null,
+          exchangeCode: listing?.exchange_code ?? null,
+          exchangeName: listing?.exchange_name ?? null,
+        };
+      }),
+    },
+  };
+}
 
 export async function GET(request: Request) {
   const cookieStore = await cookies();
@@ -55,5 +105,6 @@ export async function GET(request: Request) {
         includeGroups,
       });
 
-  return NextResponse.json(result, { status: result.status === "error" ? 500 : 200 });
+  const enriched = await enrichListings(supabase, result);
+  return NextResponse.json(enriched, { status: enriched.status === "error" ? 500 : 200 });
 }

--- a/app/api/premium/company-network/route.ts
+++ b/app/api/premium/company-network/route.ts
@@ -24,7 +24,8 @@ async function enrichListings(
   supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
   result: CompanyNetworkScopeResult,
 ): Promise<CompanyNetworkScopeResult> {
-  if (!result.data || result.data.companies.length === 0) return result;
+  if (result.status !== "ok" && result.status !== "empty") return result;
+  if (result.data.companies.length === 0) return result;
 
   const companyIds = result.data.companies.map((company) => company.id);
   const listingResult = await supabase

--- a/app/premium/company-network/types.ts
+++ b/app/premium/company-network/types.ts
@@ -15,6 +15,9 @@ export type CompanyNetworkCompany = {
   countryCode: string | null;
   listingStatus: string;
   status: string;
+  ticker: string | null;
+  exchangeCode: string | null;
+  exchangeName: string | null;
 };
 
 export type CompanyRelationship = {

--- a/app/premium/company-network/types.ts
+++ b/app/premium/company-network/types.ts
@@ -15,9 +15,9 @@ export type CompanyNetworkCompany = {
   countryCode: string | null;
   listingStatus: string;
   status: string;
-  ticker: string | null;
-  exchangeCode: string | null;
-  exchangeName: string | null;
+  ticker?: string | null;
+  exchangeCode?: string | null;
+  exchangeName?: string | null;
 };
 
 export type CompanyRelationship = {

--- a/app/premium/company-network/views/DetailPanel.tsx
+++ b/app/premium/company-network/views/DetailPanel.tsx
@@ -27,10 +27,12 @@ type Props = {
   onMakeCenter: (companyId: string) => void;
 };
 
-function listingLabel(value: string) {
-  if (value === "domestic_listed") return "上場";
-  if (value === "foreign_listed") return "海外上場";
-  if (value === "private") return "非上場";
+function listingLabel(company: CompanyNetworkCompany | undefined | null) {
+  if (!company) return "上場区分未確認";
+  const ticker = company.ticker ? ` ${company.ticker}` : "";
+  if (company.listingStatus === "domestic_listed") return `上場${ticker}`;
+  if (company.listingStatus === "foreign_listed") return `海外上場${ticker}`;
+  if (company.listingStatus === "private") return "非上場";
   return "上場区分未確認";
 }
 
@@ -87,13 +89,16 @@ export default function DetailPanel({
           <div className={styles.detailSectionHead}><h3>所属企業</h3><span>{groupMemberships.length}社</span></div>
           {groupMemberships.length > 0 ? (
             <div className={styles.detailRelations}>
-              {groupMemberships.map((membership) => (
-                <button type="button" key={membership.membershipId} className={styles.detailRelationButton} onClick={() => onSelectCompany(membership.companyId)}>
-                  <strong>{membership.companyName}</strong>
-                  <span>{listingLabel(companies.find((item) => item.id === membership.companyId)?.listingStatus ?? "")}</span>
-                  <small>{formatAsOf(membership.sourceAsOf)}</small>
-                </button>
-              ))}
+              {groupMemberships.map((membership) => {
+                const memberCompany = companies.find((item) => item.id === membership.companyId);
+                return (
+                  <button type="button" key={membership.membershipId} className={styles.detailRelationButton} onClick={() => onSelectCompany(membership.companyId)}>
+                    <strong>{membership.companyName}</strong>
+                    <span>{listingLabel(memberCompany)}</span>
+                    <small>{formatAsOf(membership.sourceAsOf)}</small>
+                  </button>
+                );
+              })}
             </div>
           ) : <p className={styles.empty}>現在の条件で表示できる所属企業はありません。</p>}
         </section>
@@ -133,7 +138,8 @@ export default function DetailPanel({
         <span className={styles.detailKicker}>{isCenter ? "CENTER COMPANY" : "SELECTED COMPANY"}</span>
         <h2>{company.name}</h2>
         <div className={styles.badges}>
-          <span>{listingLabel(company.listingStatus)}</span>
+          <span>{listingLabel(company)}</span>
+          {company.exchangeCode ? <span>{company.exchangeCode}</span> : null}
           {company.countryCode ? <span>{company.countryCode}</span> : null}
           <span>機能 {companyFunctions.length}件</span>
         </div>

--- a/app/premium/company-network/views/FunctionClusterView.tsx
+++ b/app/premium/company-network/views/FunctionClusterView.tsx
@@ -22,11 +22,12 @@ type Props = {
   onSelectCompany: (companyId: string) => void;
 };
 
-function listingLabel(value: string) {
-  if (value === "domestic_listed") return "上場";
-  if (value === "foreign_listed") return "海外上場";
-  if (value === "private") return "非上場";
-  return "未確認";
+function listingLabel(company: CompanyNetworkCompany) {
+  const ticker = company.ticker ? ` ${company.ticker}` : "";
+  if (company.listingStatus === "domestic_listed") return `上場${ticker}`;
+  if (company.listingStatus === "foreign_listed") return `海外上場${ticker}`;
+  if (company.listingStatus === "private") return "非上場";
+  return "上場区分未確認";
 }
 
 export default function FunctionClusterView({
@@ -159,7 +160,8 @@ export default function FunctionClusterView({
                                 onClick={() => onSelectCompany(company.id)}
                               >
                                 <strong>{company.name}</strong>
-                                <span>{link.role === "core" ? "主要機能" : "追加機能"} · {listingLabel(company.listingStatus)}</span>
+                                <span>{link.role === "core" ? "主要機能" : "追加機能"}</span>
+                                <small>{listingLabel(company)}</small>
                                 {whollyOwnedParent ? <small>{whollyOwnedParent} 100%出資</small> : null}
                               </button>
                             );

--- a/app/premium/company-network/views/GroupTableView.tsx
+++ b/app/premium/company-network/views/GroupTableView.tsx
@@ -29,10 +29,12 @@ type Props = {
 
 type TableMode = "companies" | "relations";
 
-function listingLabel(value: string) {
-  if (value === "domestic_listed") return "上場";
-  if (value === "foreign_listed") return "海外上場";
-  if (value === "private") return "非上場";
+function listingLabel(company: CompanyNetworkCompany | undefined) {
+  if (!company) return "未確認";
+  const ticker = company.ticker ? ` ${company.ticker}` : "";
+  if (company.listingStatus === "domestic_listed") return `上場${ticker}`;
+  if (company.listingStatus === "foreign_listed") return `海外上場${ticker}`;
+  if (company.listingStatus === "private") return "非上場";
   return "未確認";
 }
 
@@ -83,11 +85,13 @@ export default function GroupTableView({
     () => memberships
       .filter((membership) => membership.groupId === group.id)
       .filter((membership) => {
+        const company = companyById.get(membership.companyId);
         const companyRelations = relationshipsByCompany.get(membership.companyId) ?? [];
         const companyFunctions = functionsByCompany.get(membership.companyId) ?? [];
         const searchable = [
           membership.companyName,
-          listingLabel(companyById.get(membership.companyId)?.listingStatus ?? ""),
+          listingLabel(company),
+          company?.ticker ?? "",
           ...companyFunctions.flatMap((link) => [link.functionName, link.classificationName ?? ""]),
           ...companyRelations.map((relationship) => relationSentence(relationship, membership.companyId)),
         ].join(" ").toLocaleLowerCase("ja");
@@ -159,7 +163,7 @@ export default function GroupTableView({
                   return (
                     <tr key={membership.membershipId} className={selected || focusCompanyId === membership.companyId ? styles.tableRowSelected : undefined} onClick={() => onSelectCompany(membership.companyId)}>
                       <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(membership.companyId); }}>{membership.companyName}</button></td>
-                      <td>{listingLabel(company?.listingStatus ?? "")}</td>
+                      <td>{listingLabel(company)}</td>
                       <td className={functionStyles.tableFunction}>{functionSummary}</td>
                       <td className={styles.tableRelation}>{relationSummary}</td>
                       <td>{formatAsOf(latestFunctionAsOf ?? membership.sourceAsOf)}</td>


### PR DESCRIPTION
Closes #529

## 変更概要
- company-network APIで `stock_notes_company_listings` の現在有効なprimary/preferred listingを取得し、company read modelへ ticker / exchange を付加
- CompanyNetworkCompanyにlisting metadataを後方互換なoptional fieldとして追加
- 表ビューで `上場 8031` のようにtickerを表示し、ticker検索にも対応
- 構成ビューで `主要機能/追加機能` と `上場/非上場 + ticker` を別行に分離
- 詳細パネルでもticker/exchangeを表示

## DB
- schema変更なし
- #529で先行登録済みの三井22社listing dataを利用
- 現在 三井グループ: 上場16社 / 非上場6社 / 未確認0社

## 確認
- lint/test/build
- Vercel Preview Ready
- 三井グループ表で未確認0件、上場企業ticker表示を確認予定