### PR TITLE
feat(company-network): Claude Code版に寄せて5ビューを再設計

### DIFF
--- a/app/premium/company-network/ClaudeUi.module.css
+++ b/app/premium/company-network/ClaudeUi.module.css
@@ -194,7 +194,6 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   font-weight: 800;
 }
 
-/* relation network */
 .networkIntro {
   margin: -1px 0 5px;
   color: var(--color-text-muted);
@@ -207,7 +206,6 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   min-height: 330px !important;
 }
 
-/* capital hierarchy */
 .hierarchyIntro {
   padding: 7px 9px !important;
   border-radius: 8px !important;
@@ -238,10 +236,7 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   margin: 0 !important;
 }
 
-.hierarchyRoot strong {
-  font-size: 12px !important;
-}
-
+.hierarchyRoot strong { font-size: 12px !important; }
 .hierarchyRoot small { display: none !important; }
 
 .hierarchyNode {
@@ -256,16 +251,13 @@ details[open] > summary .chevron { transform: rotate(90deg); }
 .hierarchyCompany small { display: none !important; }
 .hierarchyRelation { padding: 3px 7px !important; font-size: 8px !important; }
 
-/* matrix */
 .legendBar {
   padding: 5px 7px !important;
   border-radius: 7px !important;
   font-size: 8px !important;
 }
 
-.matrixScroll {
-  border-radius: 8px !important;
-}
+.matrixScroll { border-radius: 8px !important; }
 
 .matrixTable th,
 .matrixTable td {
@@ -285,7 +277,6 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   font-size: 9px !important;
 }
 
-/* table: desktop stays dense, mobile becomes readable cards */
 .mobileList { display: none; }
 .desktopTable { display: block; }
 
@@ -314,30 +305,30 @@ details[open] > summary .chevron { transform: rotate(90deg); }
 .mobileCardBody { color: var(--color-text-sub); font-size: 9px; line-height: 1.5; }
 .mobileCardSub { color: var(--color-text-muted); font-size: 8px; line-height: 1.45; }
 
-/* toolbar / tab strip: loaded route-wide through statically imported views */
-:global([aria-label="企業関係マップの表示条件"]) {
+/* A local .view inside :has keeps CSS Modules pure while scoping route-wide density. */
+:global(body):has(.view) :global([aria-label="企業関係マップの表示条件"]) {
   gap: 7px !important;
   padding: 9px !important;
   border-radius: 12px !important;
 }
 
-:global([aria-label="企業関係マップの表示条件"] select),
-:global([aria-label="企業関係マップの表示条件"] input[type="search"]) {
+:global(body):has(.view) :global([aria-label="企業関係マップの表示条件"] select),
+:global(body):has(.view) :global([aria-label="企業関係マップの表示条件"] input[type="search"]) {
   min-height: 34px !important;
   border-radius: 8px !important;
   font-size: 12px !important;
 }
 
-:global([role="tablist"][aria-label="表現の切り替え"]) {
+:global(body):has(.view) :global([role="tablist"][aria-label="表現の切り替え"]) {
   border-radius: 9px !important;
 }
 
-:global([role="tablist"][aria-label="表現の切り替え"] button[role="tab"]) {
+:global(body):has(.view) :global([role="tablist"][aria-label="表現の切り替え"] button[role="tab"]) {
   min-height: 34px !important;
   font-size: 10px !important;
 }
 
-:global(section[aria-busy]) {
+:global(body):has(.view) :global(section[aria-busy]) {
   min-height: 0 !important;
   padding: 10px !important;
 }
@@ -367,7 +358,7 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   .matrixTable td { min-width: 56px !important; padding: 5px 4px !important; }
   .matrixTable thead button { max-height: 78px !important; font-size: 8px !important; }
 
-  :global([aria-label="企業関係マップの表示条件"]) { padding: 7px !important; gap: 6px !important; }
-  :global([role="tablist"][aria-label="表現の切り替え"] button[role="tab"]) { min-height: 32px !important; font-size: 9px !important; }
-  :global(section[aria-busy]) { padding: 7px !important; }
+  :global(body):has(.view) :global([aria-label="企業関係マップの表示条件"]) { padding: 7px !important; gap: 6px !important; }
+  :global(body):has(.view) :global([role="tablist"][aria-label="表現の切り替え"] button[role="tab"]) { min-height: 32px !important; font-size: 9px !important; }
+  :global(body):has(.view) :global(section[aria-busy]) { padding: 7px !important; }
 }

--- a/app/premium/company-network/ClaudeUi.module.css
+++ b/app/premium/company-network/ClaudeUi.module.css
@@ -1,0 +1,373 @@
+.view {
+  display: grid;
+  gap: 8px;
+}
+
+.compactIntro {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 10px;
+  line-height: 1.6;
+}
+
+.summaryStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  align-items: center;
+  padding: 7px 2px;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.summaryStat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+}
+
+.summaryStat strong {
+  font-size: 14px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.summaryStat span {
+  color: var(--color-text-muted);
+  font-size: 9px;
+  font-weight: 800;
+}
+
+/* Claude Code版のtree思想: group -> class -> function -> company */
+.functionTree {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-bg-card);
+  overflow: hidden;
+}
+
+.treeRoot,
+.treeClass,
+.treeFunction {
+  margin: 0;
+}
+
+.treeRoot > summary,
+.treeClass > summary,
+.treeFunction > summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+
+.treeRoot > summary::-webkit-details-marker,
+.treeClass > summary::-webkit-details-marker,
+.treeFunction > summary::-webkit-details-marker {
+  display: none;
+}
+
+.treeRootSummary,
+.treeClassSummary,
+.treeFunctionSummary {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+}
+
+.treeRootSummary {
+  padding: 9px 10px;
+  background: var(--color-bg-input);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.treeClass {
+  --tree-accent: #2563eb;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.treeClass:last-child { border-bottom: 0; }
+.treeTone0 { --tree-accent: #2563eb; }
+.treeTone1 { --tree-accent: #0f9f8f; }
+.treeTone2 { --tree-accent: #7c3aed; }
+.treeTone3 { --tree-accent: #d97706; }
+.treeTone4 { --tree-accent: #64748b; }
+.treeTone5 { --tree-accent: #be123c; }
+
+.treeClassSummary {
+  min-height: 38px;
+  padding: 6px 10px 6px 14px;
+}
+
+.treeFunctionSummary {
+  min-height: 34px;
+  padding: 5px 10px 5px 28px;
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  background: color-mix(in srgb, var(--tree-accent) 3%, var(--color-bg-card));
+}
+
+.chevron {
+  color: var(--color-text-muted);
+  font-size: 9px;
+  transition: transform 120ms ease;
+}
+
+details[open] > summary .chevron { transform: rotate(90deg); }
+
+.classDot,
+.roleDot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--tree-accent, var(--color-accent));
+}
+
+.roleDotSupporting {
+  background: transparent;
+  border: 1px solid var(--tree-accent, var(--color-accent));
+}
+
+.treeTitle {
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 1.35;
+}
+
+.treeRootSummary .treeTitle { font-size: 13px; }
+
+.treeMeta {
+  color: var(--color-text-muted);
+  font-size: 8px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.companyTreeList {
+  margin-left: 35px;
+  border-left: 1px solid var(--color-border);
+}
+
+.companyTreeRow {
+  width: calc(100% - 8px);
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 4px 8px 4px 10px;
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 68%, transparent);
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.companyTreeRow:last-child { border-bottom: 0; }
+.companyTreeRow:hover { background: var(--color-bg-input); }
+.companyTreeRowSelected { background: var(--color-accent-sub); }
+
+.companyTreeName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.companyTreeMeta {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--color-text-muted);
+  font-size: 8px;
+  white-space: nowrap;
+}
+
+.companyTreeRelation {
+  color: var(--color-accent);
+  font-weight: 800;
+}
+
+/* relation network */
+.networkIntro {
+  margin: -1px 0 5px;
+  color: var(--color-text-muted);
+  font-size: 9px;
+  line-height: 1.5;
+}
+
+.networkCanvas,
+.networkSvg {
+  min-height: 330px !important;
+}
+
+/* capital hierarchy */
+.hierarchyIntro {
+  padding: 7px 9px !important;
+  border-radius: 8px !important;
+  font-size: 10px !important;
+  line-height: 1.55 !important;
+}
+
+.hierarchySection {
+  padding: 6px 4px 6px 6px !important;
+  border-radius: 8px !important;
+}
+
+.hierarchyRoot {
+  display: grid !important;
+  grid-template-columns: auto minmax(0, 1fr) !important;
+  align-items: center !important;
+  gap: 6px !important;
+  min-width: 0 !important;
+  width: 100% !important;
+  padding: 6px 8px !important;
+  border: 0 !important;
+  border-radius: 6px !important;
+  background: var(--color-accent-sub) !important;
+}
+
+.hierarchyRoot span {
+  font-size: 7px !important;
+  margin: 0 !important;
+}
+
+.hierarchyRoot strong {
+  font-size: 12px !important;
+}
+
+.hierarchyRoot small { display: none !important; }
+
+.hierarchyNode {
+  min-height: 34px !important;
+  padding: 4px 5px 4px 8px !important;
+  border-radius: 7px !important;
+  background: transparent !important;
+}
+
+.hierarchyNode:hover { background: var(--color-bg-input) !important; }
+.hierarchyCompany strong { font-size: 10px !important; }
+.hierarchyCompany small { display: none !important; }
+.hierarchyRelation { padding: 3px 7px !important; font-size: 8px !important; }
+
+/* matrix */
+.legendBar {
+  padding: 5px 7px !important;
+  border-radius: 7px !important;
+  font-size: 8px !important;
+}
+
+.matrixScroll {
+  border-radius: 8px !important;
+}
+
+.matrixTable th,
+.matrixTable td {
+  min-width: 68px !important;
+  padding: 6px 5px !important;
+}
+
+.matrixTable thead button {
+  max-height: 90px !important;
+  font-size: 8px !important;
+}
+
+.matrixCellButton {
+  width: 22px !important;
+  height: 22px !important;
+  border-radius: 6px !important;
+  font-size: 9px !important;
+}
+
+/* table: desktop stays dense, mobile becomes readable cards */
+.mobileList { display: none; }
+.desktopTable { display: block; }
+
+.mobileCard {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 8px 2px;
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text);
+  text-align: left;
+  font: inherit;
+}
+
+.mobileCardHead {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.mobileCardHead strong { color: var(--color-accent); font-size: 11px; }
+.mobileCardHead span { color: var(--color-text-muted); font-size: 9px; }
+.mobileCardBody { color: var(--color-text-sub); font-size: 9px; line-height: 1.5; }
+.mobileCardSub { color: var(--color-text-muted); font-size: 8px; line-height: 1.45; }
+
+/* toolbar / tab strip: loaded route-wide through statically imported views */
+:global([aria-label="企業関係マップの表示条件"]) {
+  gap: 7px !important;
+  padding: 9px !important;
+  border-radius: 12px !important;
+}
+
+:global([aria-label="企業関係マップの表示条件"] select),
+:global([aria-label="企業関係マップの表示条件"] input[type="search"]) {
+  min-height: 34px !important;
+  border-radius: 8px !important;
+  font-size: 12px !important;
+}
+
+:global([role="tablist"][aria-label="表現の切り替え"]) {
+  border-radius: 9px !important;
+}
+
+:global([role="tablist"][aria-label="表現の切り替え"] button[role="tab"]) {
+  min-height: 34px !important;
+  font-size: 10px !important;
+}
+
+:global(section[aria-busy]) {
+  min-height: 0 !important;
+  padding: 10px !important;
+}
+
+@media (max-width: 720px) {
+  .summaryStrip { gap: 5px 11px; padding-block: 5px; }
+  .summaryStat strong { font-size: 12px; }
+  .summaryStat span { font-size: 8px; }
+
+  .treeRootSummary { padding: 7px 8px; }
+  .treeClassSummary { padding: 5px 7px 5px 9px; min-height: 34px; }
+  .treeFunctionSummary { padding: 4px 7px 4px 22px; min-height: 31px; }
+  .treeTitle { font-size: 11px; }
+  .treeRootSummary .treeTitle { font-size: 12px; }
+  .companyTreeList { margin-left: 27px; }
+  .companyTreeRow { min-height: 30px; padding: 3px 5px 3px 8px; }
+  .companyTreeName { font-size: 9px; }
+  .companyTreeMeta { gap: 4px; font-size: 7px; }
+
+  .networkCanvas,
+  .networkSvg { min-height: 290px !important; }
+
+  .desktopTable { display: none; }
+  .mobileList { display: grid; }
+
+  .matrixTable th,
+  .matrixTable td { min-width: 56px !important; padding: 5px 4px !important; }
+  .matrixTable thead button { max-height: 78px !important; font-size: 8px !important; }
+
+  :global([aria-label="企業関係マップの表示条件"]) { padding: 7px !important; gap: 6px !important; }
+  :global([role="tablist"][aria-label="表現の切り替え"] button[role="tab"]) { min-height: 32px !important; font-size: 9px !important; }
+  :global(section[aria-busy]) { padding: 7px !important; }
+}

--- a/app/premium/company-network/views/FunctionClusterView.tsx
+++ b/app/premium/company-network/views/FunctionClusterView.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import styles from "../CompanyNetwork.module.css";
 import functionStyles from "../FunctionViews.module.css";
+import claudeStyles from "../ClaudeUi.module.css";
 import { compareFunction, compareFunctionClass } from "../function-order";
 import type {
   CompanyFunctionLink,
@@ -88,92 +89,115 @@ export default function FunctionClusterView({
 
   const unmapped = companies.filter((company) => !mappedCompanyIds.has(company.id));
   const selectedCompanyId = selection?.kind === "company" ? selection.id : "";
+  const whollyOwnedCount = relationships.filter(
+    (relationship) => relationship.relationType === "equity_ownership" && relationship.ownershipPct === 100,
+  ).length;
+  const functionAreaCount = new Set(functions.map((link) => link.nodeId)).size;
 
   if (functions.length === 0) {
     return (
-      <div className={`${functionStyles.functionView} ${styles.viewFade}`}>
-        <p className={styles.seriesIntro}><strong>{groupName}</strong>には所属企業がありますが、事業・機能taxonomyがまだ登録されていません。</p>
+      <div className={`${claudeStyles.view} ${styles.viewFade}`}>
+        <p className={claudeStyles.compactIntro}><strong>{groupName}</strong>には所属企業がありますが、事業・機能taxonomyがまだ登録されていません。</p>
       </div>
     );
   }
 
   return (
-    <div className={`${functionStyles.functionView} ${styles.viewFade}`}>
+    <div className={`${claudeStyles.view} ${styles.viewFade}`}>
       <div className={styles.viewTools}>
         <span>{groupName}の事業・機能構成</span>
         <span>{mappedCompanyIds.size}/{companies.length}社 · {functions.length}機能リンク</span>
       </div>
-      <p className={functionStyles.functionIntro}>企業名簿ではなく「何を担う会社か」で整理しています。同じ会社が複数領域に現れる場合、それは複数の公式事業機能を持つことを示します。</p>
-      <div className={functionStyles.functionSummary}>
-        <div><strong>{clusters.length}</strong><span>大分類</span></div>
-        <div><strong>{new Set(functions.map((link) => link.nodeId)).size}</strong><span>機能領域</span></div>
-        <div><strong>{multiFunctionCompanies}</strong><span>複数機能を担う企業</span></div>
-        <div><strong>{relationships.filter((relationship) => relationship.relationType === "equity_ownership" && relationship.ownershipPct === 100).length}</strong><span>100%出資関係</span></div>
+      <p className={claudeStyles.compactIntro}>グループ → 大分類 → 機能領域 → 企業の順でたどれます。複数領域に現れる企業は、複数の公式事業機能を持つことを示します。</p>
+
+      <div className={claudeStyles.summaryStrip} aria-label="構成サマリー">
+        <div className={claudeStyles.summaryStat}><strong>{clusters.length}</strong><span>大分類</span></div>
+        <div className={claudeStyles.summaryStat}><strong>{functionAreaCount}</strong><span>機能領域</span></div>
+        <div className={claudeStyles.summaryStat}><strong>{multiFunctionCompanies}</strong><span>複数機能企業</span></div>
+        <div className={claudeStyles.summaryStat}><strong>{whollyOwnedCount}</strong><span>100%出資</span></div>
       </div>
 
-      <div className={functionStyles.functionClusterGrid}>
-        {clusters.map((cluster, clusterIndex) => {
-          const classLinks = cluster.functions.flatMap((item) => item.links);
-          const classCompanyCount = new Set(classLinks.map((link) => link.companyId)).size;
-          const coreCount = classLinks.filter((link) => link.role === "core").length;
-          const toneClass = functionStyles[`functionTone${clusterIndex % 6}`] ?? "";
-          return (
-            <section key={cluster.classificationId} className={`${functionStyles.functionCluster} ${toneClass}`}>
-              <header className={functionStyles.functionClusterHead}>
-                <div><span>FUNCTION CLASS</span><h3>{cluster.classificationName}</h3><small>{cluster.functions.length}領域 · 主要機能 {coreCount}件</small></div>
-                <strong>{classCompanyCount}社</strong>
-              </header>
+      <div className={claudeStyles.functionTree}>
+        <details className={claudeStyles.treeRoot} open>
+          <summary className={claudeStyles.treeRootSummary}>
+            <span className={claudeStyles.chevron}>▶</span>
+            <span className={claudeStyles.treeTitle}>{groupName}</span>
+            <span className={claudeStyles.treeMeta}>{mappedCompanyIds.size}社</span>
+          </summary>
 
-              <div className={functionStyles.functionRows}>
-                {cluster.functions.map((item) => {
-                  const visibleLinks = item.links.filter((link) => {
-                    if (focusCompanyId && link.companyId !== focusCompanyId) return false;
-                    if (!normalized) return true;
-                    const company = companyById.get(link.companyId);
-                    return [cluster.classificationName, item.functionName, company?.name ?? ""]
-                      .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+          {clusters.map((cluster, clusterIndex) => {
+            const visibleFunctions = cluster.functions
+              .map((item) => ({
+                ...item,
+                visibleLinks: item.links.filter((link) => {
+                  if (focusCompanyId && link.companyId !== focusCompanyId) return false;
+                  if (!normalized) return true;
+                  const company = companyById.get(link.companyId);
+                  return [cluster.classificationName, item.functionName, company?.name ?? ""]
+                    .some((value) => value.toLocaleLowerCase("ja").includes(normalized));
+                }),
+              }))
+              .filter((item) => item.visibleLinks.length > 0);
+
+            if (visibleFunctions.length === 0) return null;
+            const classLinks = visibleFunctions.flatMap((item) => item.visibleLinks);
+            const classCompanyCount = new Set(classLinks.map((link) => link.companyId)).size;
+            const toneClass = claudeStyles[`treeTone${clusterIndex % 6}`] ?? "";
+
+            return (
+              <details key={cluster.classificationId} className={`${claudeStyles.treeClass} ${toneClass}`} open>
+                <summary className={claudeStyles.treeClassSummary}>
+                  <span className={claudeStyles.chevron}>▶</span>
+                  <span className={claudeStyles.treeTitle}><span className={claudeStyles.classDot} /> {cluster.classificationName}</span>
+                  <span className={claudeStyles.treeMeta}>{classCompanyCount}社 · {visibleFunctions.length}領域</span>
+                </summary>
+
+                {visibleFunctions.map((item) => {
+                  const sortedLinks = [...item.visibleLinks].sort((a, b) => {
+                    if (a.role === "core" && b.role !== "core") return -1;
+                    if (a.role !== "core" && b.role === "core") return 1;
+                    return (companyById.get(a.companyId)?.name ?? "").localeCompare(companyById.get(b.companyId)?.name ?? "", "ja");
                   });
-                  if (visibleLinks.length === 0) return null;
+                  const companyCount = new Set(sortedLinks.map((link) => link.companyId)).size;
+
                   return (
-                    <div key={item.functionSlug} className={functionStyles.functionRow}>
-                      <div className={functionStyles.functionRowHead}>
-                        <strong>{item.functionName}</strong>
-                        <span>{new Set(visibleLinks.map((link) => link.companyId)).size}社</span>
+                    <details key={item.functionSlug} className={claudeStyles.treeFunction} open>
+                      <summary className={claudeStyles.treeFunctionSummary}>
+                        <span className={claudeStyles.chevron}>▶</span>
+                        <span className={claudeStyles.treeTitle}>{item.functionName}</span>
+                        <span className={claudeStyles.treeMeta}>{companyCount}社</span>
+                      </summary>
+
+                      <div className={claudeStyles.companyTreeList}>
+                        {sortedLinks.map((link) => {
+                          const company = companyById.get(link.companyId);
+                          if (!company) return null;
+                          const whollyOwnedParent = whollyOwnedBy.get(company.id);
+                          const selected = selectedCompanyId === company.id;
+                          return (
+                            <button
+                              key={link.linkId}
+                              type="button"
+                              className={`${claudeStyles.companyTreeRow} ${selected ? claudeStyles.companyTreeRowSelected : ""}`}
+                              onClick={() => onSelectCompany(company.id)}
+                            >
+                              <span className={`${claudeStyles.roleDot} ${link.role === "core" ? "" : claudeStyles.roleDotSupporting}`} />
+                              <span className={claudeStyles.companyTreeName}>{company.name}</span>
+                              <span className={claudeStyles.companyTreeMeta}>
+                                <span>{listingLabel(company)}</span>
+                                {whollyOwnedParent ? <span className={claudeStyles.companyTreeRelation}>{whollyOwnedParent} 100%</span> : null}
+                              </span>
+                            </button>
+                          );
+                        })}
                       </div>
-                      <div className={functionStyles.functionCompanies}>
-                        {visibleLinks
-                          .sort((a, b) => {
-                            if (a.role === "core" && b.role !== "core") return -1;
-                            if (a.role !== "core" && b.role === "core") return 1;
-                            return (companyById.get(a.companyId)?.name ?? "").localeCompare(companyById.get(b.companyId)?.name ?? "", "ja");
-                          })
-                          .map((link) => {
-                            const company = companyById.get(link.companyId);
-                            if (!company) return null;
-                            const whollyOwnedParent = whollyOwnedBy.get(company.id);
-                            const selected = selectedCompanyId === company.id;
-                            return (
-                              <button
-                                key={link.linkId}
-                                type="button"
-                                className={`${functionStyles.functionCompany} ${link.role === "core" ? functionStyles.functionCompanyCore : functionStyles.functionCompanySupporting} ${selected ? functionStyles.functionCompanySelected : ""}`}
-                                onClick={() => onSelectCompany(company.id)}
-                              >
-                                <strong>{company.name}</strong>
-                                <span>{link.role === "core" ? "主要機能" : "追加機能"}</span>
-                                <small>{listingLabel(company)}</small>
-                                {whollyOwnedParent ? <small>{whollyOwnedParent} 100%出資</small> : null}
-                              </button>
-                            );
-                          })}
-                      </div>
-                    </div>
+                    </details>
                   );
                 })}
-              </div>
-            </section>
-          );
-        })}
+              </details>
+            );
+          })}
+        </details>
       </div>
 
       {unmapped.length > 0 ? (

--- a/app/premium/company-network/views/FunctionCoverageMatrixView.tsx
+++ b/app/premium/company-network/views/FunctionCoverageMatrixView.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import styles from "../CompanyNetwork.module.css";
 import functionStyles from "../FunctionViews.module.css";
+import claudeStyles from "../ClaudeUi.module.css";
 import { compareFunction, compareFunctionClass } from "../function-order";
 import type { CompanyFunctionLink, CompanyNetworkCompany } from "../types";
 
@@ -71,19 +72,19 @@ export default function FunctionCoverageMatrixView({
   }
 
   return (
-    <div className={`${functionStyles.matrixView} ${styles.viewFade}`}>
+    <div className={`${functionStyles.matrixView} ${claudeStyles.view} ${styles.viewFade}`}>
       <div className={styles.viewTools}>
         <span>{groupName} 機能カバレッジ</span>
         <span>{rows.length}領域 × {companiesSorted.length}社</span>
       </div>
-      <div className={functionStyles.matrixLegend}>
+      <div className={`${functionStyles.matrixLegend} ${claudeStyles.legendBar}`}>
         <span><b className={functionStyles.legendCore}>●</b> 主要機能</span>
         <span><b className={functionStyles.legendSupporting}>○</b> 追加機能</span>
-        <span>企業は担当機能数が多い順。表示基点を選ぶと先頭列へ固定します。</span>
+        <span>担当機能数が多い企業を左側へ配置</span>
       </div>
       <div className={functionStyles.matrixScrollHint}>← 横スクロールで全社を比較 →</div>
-      <div className={functionStyles.matrixScroll}>
-        <table className={functionStyles.matrixTable}>
+      <div className={`${functionStyles.matrixScroll} ${claudeStyles.matrixScroll}`}>
+        <table className={`${functionStyles.matrixTable} ${claudeStyles.matrixTable}`}>
           <thead>
             <tr>
               <th className={functionStyles.matrixSticky}>機能</th>
@@ -112,7 +113,7 @@ export default function FunctionCoverageMatrixView({
                         {link ? (
                           <button
                             type="button"
-                            className={link.role === "core" ? functionStyles.matrixCore : functionStyles.matrixSupporting}
+                            className={`${link.role === "core" ? functionStyles.matrixCore : functionStyles.matrixSupporting} ${claudeStyles.matrixCellButton}`}
                             title={`${company.name}: ${row.functionName} (${link.role === "core" ? "主要" : "追加"})`}
                             onClick={() => onSelectCompany(company.id)}
                           >

--- a/app/premium/company-network/views/GroupHierarchyView.tsx
+++ b/app/premium/company-network/views/GroupHierarchyView.tsx
@@ -3,6 +3,7 @@
 import { useMemo, type ReactNode } from "react";
 import styles from "../CompanyNetwork.module.css";
 import relationStyles from "../RelationshipViews.module.css";
+import claudeStyles from "../ClaudeUi.module.css";
 import { relationLabel } from "../presentation";
 import type { CompanyNetworkCompany, CompanyRelationship } from "../types";
 
@@ -75,8 +76,8 @@ export default function GroupHierarchyView({
 
   if (seriesRelationships.length === 0) {
     return (
-      <div className={`${styles.seriesView} ${styles.viewFade}`}>
-        <p className={styles.seriesIntro}><strong>{groupName}</strong>の所属企業は確認済みですが、グループ内の資本・支配関係はまだ登録されていません。表示不具合ではなく、企業間relationのデータが未登録です。</p>
+      <div className={`${claudeStyles.view} ${styles.viewFade}`}>
+        <p className={`${styles.seriesIntro} ${claudeStyles.hierarchyIntro}`}><strong>{groupName}</strong>の所属企業は確認済みですが、グループ内の資本・支配関係はまだ登録されていません。</p>
       </div>
     );
   }
@@ -101,14 +102,13 @@ export default function GroupHierarchyView({
 
           return (
             <div key={relationship.relationId} className={`${relationStyles.treeBranch} ${dimmed ? relationStyles.treeBranchDim : ""}`}>
-              <div className={`${relationStyles.treeNode} ${selected ? relationStyles.treeNodeSelected : ""}`}>
-                <button type="button" className={relationStyles.treeCompany} onClick={() => onSelectCompany(target.id)} aria-pressed={selected}>
+              <div className={`${relationStyles.treeNode} ${claudeStyles.hierarchyNode} ${selected ? relationStyles.treeNodeSelected : ""}`}>
+                <button type="button" className={`${relationStyles.treeCompany} ${claudeStyles.hierarchyCompany}`} onClick={() => onSelectCompany(target.id)} aria-pressed={selected}>
                   <strong>{target.name}</strong>
-                  <small>{relationship.sourceCompanyName} からの確認済み関係</small>
                 </button>
                 <button
                   type="button"
-                  className={`${relationStyles.treeRelation} ${relationSelected ? relationStyles.treeRelationActive : ""}`}
+                  className={`${relationStyles.treeRelation} ${claudeStyles.hierarchyRelation} ${relationSelected ? relationStyles.treeRelationActive : ""}`}
                   onClick={() => onSelectRelation(relationship.relationId)}
                   aria-pressed={relationSelected}
                 >
@@ -124,15 +124,15 @@ export default function GroupHierarchyView({
   };
 
   return (
-    <div className={`${styles.seriesView} ${styles.viewFade}`}>
-      <p className={styles.seriesIntro}><strong>{groupName}</strong>内で確認済みの出資・親会社・支配・持分法関係を、起点から枝をたどるツリーとして表示します。グループ所属そのものは親子関係として扱いません。</p>
+    <div className={`${claudeStyles.view} ${styles.viewFade}`}>
+      <p className={`${styles.seriesIntro} ${claudeStyles.hierarchyIntro}`}><strong>{groupName}</strong>内の出資・親会社・支配・持分法関係だけを資本ツリーとして表示します。グループ所属は親子関係に含めません。</p>
       <div className={relationStyles.treeForest}>
         {treeModel.rootIds.map((rootId, treeIndex) => {
           const root = companyById.get(rootId);
           if (!root) return null;
           return (
-            <section key={`${rootId}:${treeIndex}`} className={relationStyles.treeSection}>
-              <button type="button" className={relationStyles.treeRoot} onClick={() => onSelectCompany(root.id)} aria-pressed={selectedCompanyId === root.id}>
+            <section key={`${rootId}:${treeIndex}`} className={`${relationStyles.treeSection} ${claudeStyles.hierarchySection}`}>
+              <button type="button" className={`${relationStyles.treeRoot} ${claudeStyles.hierarchyRoot}`} onClick={() => onSelectCompany(root.id)} aria-pressed={selectedCompanyId === root.id}>
                 <span>ROOT</span>
                 <strong>{root.name}</strong>
                 <small>確認済み資本・支配構造の起点</small>

--- a/app/premium/company-network/views/GroupTableView.tsx
+++ b/app/premium/company-network/views/GroupTableView.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import styles from "../CompanyNetwork.module.css";
 import functionStyles from "../FunctionViews.module.css";
+import claudeStyles from "../ClaudeUi.module.css";
 import { formatAsOf, relationLabel } from "../presentation";
 import type {
   CompanyFunctionLink,
@@ -117,8 +118,34 @@ export default function GroupTableView({
     [focusCompanyId, normalized, relationships],
   );
 
+  const companyRows = useMemo(() => visibleMemberships.map((membership) => {
+    const company = companyById.get(membership.companyId);
+    const companyRelations = relationshipsByCompany.get(membership.companyId) ?? [];
+    const companyFunctions = [...(functionsByCompany.get(membership.companyId) ?? [])]
+      .sort((a, b) => {
+        if (a.role === "core" && b.role !== "core") return -1;
+        if (a.role !== "core" && b.role === "core") return 1;
+        return a.functionName.localeCompare(b.functionName, "ja");
+      });
+    const relationSummary = companyRelations.length === 0
+      ? "企業間関係は未登録"
+      : companyRelations.slice(0, 2).map((relationship) => relationSentence(relationship, membership.companyId)).join(" / ") + (companyRelations.length > 2 ? ` ほか${companyRelations.length - 2}件` : "");
+    const functionSummary = companyFunctions.length === 0
+      ? "機能未分類"
+      : companyFunctions.map((link) => `${link.role === "core" ? "●" : "○"}${link.functionName}`).join(" / ");
+    const latestFunctionAsOf = companyFunctions.map((link) => link.asOf).filter((value): value is string => Boolean(value)).sort().at(-1) ?? null;
+    return {
+      membership,
+      company,
+      relationSummary,
+      functionSummary,
+      asOf: latestFunctionAsOf ?? membership.sourceAsOf,
+      selected: selection?.kind === "company" && selection.id === membership.companyId,
+    };
+  }), [companyById, functionsByCompany, relationshipsByCompany, selection, visibleMemberships]);
+
   return (
-    <div className={styles.viewFade}>
+    <div className={`${claudeStyles.view} ${styles.viewFade}`}>
       <div className={styles.viewTools}>
         <div className={styles.hopControl} aria-label="表の内容">
           <button type="button" className={mode === "companies" ? styles.toggleOn : styles.toggle} onClick={() => setMode("companies")}>企業一覧</button>
@@ -129,75 +156,92 @@ export default function GroupTableView({
 
       {mode === "companies" ? (
         visibleMemberships.length === 0 ? <p className={styles.empty}>条件に一致する所属企業がありません。</p> : (
-          <div className={styles.tableScroll}>
-            <table className={styles.table} style={{ minWidth: 900 }}>
-              <caption>所属 {visibleMemberships.length}社。各社が何を担うか、資本関係、根拠を同じ行で確認できます。</caption>
-              <thead>
-                <tr>
-                  <th>企業</th>
-                  <th>上場</th>
-                  <th>主な機能・事業</th>
-                  <th>グループ内の主な関係</th>
-                  <th>基準日</th>
-                  <th>根拠</th>
-                </tr>
-              </thead>
-              <tbody>
-                {visibleMemberships.map((membership) => {
-                  const company = companyById.get(membership.companyId);
-                  const companyRelations = relationshipsByCompany.get(membership.companyId) ?? [];
-                  const companyFunctions = [...(functionsByCompany.get(membership.companyId) ?? [])]
-                    .sort((a, b) => {
-                      if (a.role === "core" && b.role !== "core") return -1;
-                      if (a.role !== "core" && b.role === "core") return 1;
-                      return a.functionName.localeCompare(b.functionName, "ja");
-                    });
-                  const selected = selection?.kind === "company" && selection.id === membership.companyId;
-                  const relationSummary = companyRelations.length === 0
-                    ? "企業間関係は未登録"
-                    : companyRelations.slice(0, 2).map((relationship) => relationSentence(relationship, membership.companyId)).join(" / ") + (companyRelations.length > 2 ? ` ほか${companyRelations.length - 2}件` : "");
-                  const functionSummary = companyFunctions.length === 0
-                    ? "機能未分類"
-                    : companyFunctions.map((link) => `${link.role === "core" ? "●" : "○"}${link.functionName}`).join(" / ");
-                  const latestFunctionAsOf = companyFunctions.map((link) => link.asOf).filter((value): value is string => Boolean(value)).sort().at(-1) ?? null;
-                  return (
-                    <tr key={membership.membershipId} className={selected || focusCompanyId === membership.companyId ? styles.tableRowSelected : undefined} onClick={() => onSelectCompany(membership.companyId)}>
-                      <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(membership.companyId); }}>{membership.companyName}</button></td>
-                      <td>{listingLabel(company)}</td>
-                      <td className={functionStyles.tableFunction}>{functionSummary}</td>
-                      <td className={styles.tableRelation}>{relationSummary}</td>
-                      <td>{formatAsOf(latestFunctionAsOf ?? membership.sourceAsOf)}</td>
+          <>
+            <div className={claudeStyles.mobileList} aria-label="所属企業一覧">
+              {companyRows.map((row) => (
+                <button
+                  key={row.membership.membershipId}
+                  type="button"
+                  className={claudeStyles.mobileCard}
+                  onClick={() => onSelectCompany(row.membership.companyId)}
+                >
+                  <span className={claudeStyles.mobileCardHead}>
+                    <strong>{row.membership.companyName}</strong>
+                    <span>{listingLabel(row.company)}</span>
+                  </span>
+                  <span className={claudeStyles.mobileCardBody}>{row.functionSummary}</span>
+                  <span className={claudeStyles.mobileCardSub}>{row.relationSummary}</span>
+                </button>
+              ))}
+            </div>
+
+            <div className={`${styles.tableScroll} ${claudeStyles.desktopTable}`}>
+              <table className={styles.table} style={{ minWidth: 820 }}>
+                <caption>所属 {visibleMemberships.length}社。機能・資本関係・根拠を同じ行で確認できます。</caption>
+                <thead>
+                  <tr>
+                    <th>企業</th>
+                    <th>上場</th>
+                    <th>主な機能・事業</th>
+                    <th>グループ内の主な関係</th>
+                    <th>基準日</th>
+                    <th>根拠</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {companyRows.map((row) => (
+                    <tr key={row.membership.membershipId} className={row.selected || focusCompanyId === row.membership.companyId ? styles.tableRowSelected : undefined} onClick={() => onSelectCompany(row.membership.companyId)}>
+                      <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(row.membership.companyId); }}>{row.membership.companyName}</button></td>
+                      <td>{listingLabel(row.company)}</td>
+                      <td className={functionStyles.tableFunction}>{row.functionSummary}</td>
+                      <td className={styles.tableRelation}>{row.relationSummary}</td>
+                      <td>{formatAsOf(row.asOf)}</td>
                       <td className={styles.tableSource}>
-                        {membership.sourceUrl ? <a className={styles.sourceLink} href={membership.sourceUrl} target="_blank" rel="noreferrer">グループ根拠</a> : membership.sourceTitle ?? "—"}
+                        {row.membership.sourceUrl ? <a className={styles.sourceLink} href={row.membership.sourceUrl} target="_blank" rel="noreferrer">グループ根拠</a> : row.membership.sourceTitle ?? "—"}
                       </td>
                     </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         )
       ) : visibleRelationships.length === 0 ? (
         <p className={styles.empty}>{group.name}内の確認済み企業間関係は現在登録されていません。所属企業データとは別レイヤーです。</p>
       ) : (
-        <div className={styles.tableScroll}>
-          <table className={styles.table} style={{ minWidth: 760 }}>
-            <caption>{visibleRelationships.length}件の企業間関係を表示</caption>
-            <thead><tr><th>起点企業</th><th>関係</th><th>相手企業</th><th>比率</th><th>基準日</th><th>根拠</th></tr></thead>
-            <tbody>
-              {visibleRelationships.map((relationship) => (
-                <tr key={relationship.relationId} className={selectedRelationId === relationship.relationId ? styles.tableRowSelected : undefined} onClick={() => onSelectRelation(relationship.relationId)}>
-                  <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.sourceCompanyId); }}>{relationship.sourceCompanyName}</button></td>
-                  <td className={styles.tableRelation}>{relationLabel(relationship.relationType, null)}</td>
-                  <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.targetCompanyId); }}>{relationship.targetCompanyName}</button></td>
-                  <td>{relationship.ownershipPct === null ? "—" : `${relationship.ownershipPct}%`}</td>
-                  <td>{formatAsOf(relationship.sourceAsOf)}</td>
-                  <td className={styles.tableSource}>{relationship.sourceUrl ? <a className={styles.sourceLink} href={relationship.sourceUrl} target="_blank" rel="noreferrer">公式根拠</a> : relationship.sourceTitle ?? "—"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <>
+          <div className={claudeStyles.mobileList} aria-label="企業間関係一覧">
+            {visibleRelationships.map((relationship) => (
+              <button key={relationship.relationId} type="button" className={claudeStyles.mobileCard} onClick={() => onSelectRelation(relationship.relationId)}>
+                <span className={claudeStyles.mobileCardHead}>
+                  <strong>{relationship.sourceCompanyName}</strong>
+                  <span>{relationship.ownershipPct === null ? relationLabel(relationship.relationType, null) : `${relationship.ownershipPct}%`}</span>
+                </span>
+                <span className={claudeStyles.mobileCardBody}>→ {relationship.targetCompanyName}</span>
+                <span className={claudeStyles.mobileCardSub}>{relationLabel(relationship.relationType, relationship.ownershipPct)} · {formatAsOf(relationship.sourceAsOf)}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className={`${styles.tableScroll} ${claudeStyles.desktopTable}`}>
+            <table className={styles.table} style={{ minWidth: 700 }}>
+              <caption>{visibleRelationships.length}件の企業間関係を表示</caption>
+              <thead><tr><th>起点企業</th><th>関係</th><th>相手企業</th><th>比率</th><th>基準日</th><th>根拠</th></tr></thead>
+              <tbody>
+                {visibleRelationships.map((relationship) => (
+                  <tr key={relationship.relationId} className={selectedRelationId === relationship.relationId ? styles.tableRowSelected : undefined} onClick={() => onSelectRelation(relationship.relationId)}>
+                    <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.sourceCompanyId); }}>{relationship.sourceCompanyName}</button></td>
+                    <td className={styles.tableRelation}>{relationLabel(relationship.relationType, null)}</td>
+                    <td><button type="button" className={styles.tableCompanyButton} onClick={(event) => { event.stopPropagation(); onSelectCompany(relationship.targetCompanyId); }}>{relationship.targetCompanyName}</button></td>
+                    <td>{relationship.ownershipPct === null ? "—" : `${relationship.ownershipPct}%`}</td>
+                    <td>{formatAsOf(relationship.sourceAsOf)}</td>
+                    <td className={styles.tableSource}>{relationship.sourceUrl ? <a className={styles.sourceLink} href={relationship.sourceUrl} target="_blank" rel="noreferrer">公式根拠</a> : relationship.sourceTitle ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </div>
   );

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { usePanZoom } from "../../industry-map/use-pan-zoom";
 import styles from "../CompanyNetwork.module.css";
 import relationStyles from "../RelationshipViews.module.css";
+import claudeStyles from "../ClaudeUi.module.css";
 import { seedSimNodes, simExtent, stepForce, type SimLink, type SimNode, type VisualNode } from "../graph-layout";
 import { buildSelectedNeighbourIds, groupGraphNodeId, selectedGraphNodeId } from "../node-selection";
 import { CATEGORY_COLOR, groupTypeLabel, relationLabel } from "../presentation";
@@ -16,10 +17,10 @@ import type {
 
 const TOTAL_STEPS = 300;
 const STEPS_PER_FRAME = 3;
-const VIEWBOX_HALF = 500;
-const LABEL_PADDING = 120;
+const FULL_VIEWBOX_HALF = 500;
+const COMPACT_VIEWBOX_HALF = 320;
 const SEED_SPREAD = 270;
-const COMPACT_SEED_SPREAD = 170;
+const COMPACT_SEED_SPREAD = 150;
 
 function truncate(value: string, max = 16) {
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;
@@ -117,8 +118,11 @@ export default function NetworkView({
 
   const nodes = frame?.source === seeded ? frame.nodes : seeded;
   const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
-  const fit = (VIEWBOX_HALF - LABEL_PADDING) / simExtent(nodes, relationsOnly ? 135 : 240);
-  const size = VIEWBOX_HALF * 2;
+  const viewBoxHalf = relationsOnly ? COMPACT_VIEWBOX_HALF : FULL_VIEWBOX_HALF;
+  const labelPadding = relationsOnly ? 72 : 120;
+  const minimumExtent = relationsOnly ? 105 : 240;
+  const fit = (viewBoxHalf - labelPadding) / simExtent(nodes, minimumExtent);
+  const size = viewBoxHalf * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
   const selectedNodeId = selectedGraphNodeId(graphSelection);
   const selectedNeighbours = useMemo(
@@ -127,22 +131,31 @@ export default function NetworkView({
   );
 
   return (
-    <div className={styles.viewFade}>
+    <div className={`${claudeStyles.view} ${styles.viewFade}`}>
       <div className={styles.viewTools}>
         <span>{title}</span>
         <span className={relationStyles.relationMeta}>{visibleCompanies.length}社 · {relationships.length}関係</span>
         <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button>
       </div>
       {relationsOnly ? (
-        <p className={relationStyles.relationIntro}>企業間relationが確認できている会社だけをグラフ本体に表示しています。所属しているだけの会社は下の「関係未登録」に分け、線の意味を読みやすくしています。</p>
+        <p className={claudeStyles.networkIntro}>確認済みの企業間relationだけを主図に表示。所属のみの企業は下へ分離しています。</p>
       ) : null}
-      <div className={`${styles.svgWrap} ${relationsOnly ? relationStyles.compactGraph : ""}`}>
+      <div className={`${styles.svgWrap} ${relationsOnly ? relationStyles.compactGraph : ""} ${relationsOnly ? claudeStyles.networkCanvas : ""}`}>
         <div className={styles.zoomControls}>
           <button type="button" onClick={panZoom.zoomIn} aria-label="拡大">＋</button>
           <button type="button" onClick={panZoom.zoomOut} aria-label="縮小">−</button>
           <button type="button" onClick={panZoom.reset} disabled={!panZoom.canReset}>戻す</button>
         </div>
-        <svg ref={svgRef} className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`} style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }} viewBox={`${-VIEWBOX_HALF} ${-VIEWBOX_HALF} ${size} ${size}`} role="img" aria-label="企業関係ネットワーク" onPointerDown={panZoom.onPointerDown} onDoubleClick={panZoom.onDoubleClick}>
+        <svg
+          ref={svgRef}
+          className={`${styles.svg} ${relationsOnly ? claudeStyles.networkSvg : ""} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
+          style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
+          viewBox={`${-viewBoxHalf} ${-viewBoxHalf} ${size} ${size}`}
+          role="img"
+          aria-label="企業関係ネットワーク"
+          onPointerDown={panZoom.onPointerDown}
+          onDoubleClick={panZoom.onDoubleClick}
+        >
           <defs><marker id="company-relation-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="5" markerHeight="5" orient="auto-start-reverse"><path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" /></marker></defs>
           <g transform={panZoom.transform}>
             {relationships.map((relationship) => {
@@ -153,7 +166,7 @@ export default function NetworkView({
               const focused = selectedNeighbours === null || (selectedNeighbours.has(relationship.sourceCompanyId) && selectedNeighbours.has(relationship.targetCompanyId));
               return <g key={relationship.relationId}>
                 <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.6 : focused ? 2.2 : 1.2} strokeOpacity={selected ? 1 : focused ? 0.9 : 0.22} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
-                {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - 9} textAnchor="middle" className={styles.svgEdgeLabel}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
+                {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - (relationsOnly ? 13 : 9)} textAnchor="middle" className={styles.svgEdgeLabel} style={relationsOnly ? { fontSize: 12 } : undefined}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
               </g>;
             })}
             {memberships.map((membership) => {
@@ -173,7 +186,7 @@ export default function NetworkView({
               const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
               const neighbourDimmed = selectedNeighbours !== null && !selectedNeighbours.has(node.id);
               const dimmed = queryDimmed || neighbourDimmed;
-              const baseRadius = relationsOnly ? 10 : 8;
+              const baseRadius = relationsOnly ? 14 : 8;
               const radius = node.kind === "group" ? (selected ? 11 : 9) : center ? 11 : selected ? baseRadius + 2 : baseRadius;
               const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
@@ -199,7 +212,7 @@ export default function NetworkView({
                 <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
                 {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke={stroke} strokeWidth={2} /> : null}
                 <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected || center ? 3 : 2} />
-                <text className={styles.svgLabel} x={radius + 7} dominantBaseline="middle">{truncate(node.label)}</text>
+                <text className={styles.svgLabel} x={radius + 7} dominantBaseline="middle" style={relationsOnly ? { fontSize: 14 } : undefined}>{truncate(node.label)}</text>
               </g>;
             })}
           </g>


### PR DESCRIPTION
Closes #533

## 変更概要
- 企業関係画面全体をClaude Code版の情報密度・階層表現へ寄せる
- 構成: 大型カード群を廃止し、`グループ → 大分類 → 機能領域 → 企業` の折りたたみtaxonomy treeへ変更
- 関係: relation参加企業だけを主図にし、少数ノード時のviewBox/radius/fontを自動拡大
- 系列: 資本ツリーの大型ROOT/カード表現を抑え、高密度な枝表示へ変更
- 機能表: 凡例・セル・会社見出しを圧縮し、Coverage Matrixの一覧性を改善
- 表: desktop tableは維持しつつ、モバイルでは横長表を隠して読みやすい縦カードへ切替
- toolbar/tab stripもroute-wide CSSで高さ・余白を圧縮

## データ
- schema変更なし
- taxonomy/relationの意味変更なし
- #532で指摘されたToyota relation networkの豆粒表示もこのPRで吸収

## 確認予定
- lint
- test
- build
- Vercel Preview Ready
- mobile UATはマージ後スクショで最終確認