### PR TITLE
feat(company-network): 関係タブに事業・機能の放射マップを追加

### DIFF
--- a/app/premium/company-network/CompanyNetworkClient.tsx
+++ b/app/premium/company-network/CompanyNetworkClient.tsx
@@ -20,6 +20,7 @@ import GroupTableView from "./views/GroupTableView";
 import HierarchyView from "./views/HierarchyView";
 import NetworkView from "./views/NetworkView";
 import RadialView from "./views/RadialView";
+import RelationshipModesView from "./views/RelationshipModesView";
 import TableView from "./views/TableView";
 
 const ALL_CATEGORIES: readonly RelationCategory[] = ["capital", "control", "historical"];
@@ -181,7 +182,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
             <h1 className={styles.heroTitle}>企業グループマップ</h1>
             <p className={styles.heroLead}>所属企業を並べるだけでなく、「何を担う会社か」「誰が誰を保有するか」「どこに機能の厚みがあるか」を同じ事実レイヤーから読みます。</p>
           </div>
-          <span className={styles.versionBadge}>company-network v6</span>
+          <span className={styles.versionBadge}>company-network v7</span>
         </div>
         <div className={styles.statRow}>
           <div className={styles.stat}><span>企業グループ</span><strong>{groups.length}</strong><small>件</small></div>
@@ -251,9 +252,19 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
           ) : null}
 
           {scope && view === "network" && scopeMode === "group" && activeGroup ? (
-            relationships.length === 0
-              ? <p className={styles.empty}><strong>{activeGroup.name}</strong>の所属 {memberships.length}社は確認済みですが、グループ内の企業間relationは現在未登録です。</p>
-              : <NetworkView title={`${activeGroup.name}の企業間関係`} companies={scope.companies} relationships={relationships} memberships={[]} centerCompanyId="" selection={groupNetworkSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} />
+            <RelationshipModesView
+              groupName={activeGroup.name}
+              companies={scope.companies}
+              relationships={relationships}
+              functions={functions}
+              selection={groupNetworkSelection}
+              selectedRelationId={selectedRelationId}
+              focusCompanyId={displayBaseCompanyId}
+              query={query}
+              onSelectCompany={selectCompany}
+              onSelectGroup={selectGroup}
+              onSelectRelation={setSelectedRelationId}
+            />
           ) : null}
           {scope && view === "network" && scopeMode === "company" ? <NetworkView companies={scope.companies} relationships={relationships} memberships={memberships} centerCompanyId={centerCompanyId} selection={activeSelection} selectedRelationId={selectedRelationId} query={query} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} /> : null}
 
@@ -273,7 +284,7 @@ export default function CompanyNetworkClient({ result }: { result: CompanyNetwor
         <DetailPanel groups={groups} companies={scope?.companies ?? []} selection={activeSelection} centerCompanyId={scopeMode === "company" ? centerCompanyId : ""} relationships={relationships} memberships={memberships} functions={functions} selectedRelation={selectedRelation} onSelectCompany={selectCompany} onSelectGroup={selectGroup} onSelectRelation={setSelectedRelationId} onMakeCenter={changeCenter} />
       </div>
 
-      <p className={styles.note}>構成＝事業・機能の役割分担、関係＝企業間relation、系列＝資本・支配構造、機能表＝企業×機能の厚み、表＝根拠付き一覧です。</p>
+      <p className={styles.note}>構成＝事業・機能の階層、関係＝資本relationと事業・機能の放射マップ、系列＝資本・支配構造、機能表＝企業×機能の厚み、表＝根拠付き一覧です。</p>
     </main>
   );
 }

--- a/app/premium/company-network/views/FunctionRelationRadialView.tsx
+++ b/app/premium/company-network/views/FunctionRelationRadialView.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { buildMapContext, selectActiveIds } from "../../industry-map/context";
+import type {
+  IndustryCompanyLink,
+  IndustryDomain,
+  IndustryEdge,
+  IndustryNode,
+  TaxonomyKind,
+} from "../../industry-map/types";
+import IndustryRadialView from "../../industry-map/views/RadialView";
+import styles from "../CompanyNetwork.module.css";
+import type {
+  CompanyFunctionLink,
+  CompanyNetworkCompany,
+  CompanyNetworkNodeSelection,
+} from "../types";
+
+type Props = {
+  groupName: string;
+  companies: CompanyNetworkCompany[];
+  functions: CompanyFunctionLink[];
+  selection: CompanyNetworkNodeSelection | null;
+  focusCompanyId: string;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+};
+
+const ALL_KINDS = new Set<TaxonomyKind>([
+  "classification",
+  "product_segment",
+  "technology",
+]);
+
+function presentationCompanyId(link: CompanyFunctionLink) {
+  // 同一企業が複数機能を担う場合も、各機能クラスターに1つずつ表示する。
+  return `company-function:${link.linkId}`;
+}
+
+function functionNodeId(link: CompanyFunctionLink) {
+  return `function:${link.nodeId}`;
+}
+
+function classificationNodeId(link: CompanyFunctionLink) {
+  return `classification:${link.classificationId ?? link.classificationSlug ?? "other"}`;
+}
+
+function companyLinkForRadial(
+  link: CompanyFunctionLink,
+  company: CompanyNetworkCompany,
+  nodeId: string,
+): IndustryCompanyLink {
+  return {
+    linkId: `radial:${link.linkId}`,
+    companyId: company.id,
+    companyName: company.name,
+    companySlug: company.id,
+    companyStatus: company.status,
+    countryCode: company.countryCode,
+    listingStatus: company.listingStatus,
+    nodeId,
+    strategicRole: link.role === "core" ? "core" : "supporting",
+    controlType: "unknown",
+    confidence: link.confidence,
+    sourceType: link.sourceType ?? "company_function",
+    note: link.note,
+    asOf: link.asOf,
+    stockId: null,
+    stockCode: company.ticker ?? null,
+    stockName: company.name,
+  };
+}
+
+export default function FunctionRelationRadialView({
+  groupName,
+  companies,
+  functions,
+  selection,
+  focusCompanyId,
+  query,
+  onSelectCompany,
+}: Props) {
+  const companyById = useMemo(
+    () => new Map(companies.map((company) => [company.id, company])),
+    [companies],
+  );
+
+  const adapted = useMemo(() => {
+    const nodes = new Map<string, IndustryNode>();
+    const edges = new Map<string, IndustryEdge>();
+    const companyLinks: IndustryCompanyLink[] = [];
+    const presentationToCompany = new Map<string, string>();
+    const presentationsByCompany = new Map<string, string[]>();
+    const rootIds = new Set<string>();
+
+    for (const link of functions) {
+      const company = companyById.get(link.companyId);
+      if (!company) continue;
+
+      const classId = classificationNodeId(link);
+      const fnId = functionNodeId(link);
+      const companyNodeId = presentationCompanyId(link);
+      rootIds.add(classId);
+
+      if (!nodes.has(classId)) {
+        nodes.set(classId, {
+          id: classId,
+          domain: "company-functions",
+          kind: "classification",
+          slug: link.classificationSlug ?? classId,
+          displayName: link.classificationName ?? "その他",
+          description: `${groupName}の事業・機能大分類`,
+          status: "active",
+          layer: "function_class",
+        });
+      }
+
+      if (!nodes.has(fnId)) {
+        nodes.set(fnId, {
+          id: fnId,
+          domain: "company-functions",
+          kind: "product_segment",
+          slug: link.functionSlug,
+          displayName: link.functionName,
+          description: `${groupName}の機能領域`,
+          status: "active",
+          layer: "function",
+        });
+      }
+
+      nodes.set(companyNodeId, {
+        id: companyNodeId,
+        domain: "company-functions",
+        kind: "technology",
+        slug: company.id,
+        displayName: company.name,
+        description: `${link.role === "core" ? "主要機能" : "追加機能"}: ${link.functionName}`,
+        status: "active",
+        layer: "company",
+      });
+
+      const classEdgeId = `${classId}->${fnId}`;
+      if (!edges.has(classEdgeId)) {
+        edges.set(classEdgeId, {
+          id: classEdgeId,
+          domain: "company-functions",
+          sourceId: classId,
+          targetId: fnId,
+          relationType: "contains",
+          note: "企業グループの事業・機能taxonomy",
+        });
+      }
+
+      const companyEdgeId = `${fnId}->${companyNodeId}`;
+      edges.set(companyEdgeId, {
+        id: companyEdgeId,
+        domain: "company-functions",
+        sourceId: fnId,
+        targetId: companyNodeId,
+        relationType: "contains",
+        note: link.role === "core" ? "主要機能" : "追加機能",
+      });
+
+      presentationToCompany.set(companyNodeId, company.id);
+      presentationsByCompany.set(company.id, [
+        ...(presentationsByCompany.get(company.id) ?? []),
+        companyNodeId,
+      ]);
+      companyLinks.push(companyLinkForRadial(link, company, companyNodeId));
+    }
+
+    const domain: IndustryDomain = {
+      domain: `company-functions-${groupName}`,
+      label: `${groupName} 事業・機能`,
+      rootIds: [...rootIds],
+      nodes: [...nodes.values()],
+      edges: [...edges.values()],
+      companyLinks,
+      themeLinks: [],
+    };
+
+    return {
+      context: buildMapContext(domain, []),
+      presentationToCompany,
+      presentationsByCompany,
+    };
+  }, [companyById, functions, groupName]);
+
+  const externallySelectedCompanyId =
+    selection?.kind === "company" ? selection.id : focusCompanyId;
+  const firstSelectedPresentation = externallySelectedCompanyId
+    ? adapted.presentationsByCompany.get(externallySelectedCompanyId)?.[0] ?? null
+    : null;
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(firstSelectedPresentation);
+
+  useEffect(() => {
+    setSelectedNodeId(firstSelectedPresentation);
+  }, [firstSelectedPresentation]);
+
+  const activeIds = useMemo(() => {
+    const base = selectActiveIds(adapted.context, ALL_KINDS, query);
+    if (!focusCompanyId || query.trim()) return base;
+
+    const focused = new Set<string>();
+    for (const nodeId of adapted.presentationsByCompany.get(focusCompanyId) ?? []) {
+      focused.add(nodeId);
+      let parent = adapted.context.parentOf.get(nodeId);
+      while (parent) {
+        focused.add(parent);
+        parent = adapted.context.parentOf.get(parent);
+      }
+    }
+    return focused.size > 0 ? focused : base;
+  }, [adapted, focusCompanyId, query]);
+
+  if (functions.length === 0 || adapted.context.domain.nodes.length === 0) {
+    return (
+      <p className={styles.empty}>
+        <strong>{groupName}</strong>には事業・機能taxonomyがまだ登録されていません。
+      </p>
+    );
+  }
+
+  return (
+    <div className={styles.viewFade}>
+      <div className={styles.viewTools}>
+        <span>{groupName}の事業・機能関係</span>
+        <span>{adapted.context.domain.rootIds.length}分類 · {functions.length}機能リンク</span>
+      </div>
+      <p className={styles.hint}>
+        Claude Code版の放射ビューと同じ描画・配置・pan/zoomを使い、大分類 → 機能領域 → 企業を複数クラスターで表示しています。同じ企業が複数機能を担う場合は複数箇所に現れます。
+      </p>
+      <IndustryRadialView
+        context={adapted.context}
+        activeIds={activeIds}
+        selectedId={selectedNodeId}
+        onSelect={(nodeId) => {
+          setSelectedNodeId(nodeId);
+          const companyId = adapted.presentationToCompany.get(nodeId);
+          if (companyId) onSelectCompany(companyId);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/premium/company-network/views/RelationshipModesView.tsx
+++ b/app/premium/company-network/views/RelationshipModesView.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import styles from "../CompanyNetwork.module.css";
+import type {
+  CompanyFunctionLink,
+  CompanyNetworkCompany,
+  CompanyNetworkNodeSelection,
+  CompanyRelationship,
+} from "../types";
+import FunctionRelationRadialView from "./FunctionRelationRadialView";
+import NetworkView from "./NetworkView";
+
+type RelationMode = "capital" | "function";
+
+type Props = {
+  groupName: string;
+  companies: CompanyNetworkCompany[];
+  relationships: CompanyRelationship[];
+  functions: CompanyFunctionLink[];
+  selection: CompanyNetworkNodeSelection | null;
+  selectedRelationId: string | null;
+  focusCompanyId: string;
+  query: string;
+  onSelectCompany: (companyId: string) => void;
+  onSelectGroup: (groupId: string) => void;
+  onSelectRelation: (relationId: string | null) => void;
+};
+
+export default function RelationshipModesView({
+  groupName,
+  companies,
+  relationships,
+  functions,
+  selection,
+  selectedRelationId,
+  focusCompanyId,
+  query,
+  onSelectCompany,
+  onSelectGroup,
+  onSelectRelation,
+}: Props) {
+  const [mode, setMode] = useState<RelationMode>("capital");
+
+  return (
+    <div className={styles.viewFade}>
+      <div
+        className={styles.filterRow}
+        role="tablist"
+        aria-label="関係の種類"
+        style={{ marginBottom: 8 }}
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === "capital"}
+          className={`${styles.toggle} ${mode === "capital" ? styles.toggleOn : ""}`}
+          onClick={() => setMode("capital")}
+        >
+          資本関係
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === "function"}
+          className={`${styles.toggle} ${mode === "function" ? styles.toggleOn : ""}`}
+          onClick={() => setMode("function")}
+        >
+          事業・機能
+        </button>
+      </div>
+
+      {mode === "capital" ? (
+        relationships.length === 0 ? (
+          <p className={styles.empty}>
+            <strong>{groupName}</strong>の企業間relationは現在未登録です。事業・機能モードでは登録済みtaxonomyを確認できます。
+          </p>
+        ) : (
+          <NetworkView
+            title={`${groupName}の企業間関係`}
+            companies={companies}
+            relationships={relationships}
+            memberships={[]}
+            centerCompanyId=""
+            selection={selection}
+            selectedRelationId={selectedRelationId}
+            query={query}
+            onSelectCompany={onSelectCompany}
+            onSelectGroup={onSelectGroup}
+            onSelectRelation={onSelectRelation}
+          />
+        )
+      ) : (
+        <FunctionRelationRadialView
+          groupName={groupName}
+          companies={companies}
+          functions={functions}
+          selection={selection}
+          focusCompanyId={focusCompanyId}
+          query={query}
+          onSelectCompany={onSelectCompany}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #535

## 変更概要
- 「関係」タブに `[資本関係] [事業・機能]` の2サブモードを追加
- 資本関係は既存の企業間relation graphを維持
- 事業・機能モードは company-functions taxonomy を `大分類 → 機能領域 → 企業` へadapter変換
- 描画本体は industry-map の Claude Code版 `RadialView` をそのまま再利用
  - `layoutRadial`
  - `buildMapContext`
  - pan / zoom / reset
  - 曲線リンク
  - viewBox fit
  - ラベル方向
  - 選択ハイライト
  - touch操作
- 1社が複数機能を担う場合、機能リンク単位のpresentation nodeを作り複数クラスターに同じ企業名を表示可能
- 表示基点の企業がある場合、その企業の機能経路を強調

## データ
- DB schema変更なし
- taxonomy/relationの意味変更なし
- 新規relation推測なし

## 確認
- lint
- test
- build
- Vercel Preview Ready
- industry-map既存RadialViewの回帰確認