### PR TITLE
refactor(radial): 共通Radial基盤と企業向けpresentationを分離

### DIFF
--- a/app/premium/company-network/views/FunctionRelationRadialView.tsx
+++ b/app/premium/company-network/views/FunctionRelationRadialView.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { buildMapContext, selectActiveIds } from "../../industry-map/context";
-import type {
-  IndustryCompanyLink,
-  IndustryDomain,
-  IndustryEdge,
-  IndustryNode,
-  TaxonomyKind,
-} from "../../industry-map/types";
-import IndustryRadialView from "../../industry-map/views/RadialView";
+import RadialHierarchyCanvas from "../../shared/radial/RadialHierarchyCanvas";
+import type { RadialHierarchyNode } from "../../shared/radial/radial-layout";
 import styles from "../CompanyNetwork.module.css";
+import { compareFunction, compareFunctionClass } from "../function-order";
 import type {
   CompanyFunctionLink,
   CompanyNetworkCompany,
@@ -27,14 +21,9 @@ type Props = {
   onSelectCompany: (companyId: string) => void;
 };
 
-const ALL_KINDS = new Set<TaxonomyKind>([
-  "classification",
-  "product_segment",
-  "technology",
-]);
+const CLASS_TONES = ["#2563eb", "#0f9f8f", "#7c3aed", "#d97706", "#64748b", "#be123c"] as const;
 
 function presentationCompanyId(link: CompanyFunctionLink) {
-  // 同一企業が複数機能を担う場合も、各機能クラスターに1つずつ表示する。
   return `company-function:${link.linkId}`;
 }
 
@@ -46,30 +35,29 @@ function classificationNodeId(link: CompanyFunctionLink) {
   return `classification:${link.classificationId ?? link.classificationSlug ?? "other"}`;
 }
 
-function companyLinkForRadial(
-  link: CompanyFunctionLink,
-  company: CompanyNetworkCompany,
-  nodeId: string,
-): IndustryCompanyLink {
-  return {
-    linkId: `radial:${link.linkId}`,
-    companyId: company.id,
-    companyName: company.name,
-    companySlug: company.id,
-    companyStatus: company.status,
-    countryCode: company.countryCode,
-    listingStatus: company.listingStatus,
-    nodeId,
-    strategicRole: link.role === "core" ? "core" : "supporting",
-    controlType: "unknown",
-    confidence: link.confidence,
-    sourceType: link.sourceType ?? "company_function",
-    note: link.note,
-    asOf: link.asOf,
-    stockId: null,
-    stockCode: company.ticker ?? null,
-    stockName: company.name,
+function collectParentMap(roots: RadialHierarchyNode[]) {
+  const parentOf = new Map<string, string>();
+  const walk = (node: RadialHierarchyNode) => {
+    node.children.forEach((child) => {
+      parentOf.set(child.id, node.id);
+      walk(child);
+    });
   };
+  roots.forEach(walk);
+  return parentOf;
+}
+
+function withAncestors(ids: Iterable<string>, parentOf: Map<string, string>) {
+  const result = new Set<string>();
+  for (const id of ids) {
+    result.add(id);
+    let parent = parentOf.get(id);
+    while (parent && !result.has(parent)) {
+      result.add(parent);
+      parent = parentOf.get(parent);
+    }
+  }
+  return result;
 }
 
 export default function FunctionRelationRadialView({
@@ -87,108 +75,125 @@ export default function FunctionRelationRadialView({
   );
 
   const adapted = useMemo(() => {
-    const nodes = new Map<string, IndustryNode>();
-    const edges = new Map<string, IndustryEdge>();
-    const companyLinks: IndustryCompanyLink[] = [];
+    const byClass = new Map<string, CompanyFunctionLink[]>();
+    functions.forEach((link) => {
+      const key = link.classificationId ?? link.classificationSlug ?? "other";
+      byClass.set(key, [...(byClass.get(key) ?? []), link]);
+    });
+
+    const classGroups = [...byClass.entries()]
+      .map(([key, links]) => ({
+        key,
+        classificationSlug: links[0]?.classificationSlug ?? null,
+        classificationName: links[0]?.classificationName ?? "その他",
+        links,
+      }))
+      .sort(compareFunctionClass);
+
     const presentationToCompany = new Map<string, string>();
     const presentationsByCompany = new Map<string, string[]>();
-    const rootIds = new Set<string>();
 
-    for (const link of functions) {
-      const company = companyById.get(link.companyId);
-      if (!company) continue;
-
-      const classId = classificationNodeId(link);
-      const fnId = functionNodeId(link);
-      const companyNodeId = presentationCompanyId(link);
-      rootIds.add(classId);
-
-      if (!nodes.has(classId)) {
-        nodes.set(classId, {
-          id: classId,
-          domain: "company-functions",
-          kind: "classification",
-          slug: link.classificationSlug ?? classId,
-          displayName: link.classificationName ?? "その他",
-          description: `${groupName}の事業・機能大分類`,
-          status: "active",
-          layer: "function_class",
-        });
-      }
-
-      if (!nodes.has(fnId)) {
-        nodes.set(fnId, {
-          id: fnId,
-          domain: "company-functions",
-          kind: "product_segment",
-          slug: link.functionSlug,
-          displayName: link.functionName,
-          description: `${groupName}の機能領域`,
-          status: "active",
-          layer: "function",
-        });
-      }
-
-      nodes.set(companyNodeId, {
-        id: companyNodeId,
-        domain: "company-functions",
-        kind: "technology",
-        slug: company.id,
-        displayName: company.name,
-        description: `${link.role === "core" ? "主要機能" : "追加機能"}: ${link.functionName}`,
-        status: "active",
-        layer: "company",
+    const roots: RadialHierarchyNode[] = classGroups.map((group, classIndex) => {
+      const tone = CLASS_TONES[classIndex % CLASS_TONES.length];
+      const byFunction = new Map<string, CompanyFunctionLink[]>();
+      group.links.forEach((link) => {
+        byFunction.set(link.nodeId, [...(byFunction.get(link.nodeId) ?? []), link]);
       });
 
-      const classEdgeId = `${classId}->${fnId}`;
-      if (!edges.has(classEdgeId)) {
-        edges.set(classEdgeId, {
-          id: classEdgeId,
-          domain: "company-functions",
-          sourceId: classId,
-          targetId: fnId,
-          relationType: "contains",
-          note: "企業グループの事業・機能taxonomy",
-        });
-      }
+      const functionGroups = [...byFunction.values()]
+        .map((links) => ({
+          functionSlug: links[0].functionSlug,
+          functionName: links[0].functionName,
+          links,
+        }))
+        .sort(compareFunction);
 
-      const companyEdgeId = `${fnId}->${companyNodeId}`;
-      edges.set(companyEdgeId, {
-        id: companyEdgeId,
-        domain: "company-functions",
-        sourceId: fnId,
-        targetId: companyNodeId,
-        relationType: "contains",
-        note: link.role === "core" ? "主要機能" : "追加機能",
-      });
+      return {
+        id: classificationNodeId(group.links[0]),
+        label: group.classificationName,
+        title: `${group.classificationName}（事業・機能の大分類）`,
+        tone,
+        fill: tone,
+        stroke: tone,
+        strokeWidth: 2.4,
+        radius: 14,
+        labelSize: 12,
+        labelWeight: 900,
+        linkColor: tone,
+        linkWidth: 1.7,
+        children: functionGroups.map((fnGroup) => ({
+          id: functionNodeId(fnGroup.links[0]),
+          label: fnGroup.functionName,
+          title: `${fnGroup.functionName}（機能領域）`,
+          tone,
+          fill: "var(--color-bg-card)",
+          stroke: tone,
+          strokeWidth: 2,
+          radius: 8.5,
+          labelSize: 10.5,
+          labelWeight: 850,
+          linkColor: tone,
+          linkWidth: 1.25,
+          children: [...fnGroup.links]
+            .sort((a, b) => {
+              if (a.role === "core" && b.role !== "core") return -1;
+              if (a.role !== "core" && b.role === "core") return 1;
+              return (companyById.get(a.companyId)?.name ?? "").localeCompare(
+                companyById.get(b.companyId)?.name ?? "",
+                "ja",
+              );
+            })
+            .flatMap((link): RadialHierarchyNode[] => {
+              const company = companyById.get(link.companyId);
+              if (!company) return [];
+              const nodeId = presentationCompanyId(link);
+              presentationToCompany.set(nodeId, company.id);
+              presentationsByCompany.set(company.id, [
+                ...(presentationsByCompany.get(company.id) ?? []),
+                nodeId,
+              ]);
+              const core = link.role === "core";
+              return [{
+                id: nodeId,
+                label: company.name,
+                title: `${company.name} — ${core ? "主要機能" : "追加機能"}: ${fnGroup.functionName}`,
+                tone,
+                fill: "var(--color-bg-card)",
+                stroke: core ? tone : "#94a3b8",
+                strokeWidth: core ? 1.6 : 1.15,
+                radius: core ? 5.4 : 4.5,
+                labelSize: 9.4,
+                labelWeight: core ? 800 : 650,
+                linkColor: core ? tone : "#cbd5e1",
+                linkWidth: core ? 1 : 0.8,
+                children: [],
+              }];
+            }),
+        })),
+      };
+    });
 
-      presentationToCompany.set(companyNodeId, company.id);
-      presentationsByCompany.set(company.id, [
-        ...(presentationsByCompany.get(company.id) ?? []),
-        companyNodeId,
-      ]);
-      companyLinks.push(companyLinkForRadial(link, company, companyNodeId));
-    }
-
-    const domain: IndustryDomain = {
-      domain: `company-functions-${groupName}`,
-      label: `${groupName} 事業・機能`,
-      rootIds: [...rootIds],
-      nodes: [...nodes.values()],
-      edges: [...edges.values()],
-      companyLinks,
-      themeLinks: [],
+    const parentOf = collectParentMap(roots);
+    const allIds = new Set<string>();
+    const labelById = new Map<string, string>();
+    const walk = (node: RadialHierarchyNode) => {
+      allIds.add(node.id);
+      labelById.set(node.id, node.label);
+      node.children.forEach(walk);
     };
+    roots.forEach(walk);
 
     return {
-      context: buildMapContext(domain, []),
+      roots,
+      parentOf,
+      allIds,
+      labelById,
       presentationToCompany,
       presentationsByCompany,
     };
-  }, [companyById, functions, groupName]);
+  }, [companyById, functions]);
 
-  const externallySelectedCompanyId =
-    selection?.kind === "company" ? selection.id : focusCompanyId;
+  const externallySelectedCompanyId = selection?.kind === "company" ? selection.id : focusCompanyId;
   const firstSelectedPresentation = externallySelectedCompanyId
     ? adapted.presentationsByCompany.get(externallySelectedCompanyId)?.[0] ?? null
     : null;
@@ -199,22 +204,20 @@ export default function FunctionRelationRadialView({
   }, [firstSelectedPresentation]);
 
   const activeIds = useMemo(() => {
-    const base = selectActiveIds(adapted.context, ALL_KINDS, query);
-    if (!focusCompanyId || query.trim()) return base;
-
-    const focused = new Set<string>();
-    for (const nodeId of adapted.presentationsByCompany.get(focusCompanyId) ?? []) {
-      focused.add(nodeId);
-      let parent = adapted.context.parentOf.get(nodeId);
-      while (parent) {
-        focused.add(parent);
-        parent = adapted.context.parentOf.get(parent);
-      }
+    if (focusCompanyId && !query.trim()) {
+      const ids = adapted.presentationsByCompany.get(focusCompanyId) ?? [];
+      return ids.length > 0 ? withAncestors(ids, adapted.parentOf) : adapted.allIds;
     }
-    return focused.size > 0 ? focused : base;
+
+    const needle = query.trim().toLocaleLowerCase("ja");
+    if (!needle) return adapted.allIds;
+    const matches = [...adapted.labelById.entries()]
+      .filter(([, label]) => label.toLocaleLowerCase("ja").includes(needle))
+      .map(([id]) => id);
+    return withAncestors(matches, adapted.parentOf);
   }, [adapted, focusCompanyId, query]);
 
-  if (functions.length === 0 || adapted.context.domain.nodes.length === 0) {
+  if (functions.length === 0 || adapted.roots.length === 0) {
     return (
       <p className={styles.empty}>
         <strong>{groupName}</strong>には事業・機能taxonomyがまだ登録されていません。
@@ -226,15 +229,20 @@ export default function FunctionRelationRadialView({
     <div className={styles.viewFade}>
       <div className={styles.viewTools}>
         <span>{groupName}の事業・機能関係</span>
-        <span>{adapted.context.domain.rootIds.length}分類 · {functions.length}機能リンク</span>
+        <span>{adapted.roots.length}分類 · {functions.length}機能リンク</span>
       </div>
       <p className={styles.hint}>
-        Claude Code版の放射ビューと同じ描画・配置・pan/zoomを使い、大分類 → 機能領域 → 企業を複数クラスターで表示しています。同じ企業が複数機能を担う場合は複数箇所に現れます。
+        色の大きな点が大分類、白抜きの中点が機能領域、小さな点が企業です。構成ツリーと同じ分類順・色で、役割のまとまりを空間的に見ます。
       </p>
-      <IndustryRadialView
-        context={adapted.context}
+      <RadialHierarchyCanvas
+        roots={adapted.roots}
         activeIds={activeIds}
         selectedId={selectedNodeId}
+        resetKey={`${groupName}|functional-radial`}
+        ariaLabel={`${groupName}の事業・機能放射マップ`}
+        viewBoxHalf={460}
+        labelPadding={88}
+        layoutOptions={{ radiusStep: 104, satelliteOffsetDelta: -1 }}
         onSelect={(nodeId) => {
           setSelectedNodeId(nodeId);
           const companyId = adapted.presentationToCompany.get(nodeId);

--- a/app/premium/industry-map/views/RadialView.tsx
+++ b/app/premium/industry-map/views/RadialView.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useMemo, useRef } from "react";
-import styles from "../IndustryMap.module.css";
+import { useMemo } from "react";
+import RadialHierarchyCanvas from "../../shared/radial/RadialHierarchyCanvas";
+import type { RadialHierarchyNode } from "../../shared/radial/radial-layout";
 import type { MapContext } from "../context";
-import { layoutRadial } from "../graph-layout";
+import type { TreeNode } from "../graph-layout";
 import { KIND_COLOR, KIND_LABEL } from "../presentation";
-import { usePanZoom } from "../use-pan-zoom";
-import ZoomControls from "./ZoomControls";
 
 type Props = {
   context: MapContext;
@@ -15,161 +14,45 @@ type Props = {
   onSelect: (nodeId: string) => void;
 };
 
-const RADIUS_STEP = 100;
-/**
- * viewBox は常にこの大きさに正規化する。
- * 環の数が domain ごとに違っても、画面上の文字と点の大きさを一定に保つため。
- */
-const VIEWBOX_HALF = 500;
-/** ラベルが viewBox からはみ出さないための余白。 */
-const LABEL_PADDING = 118;
-
-function truncate(text: string, max: number) {
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+function adaptTree(item: TreeNode, context: MapContext): RadialHierarchyNode {
+  const tone = KIND_COLOR[item.node.kind];
+  const companyCount = (context.companyLinksByNode.get(item.node.id) ?? []).length;
+  const radius = item.depth === 0 ? 13 : Math.max(4, 10 - item.depth * 2);
+  return {
+    id: item.node.id,
+    label: item.node.displayName,
+    title: `${item.node.displayName}（${KIND_LABEL[item.node.kind]}）`,
+    tone,
+    fill: companyCount > 0 ? tone : "var(--color-bg-card)",
+    stroke: tone,
+    strokeWidth: 2,
+    radius,
+    labelSize: 11,
+    labelWeight: item.depth === 0 ? 900 : 800,
+    linkColor: "var(--rel-hierarchy)",
+    linkWidth: 1.2,
+    markerColor: item.crossEdges.length > 0 ? "var(--rel-depends)" : null,
+    children: item.children.map((child) => adaptTree(child, context)),
+  };
 }
 
-export default function RadialView({
-  context,
-  activeIds,
-  selectedId,
-  onSelect,
-}: Props) {
-  const svgRef = useRef<SVGSVGElement>(null);
-  const panZoom = usePanZoom(svgRef, context.domain.domain);
-  const layout = useMemo(
-    () => layoutRadial(context.roots, RADIUS_STEP),
-    [context.roots],
+export default function RadialView({ context, activeIds, selectedId, onSelect }: Props) {
+  const roots = useMemo(
+    () => context.roots.map((root) => adaptTree(root, context)),
+    [context],
   );
 
-  // 図の広がりを一定の viewBox へ収める。以降の座標はすべて正規化後の値を使う。
-  const fit = (VIEWBOX_HALF - LABEL_PADDING) / layout.extent;
-  const size = VIEWBOX_HALF * 2;
-  const selectedAncestors = useMemo(() => {
-    const ancestors = new Set<string>();
-    let current = selectedId ? context.parentOf.get(selectedId) : undefined;
-    while (current && !ancestors.has(current)) {
-      ancestors.add(current);
-      current = context.parentOf.get(current);
-    }
-    return ancestors;
-  }, [context.parentOf, selectedId]);
-
   return (
-    <div className={`${styles.svgWrap} ${styles.viewFade}`}>
-      <ZoomControls panZoom={panZoom} />
-      <svg
-        ref={svgRef}
-        className={`${styles.svg} ${panZoom.panning ? styles.svgGrabbing : styles.svgGrab}`}
-        /* 等倍のうちは1本指で画面を縦スクロールでき、拡大後は図の操作に切り替わる。 */
-        style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
-        viewBox={`${-VIEWBOX_HALF} ${-VIEWBOX_HALF} ${size} ${size}`}
-        role="img"
-        aria-label={`${context.domain.label}の放射マップ`}
-        onPointerDown={panZoom.onPointerDown}
-        onDoubleClick={panZoom.onDoubleClick}
-      >
-        <g transform={panZoom.transform}>
-        <g>
-          {layout.links.map((link, index) => {
-            // 親の半径を通る曲線にすると、放射状の枝らしい形になる。
-            const control = {
-              x: Math.cos(link.to.angle) * link.from.radius * fit,
-              y: Math.sin(link.to.angle) * link.from.radius * fit,
-            };
-            const highlighted =
-              selectedId === link.to.id ||
-              selectedId === link.from.id ||
-              selectedAncestors.has(link.to.id);
-            return (
-              <path
-                key={link.id}
-                className={`${styles.svgLink} ${highlighted ? styles.svgLinkActive : ""}`}
-                style={{ animationDelay: `${Math.min(index, 60) * 8}ms` }}
-                d={`M ${link.from.x * fit} ${link.from.y * fit} Q ${control.x} ${control.y} ${
-                  link.to.x * fit
-                } ${link.to.y * fit}`}
-              />
-            );
-          })}
-        </g>
-        <g>
-          {layout.points.map((point, index) => {
-            const active = activeIds.has(point.id);
-            const selected = selectedId === point.id;
-            const radius =
-              point.depth === 0 ? 13 : Math.max(4, 10 - point.depth * 2);
-            const onLeft = Math.cos(point.angle) < 0;
-            const labelOffset = radius + 7;
-            const companyCount = (context.companyLinksByNode.get(point.id) ?? [])
-              .length;
-
-            return (
-              /*
-               * 位置は transform 属性、登場アニメーションは内側の g に分ける。
-               * 同じ要素に両方を書くと CSS の transform が属性を上書きし、
-               * すべてのノードが原点へ寄ってしまう。
-               */
-              <g
-                key={point.id}
-                transform={`translate(${point.x * fit} ${point.y * fit})`}
-                className={active ? undefined : styles.svgNodeDim}
-                onClick={() => {
-                  // ドラッグで図を動かしたときは選択しない。
-                  if (!panZoom.didPan()) onSelect(point.id);
-                }}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    onSelect(point.id);
-                  }
-                }}
-              >
-                <g
-                  className={styles.svgNode}
-                  style={{ animationDelay: `${Math.min(index, 70) * 10}ms` }}
-                >
-                  <title>{`${point.node.displayName}（${KIND_LABEL[point.node.kind]}）`}</title>
-                  {selected ? (
-                    <circle
-                      className={styles.pulse}
-                      r={radius + 8}
-                      fill="none"
-                      stroke={KIND_COLOR[point.node.kind]}
-                      strokeWidth={2}
-                    />
-                  ) : null}
-                  <circle
-                    className={styles.svgNodeShape}
-                    r={radius}
-                    fill={
-                      companyCount > 0
-                        ? KIND_COLOR[point.node.kind]
-                        : "var(--color-bg-card)"
-                    }
-                    stroke={KIND_COLOR[point.node.kind]}
-                    strokeWidth={selected ? 3 : 2}
-                  />
-                  {point.hasCrossEdges ? (
-                    <circle r={2} cy={-radius - 4} fill="var(--rel-depends)" />
-                  ) : null}
-                  <text
-                    className={`${styles.svgLabel} ${point.depth === 0 ? styles.svgLabelStrong : ""}`}
-                    transform={`rotate(${(point.angle * 180) / Math.PI + (onLeft ? 180 : 0)})`}
-                    x={onLeft ? -labelOffset : labelOffset}
-                    textAnchor={onLeft ? "end" : "start"}
-                    dominantBaseline="middle"
-                  >
-                    {truncate(point.node.displayName, 18)}
-                  </text>
-                </g>
-              </g>
-            );
-          })}
-        </g>
-        </g>
-      </svg>
-    </div>
+    <RadialHierarchyCanvas
+      roots={roots}
+      activeIds={activeIds}
+      selectedId={selectedId}
+      onSelect={onSelect}
+      resetKey={context.domain.domain}
+      ariaLabel={`${context.domain.label}の放射マップ`}
+      viewBoxHalf={500}
+      labelPadding={118}
+      layoutOptions={{ radiusStep: 100, satelliteOffsetDelta: 0 }}
+    />
   );
 }

--- a/app/premium/shared/radial/RadialHierarchyCanvas.module.css
+++ b/app/premium/shared/radial/RadialHierarchyCanvas.module.css
@@ -1,0 +1,118 @@
+.wrap {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  min-height: 320px;
+  overflow: hidden;
+  border-radius: 12px;
+  background:
+    radial-gradient(circle at 50% 44%, rgba(37, 84, 255, 0.035), rgba(37, 84, 255, 0) 62%),
+    var(--color-bg-card);
+}
+
+.svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  user-select: none;
+}
+
+.grab { cursor: grab; }
+.grabbing { cursor: grabbing; }
+
+.zoomControls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-bg-card) 90%, transparent);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+}
+
+.zoomButton {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-sub);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.zoomButton:hover:not(:disabled) { background: var(--color-bg-input); }
+.zoomButton:disabled { opacity: 0.28; cursor: default; }
+
+.zoomLevel {
+  min-width: 42px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.link {
+  fill: none;
+  stroke-linecap: round;
+  transition: opacity 140ms ease, stroke-width 140ms ease;
+}
+
+.linkMuted { opacity: 0.28; }
+.linkActive { opacity: 0.95; }
+
+.node {
+  cursor: pointer;
+  transition: opacity 140ms ease;
+}
+
+.nodeDim { opacity: 0.13; }
+
+.node:focus { outline: none; }
+.node:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.label {
+  paint-order: stroke;
+  stroke: var(--color-bg-card);
+  stroke-width: 4px;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.pulse {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: pulse 1.8s ease-out infinite;
+  pointer-events: none;
+}
+
+@keyframes pulse {
+  0% { opacity: 0.65; transform: scale(0.9); }
+  75%, 100% { opacity: 0; transform: scale(1.55); }
+}
+
+@media (max-width: 720px) {
+  .wrap,
+  .svg { min-height: 300px; }
+
+  .zoomControls { top: 6px; right: 6px; }
+  .zoomButton { width: 26px; height: 26px; }
+  .zoomLevel { min-width: 38px; font-size: 9px; }
+}

--- a/app/premium/shared/radial/RadialHierarchyCanvas.tsx
+++ b/app/premium/shared/radial/RadialHierarchyCanvas.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useMemo, useRef } from "react";
+import { MAX_SCALE, MIN_SCALE, usePanZoom } from "../../industry-map/use-pan-zoom";
+import styles from "./RadialHierarchyCanvas.module.css";
+import {
+  layoutRadialHierarchy,
+  type RadialHierarchyNode,
+  type RadialLayoutOptions,
+} from "./radial-layout";
+
+type Props = {
+  roots: RadialHierarchyNode[];
+  activeIds?: Set<string>;
+  selectedId: string | null;
+  onSelect: (nodeId: string) => void;
+  resetKey: unknown;
+  ariaLabel: string;
+  viewBoxHalf?: number;
+  labelPadding?: number;
+  layoutOptions?: RadialLayoutOptions;
+};
+
+function truncate(text: string, max: number) {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+export default function RadialHierarchyCanvas({
+  roots,
+  activeIds,
+  selectedId,
+  onSelect,
+  resetKey,
+  ariaLabel,
+  viewBoxHalf = 500,
+  labelPadding = 118,
+  layoutOptions,
+}: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const panZoom = usePanZoom(svgRef, resetKey);
+  const layout = useMemo(
+    () => layoutRadialHierarchy(roots, layoutOptions),
+    [layoutOptions, roots],
+  );
+  const safeExtent = Math.max(layout.extent, 1);
+  const fit = (viewBoxHalf - labelPadding) / safeExtent;
+  const size = viewBoxHalf * 2;
+
+  const selectedAncestors = useMemo(() => {
+    const ancestors = new Set<string>();
+    let current = selectedId ? layout.parentOf.get(selectedId) : undefined;
+    while (current && !ancestors.has(current)) {
+      ancestors.add(current);
+      current = layout.parentOf.get(current);
+    }
+    return ancestors;
+  }, [layout.parentOf, selectedId]);
+
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.zoomControls} role="group" aria-label="図の拡大縮小">
+        <button
+          type="button"
+          className={styles.zoomButton}
+          onClick={panZoom.zoomIn}
+          disabled={panZoom.viewport.scale >= MAX_SCALE}
+          aria-label="拡大"
+          title="拡大"
+        >
+          ＋
+        </button>
+        <span className={styles.zoomLevel}>{Math.round(panZoom.viewport.scale * 100)}%</span>
+        <button
+          type="button"
+          className={styles.zoomButton}
+          onClick={panZoom.zoomOut}
+          disabled={panZoom.viewport.scale <= MIN_SCALE}
+          aria-label="縮小"
+          title="縮小"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          className={styles.zoomButton}
+          onClick={panZoom.reset}
+          disabled={!panZoom.canReset}
+          aria-label="表示を元に戻す"
+          title="表示を元に戻す"
+        >
+          ⟲
+        </button>
+      </div>
+
+      <svg
+        ref={svgRef}
+        className={`${styles.svg} ${panZoom.panning ? styles.grabbing : styles.grab}`}
+        style={{ touchAction: panZoom.viewport.scale === 1 ? "pan-y" : "none" }}
+        viewBox={`${-viewBoxHalf} ${-viewBoxHalf} ${size} ${size}`}
+        role="img"
+        aria-label={ariaLabel}
+        onPointerDown={panZoom.onPointerDown}
+        onDoubleClick={panZoom.onDoubleClick}
+      >
+        <g transform={panZoom.transform}>
+          {layout.links.map((link) => {
+            const control = {
+              x: Math.cos(link.to.angle) * link.from.radius * fit,
+              y: Math.sin(link.to.angle) * link.from.radius * fit,
+            };
+            const highlighted =
+              selectedId === link.to.id ||
+              selectedId === link.from.id ||
+              selectedAncestors.has(link.to.id);
+            return (
+              <path
+                key={link.id}
+                className={`${styles.link} ${highlighted ? styles.linkActive : styles.linkMuted}`}
+                d={`M ${link.from.x * fit} ${link.from.y * fit} Q ${control.x} ${control.y} ${link.to.x * fit} ${link.to.y * fit}`}
+                stroke={link.color}
+                strokeWidth={highlighted ? Math.max(2, link.width + 0.7) : link.width}
+              />
+            );
+          })}
+
+          {layout.points.map((point) => {
+            const active = activeIds ? activeIds.has(point.id) : true;
+            const selected = selectedId === point.id;
+            const node = point.node;
+            const onLeft = Math.cos(point.angle) < 0;
+            const labelOffset = node.radius + 7;
+            const labelMax = point.depth >= 2 ? 16 : 18;
+
+            return (
+              <g
+                key={point.id}
+                transform={`translate(${point.x * fit} ${point.y * fit})`}
+                className={`${styles.node} ${active ? "" : styles.nodeDim}`}
+                onClick={() => {
+                  if (!panZoom.didPan()) onSelect(point.id);
+                }}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    onSelect(point.id);
+                  }
+                }}
+              >
+                <title>{node.title ?? node.label}</title>
+                {selected ? (
+                  <circle
+                    className={styles.pulse}
+                    r={node.radius + 7}
+                    fill="none"
+                    stroke={node.stroke}
+                    strokeWidth={2}
+                  />
+                ) : null}
+                <circle
+                  r={node.radius}
+                  fill={node.fill}
+                  stroke={node.stroke}
+                  strokeWidth={selected ? Math.max(3, node.strokeWidth ?? 1.5) : node.strokeWidth ?? 1.5}
+                />
+                {node.markerColor ? (
+                  <circle r={2} cy={-node.radius - 4} fill={node.markerColor} />
+                ) : null}
+                <text
+                  className={styles.label}
+                  transform={`rotate(${(point.angle * 180) / Math.PI + (onLeft ? 180 : 0)})`}
+                  x={onLeft ? -labelOffset : labelOffset}
+                  textAnchor={onLeft ? "end" : "start"}
+                  dominantBaseline="middle"
+                  fill={node.labelColor ?? "var(--color-text)"}
+                  fontSize={node.labelSize ?? 11}
+                  fontWeight={node.labelWeight ?? 750}
+                >
+                  {truncate(node.label, labelMax)}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/app/premium/shared/radial/radial-layout.ts
+++ b/app/premium/shared/radial/radial-layout.ts
@@ -1,0 +1,139 @@
+export type RadialHierarchyNode = {
+  id: string;
+  label: string;
+  children: RadialHierarchyNode[];
+  title?: string;
+  tone: string;
+  fill: string;
+  stroke: string;
+  strokeWidth?: number;
+  radius: number;
+  labelSize?: number;
+  labelWeight?: number;
+  labelColor?: string;
+  linkColor?: string;
+  linkWidth?: number;
+  markerColor?: string | null;
+};
+
+export type RadialHierarchyPoint = {
+  id: string;
+  node: RadialHierarchyNode;
+  depth: number;
+  angle: number;
+  radius: number;
+  x: number;
+  y: number;
+};
+
+export type RadialHierarchyLink = {
+  id: string;
+  from: RadialHierarchyPoint;
+  to: RadialHierarchyPoint;
+  color: string;
+  width: number;
+};
+
+export type RadialHierarchyLayout = {
+  points: RadialHierarchyPoint[];
+  links: RadialHierarchyLink[];
+  extent: number;
+  parentOf: Map<string, string>;
+};
+
+function countLeaves(node: RadialHierarchyNode): number {
+  if (node.children.length === 0) return 1;
+  return node.children.reduce((total, child) => total + countLeaves(child), 0);
+}
+
+function maxDepth(node: RadialHierarchyNode, depth = 0): number {
+  if (node.children.length === 0) return depth;
+  return node.children.reduce((deepest, child) => Math.max(deepest, maxDepth(child, depth + 1)), depth);
+}
+
+export type RadialLayoutOptions = {
+  radiusStep?: number;
+  /** Claude Code版は0。企業グループの少数クラスターでは-1で衛星rootを少し内側へ寄せる。 */
+  satelliteOffsetDelta?: number;
+};
+
+/**
+ * Claude Code版の radial tree と同じ思想の汎用レイアウト。
+ * 葉数で角度を配分し、最大の木を中心、残りのrootを衛星クラスターとして外側へ配置する。
+ */
+export function layoutRadialHierarchy(
+  roots: RadialHierarchyNode[],
+  options: RadialLayoutOptions = {},
+): RadialHierarchyLayout {
+  const radiusStep = options.radiusStep ?? 100;
+  const satelliteOffsetDelta = options.satelliteOffsetDelta ?? 0;
+  const points: RadialHierarchyPoint[] = [];
+  const links: RadialHierarchyLink[] = [];
+  const parentOf = new Map<string, string>();
+
+  const totalLeaves = roots.reduce((total, root) => total + countLeaves(root), 0);
+  if (totalLeaves === 0) return { points, links, extent: radiusStep, parentOf };
+
+  const anyHierarchy = roots.some((root) => root.children.length > 0);
+  const mainRoot = anyHierarchy
+    ? roots.reduce((widest, root) => (countLeaves(root) > countLeaves(widest) ? root : widest))
+    : null;
+  const mainOuterRing = mainRoot ? maxDepth(mainRoot) + 1 : 1;
+
+  const place = (
+    item: RadialHierarchyNode,
+    startAngle: number,
+    endAngle: number,
+    treeDepth: number,
+    depthOffset: number,
+    leafRing: number,
+  ): RadialHierarchyPoint => {
+    const angle = (startAngle + endAngle) / 2;
+    const ring = item.children.length === 0 ? leafRing : treeDepth + depthOffset;
+    const radius = ring * radiusStep;
+    const point: RadialHierarchyPoint = {
+      id: item.id,
+      node: item,
+      depth: treeDepth,
+      angle,
+      radius,
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+    };
+    points.push(point);
+
+    const leaves = countLeaves(item);
+    let cursor = startAngle;
+    for (const child of item.children) {
+      const span = ((endAngle - startAngle) * countLeaves(child)) / leaves;
+      const childPoint = place(child, cursor, cursor + span, treeDepth + 1, depthOffset, leafRing);
+      parentOf.set(child.id, item.id);
+      links.push({
+        id: `${point.id}->${childPoint.id}`,
+        from: point,
+        to: childPoint,
+        color: child.linkColor ?? item.linkColor ?? item.tone,
+        width: child.linkWidth ?? item.linkWidth ?? 1.2,
+      });
+      cursor += span;
+    }
+    return point;
+  };
+
+  const fullTurn = Math.PI * 2;
+  let cursor = -Math.PI / 2;
+  for (const root of roots) {
+    const span = (fullTurn * countLeaves(root)) / totalLeaves;
+    const rootDepth = maxDepth(root);
+    const depthOffset = !anyHierarchy
+      ? 1
+      : root === mainRoot
+        ? 0
+        : Math.max(1, mainOuterRing + satelliteOffsetDelta);
+    place(root, cursor, cursor + span, 0, depthOffset, rootDepth + depthOffset);
+    cursor += span;
+  }
+
+  const extent = points.reduce((widest, point) => Math.max(widest, point.radius), radiusStep);
+  return { points, links, extent, parentOf };
+}


### PR DESCRIPTION
Closes #537

## 変更概要
- `app/premium/shared/radial/` に汎用Radial基盤を追加
  - generic hierarchy layout
  - shared SVG canvas
  - shared zoom controls/pan-zoom利用
- Industry MapのRadialViewをshared canvasのadapterへ変更
- Company Networkの事業・機能RadialをIndustry Map型への偽装adapterから分離
- Company Networkでは構成treeと同じ分類順・6色を利用
  - 大分類: 大きい塗りつぶしnode
  - 機能領域: 白地+分類色border
  - 企業: 小さいneutral node（黒ベタ廃止）
  - core/supportingで企業node/枝の強さを差別化
- Toyota等の少数クラスターでは衛星rootを1ring内側へ寄せ、空白を削減
- query / 表示基点 / company selectionは維持

## 解消する問題
- Company側でIndustry専用CSS変数が欠けて黒点になる
- 企業を`technology`として扱う意味の歪み
- company-linkの塗りつぶし規則で企業が視覚的主役になる問題
- Company Network→Industry Map UIへの直接依存

## 非変更
- DB schema / taxonomyデータ変更なし
- 資本関係graph変更なし

## 確認予定
- lint
- test
- build
- Vercel Preview Ready
- Industry Map Radialの回帰確認