### PR TITLE
fix(company-network): 事業・機能Radialの枝角度を適応的に圧縮

### DIFF
--- a/app/premium/company-network/views/FunctionRelationRadialView.tsx
+++ b/app/premium/company-network/views/FunctionRelationRadialView.tsx
@@ -250,7 +250,12 @@ export default function FunctionRelationRadialView({
         ariaLabel={`${groupName}の事業・機能放射マップ`}
         viewBoxHalf={500}
         labelPadding={118}
-        layoutOptions={{ radiusStep: 100, satelliteOffsetDelta: 0 }}
+        layoutOptions={{
+          radiusStep: 100,
+          satelliteOffsetDelta: 0,
+          childFanRatio: 0.78,
+          minLeafArc: 28,
+        }}
         onSelect={(nodeId) => {
           setSelectedNodeId(nodeId);
           const companyId = adapted.presentationToCompany.get(nodeId);

--- a/app/premium/shared/radial/radial-layout.test.ts
+++ b/app/premium/shared/radial/radial-layout.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  layoutRadialHierarchy,
+  type RadialHierarchyNode,
+} from "./radial-layout";
+
+function leaf(id: string): RadialHierarchyNode {
+  return {
+    id,
+    label: id,
+    children: [],
+    tone: "#000",
+    fill: "#fff",
+    stroke: "#000",
+    radius: 4,
+  };
+}
+
+function root(children: RadialHierarchyNode[]): RadialHierarchyNode {
+  return {
+    id: "root",
+    label: "root",
+    children,
+    tone: "#000",
+    fill: "#000",
+    stroke: "#000",
+    radius: 10,
+  };
+}
+
+function pointAngle(layout: ReturnType<typeof layoutRadialHierarchy>, id: string) {
+  const point = layout.points.find((candidate) => candidate.id === id);
+  if (!point) throw new Error(`missing point: ${id}`);
+  return point.angle;
+}
+
+describe("layoutRadialHierarchy adaptive child fan", () => {
+  it("keeps the legacy full fan when childFanRatio is omitted", () => {
+    const layout = layoutRadialHierarchy([root([leaf("a"), leaf("b")])], { radiusStep: 100 });
+    const spread = Math.abs(pointAngle(layout, "b") - pointAngle(layout, "a"));
+    expect(spread).toBeCloseTo(Math.PI, 6);
+  });
+
+  it("tightens sibling angles around the parent when requested", () => {
+    const layout = layoutRadialHierarchy([root([leaf("a"), leaf("b")])], {
+      radiusStep: 100,
+      childFanRatio: 0.5,
+    });
+    const spread = Math.abs(pointAngle(layout, "b") - pointAngle(layout, "a"));
+    expect(spread).toBeCloseTo(Math.PI / 2, 6);
+  });
+
+  it("backs off compression when the minimum leaf arc needs more room", () => {
+    const children = Array.from({ length: 8 }, (_, index) => leaf(`leaf-${index}`));
+    const layout = layoutRadialHierarchy([root(children)], {
+      radiusStep: 100,
+      childFanRatio: 0.5,
+      minLeafArc: 80,
+    });
+    const first = pointAngle(layout, "leaf-0");
+    const last = pointAngle(layout, "leaf-7");
+    const spread = Math.abs(last - first);
+    expect(spread).toBeGreaterThan(Math.PI);
+  });
+});

--- a/app/premium/shared/radial/radial-layout.ts
+++ b/app/premium/shared/radial/radial-layout.ts
@@ -55,11 +55,20 @@ export type RadialLayoutOptions = {
   radiusStep?: number;
   /** Claude Code版は0。企業グループの少数クラスターでは-1で衛星rootを少し内側へ寄せる。 */
   satelliteOffsetDelta?: number;
+  /** 1.0で従来どおり。1未満では各親配下のfanを中心へ寄せる。 */
+  childFanRatio?: number;
+  /** fan圧縮時に各leafへ最低限確保する円周上の距離。layout座標px相当。 */
+  minLeafArc?: number;
 };
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
 
 /**
  * Claude Code版の radial tree と同じ思想の汎用レイアウト。
  * 葉数で角度を配分し、最大の木を中心、残りのrootを衛星クラスターとして外側へ配置する。
+ * childFanRatioを指定した利用側だけ、子fanを中心寄せできる。既定値1.0は従来表示と同一。
  */
 export function layoutRadialHierarchy(
   roots: RadialHierarchyNode[],
@@ -67,6 +76,8 @@ export function layoutRadialHierarchy(
 ): RadialHierarchyLayout {
   const radiusStep = options.radiusStep ?? 100;
   const satelliteOffsetDelta = options.satelliteOffsetDelta ?? 0;
+  const childFanRatio = clamp(options.childFanRatio ?? 1, 0.5, 1);
+  const minLeafArc = Math.max(0, options.minLeafArc ?? 0);
   const points: RadialHierarchyPoint[] = [];
   const links: RadialHierarchyLink[] = [];
   const parentOf = new Map<string, string>();
@@ -103,9 +114,18 @@ export function layoutRadialHierarchy(
     points.push(point);
 
     const leaves = countLeaves(item);
-    let cursor = startAngle;
+    const rawSpan = endAngle - startAngle;
+    const leafRadius = Math.max(radiusStep, leafRing * radiusStep);
+    const requestedSpan = rawSpan * childFanRatio;
+    const minimumSpan = Math.min(rawSpan, leaves * (minLeafArc / leafRadius));
+    const childSpan = item.children.length <= 1
+      ? rawSpan
+      : Math.min(rawSpan, Math.max(requestedSpan, minimumSpan));
+    const childStart = angle - childSpan / 2;
+    let cursor = childStart;
+
     for (const child of item.children) {
-      const span = ((endAngle - startAngle) * countLeaves(child)) / leaves;
+      const span = (childSpan * countLeaves(child)) / leaves;
       const childPoint = place(child, cursor, cursor + span, treeDepth + 1, depthOffset, leafRing);
       parentOf.set(child.id, item.id);
       links.push({


### PR DESCRIPTION
Closes #543

## 変更概要
- shared radial layoutに`childFanRatio`と`minLeafArc`を追加
- 既定値は`childFanRatio=1.0`のためIndustry Map/Claude版は従来表示を維持
- Company Networkの`関係 > 事業・機能`のみ`childFanRatio=0.78`を指定
- `minLeafArc=28`を下限にして、企業数が多い枝は自動的に圧縮を弱める
- root同士のsector配分は変更せず、各親ノード配下のfanのみ中心寄せ

## 狙い
- 開きすぎて散って見える枝を少し締める
- ただしノード/ラベルが近づきすぎないよう、円周上の最低間隔を維持

## テスト
- 既定値で従来full fanを維持
- 圧縮指定時に兄弟角度が縮む
- minLeafArcが必要な場合は圧縮を自動的に戻す

## 非変更
- DB / taxonomy
- 色・塗り/白抜きの視覚文法
- 資本関係graph
- 構成/系列/機能表/表