### PR TITLE
fix(company-network): Claude基準で構成可読性と高密度資本図を改善

### DIFF
--- a/app/premium/company-network/ClaudeUi.module.css
+++ b/app/premium/company-network/ClaudeUi.module.css
@@ -6,7 +6,7 @@
 .compactIntro {
   margin: 0;
   color: var(--color-text-muted);
-  font-size: 10px;
+  font-size: 11px;
   line-height: 1.6;
 }
 
@@ -73,7 +73,7 @@
   display: grid;
   grid-template-columns: 16px minmax(0, 1fr) auto;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
 }
 
 .treeRootSummary {
@@ -96,20 +96,20 @@
 .treeTone5 { --tree-accent: #be123c; }
 
 .treeClassSummary {
-  min-height: 38px;
-  padding: 6px 10px 6px 14px;
+  min-height: 40px;
+  padding: 7px 10px 7px 14px;
 }
 
 .treeFunctionSummary {
-  min-height: 34px;
-  padding: 5px 10px 5px 28px;
+  min-height: 38px;
+  padding: 6px 10px 6px 28px;
   border-top: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
   background: color-mix(in srgb, var(--tree-accent) 3%, var(--color-bg-card));
 }
 
 .chevron {
   color: var(--color-text-muted);
-  font-size: 9px;
+  font-size: 10px;
   transition: transform 120ms ease;
 }
 
@@ -118,8 +118,8 @@ details[open] > summary .chevron { transform: rotate(90deg); }
 .classDot,
 .roleDot {
   display: inline-block;
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--tree-accent, var(--color-accent));
 }
@@ -131,16 +131,22 @@ details[open] > summary .chevron { transform: rotate(90deg); }
 
 .treeTitle {
   min-width: 0;
-  font-size: 12px;
-  font-weight: 850;
-  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1.4;
 }
 
-.treeRootSummary .treeTitle { font-size: 13px; }
+.treeRootSummary .treeTitle {
+  font-size: 13px;
+  font-weight: 900;
+}
 
 .treeMeta {
   color: var(--color-text-muted);
-  font-size: 8px;
+  font-size: 10px;
   font-weight: 800;
   white-space: nowrap;
 }
@@ -155,9 +161,9 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   display: grid;
   grid-template-columns: 12px minmax(0, 1fr) auto;
   align-items: center;
-  gap: 6px;
-  min-height: 32px;
-  padding: 4px 8px 4px 10px;
+  gap: 7px;
+  min-height: 38px;
+  padding: 5px 8px 5px 10px;
   border: 0;
   border-bottom: 1px solid color-mix(in srgb, var(--color-border) 68%, transparent);
   background: transparent;
@@ -176,8 +182,8 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 10px;
-  font-weight: 800;
+  font-size: 13px;
+  font-weight: 750;
 }
 
 .companyTreeMeta {
@@ -185,7 +191,7 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   gap: 6px;
   align-items: center;
   color: var(--color-text-muted);
-  font-size: 8px;
+  font-size: 10px;
   white-space: nowrap;
 }
 
@@ -197,8 +203,8 @@ details[open] > summary .chevron { transform: rotate(90deg); }
 .networkIntro {
   margin: -1px 0 5px;
   color: var(--color-text-muted);
-  font-size: 9px;
-  line-height: 1.5;
+  font-size: 10px;
+  line-height: 1.55;
 }
 
 .networkCanvas,
@@ -338,15 +344,16 @@ details[open] > summary .chevron { transform: rotate(90deg); }
   .summaryStat strong { font-size: 12px; }
   .summaryStat span { font-size: 8px; }
 
-  .treeRootSummary { padding: 7px 8px; }
-  .treeClassSummary { padding: 5px 7px 5px 9px; min-height: 34px; }
-  .treeFunctionSummary { padding: 4px 7px 4px 22px; min-height: 31px; }
-  .treeTitle { font-size: 11px; }
-  .treeRootSummary .treeTitle { font-size: 12px; }
-  .companyTreeList { margin-left: 27px; }
-  .companyTreeRow { min-height: 30px; padding: 3px 5px 3px 8px; }
-  .companyTreeName { font-size: 9px; }
-  .companyTreeMeta { gap: 4px; font-size: 7px; }
+  .treeRootSummary { padding: 8px; }
+  .treeClassSummary { padding: 7px 8px 7px 10px; min-height: 40px; }
+  .treeFunctionSummary { padding: 6px 8px 6px 23px; min-height: 38px; }
+  .treeTitle { font-size: 13px; }
+  .treeRootSummary .treeTitle { font-size: 13px; }
+  .treeMeta { font-size: 10px; }
+  .companyTreeList { margin-left: 28px; }
+  .companyTreeRow { min-height: 38px; padding: 5px 6px 5px 8px; }
+  .companyTreeName { font-size: 13px; }
+  .companyTreeMeta { gap: 4px; font-size: 9px; }
 
   .networkCanvas,
   .networkSvg { min-height: 290px !important; }

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -197,10 +197,7 @@ export default function NetworkView({
   }, [graph.nodes, relationsOnly, runId]);
 
   useEffect(() => {
-    if (highDegreeNodes) {
-      setFrame(null);
-      return;
-    }
+    if (highDegreeNodes) return;
     const working = seeded.map((node) => ({ ...node }));
     let steps = 0;
     let handle = 0;

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -21,9 +21,93 @@ const FULL_VIEWBOX_HALF = 500;
 const COMPACT_VIEWBOX_HALF = 320;
 const SEED_SPREAD = 270;
 const COMPACT_SEED_SPREAD = 150;
+const HIGH_DEGREE_MIN_RELATIONS = 10;
+const HIGH_DEGREE_RATIO = 0.6;
 
 function truncate(value: string, max = 16) {
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function findHighDegreeHub(relationships: CompanyRelationship[]) {
+  if (relationships.length < HIGH_DEGREE_MIN_RELATIONS) return null;
+  const degree = new Map<string, number>();
+  relationships.forEach((relationship) => {
+    degree.set(relationship.sourceCompanyId, (degree.get(relationship.sourceCompanyId) ?? 0) + 1);
+    degree.set(relationship.targetCompanyId, (degree.get(relationship.targetCompanyId) ?? 0) + 1);
+  });
+
+  let hubId: string | null = null;
+  let hubDegree = 0;
+  degree.forEach((value, companyId) => {
+    if (value > hubDegree) {
+      hubId = companyId;
+      hubDegree = value;
+    }
+  });
+
+  return hubId && hubDegree / relationships.length >= HIGH_DEGREE_RATIO ? hubId : null;
+}
+
+function positioned(node: VisualNode, x: number, y: number): SimNode {
+  return { ...node, x, y, vx: 0, vy: 0 };
+}
+
+/**
+ * NTTのような高次数starではforce simulationよりも、hubを中心に固定して
+ * 周辺会社をリングへ整列した方が関係の全体像とラベルを同時に読みやすい。
+ */
+function layoutHighDegreeStar(
+  nodes: VisualNode[],
+  relationships: CompanyRelationship[],
+  hubId: string,
+): SimNode[] {
+  const directIds = new Set<string>();
+  relationships.forEach((relationship) => {
+    if (relationship.sourceCompanyId === hubId) directIds.add(relationship.targetCompanyId);
+    if (relationship.targetCompanyId === hubId) directIds.add(relationship.sourceCompanyId);
+  });
+
+  const hub = nodes.find((node) => node.id === hubId);
+  if (!hub) return seedSimNodes(nodes, COMPACT_SEED_SPREAD);
+
+  const direct = nodes
+    .filter((node) => node.id !== hubId && directIds.has(node.id))
+    .sort((a, b) => a.label.localeCompare(b.label, "ja"));
+  const remaining = nodes
+    .filter((node) => node.id !== hubId && !directIds.has(node.id))
+    .sort((a, b) => a.label.localeCompare(b.label, "ja"));
+
+  const placed = new Map<string, SimNode>([[hubId, positioned(hub, 0, 0)]]);
+
+  const placeRing = (ringNodes: VisualNode[], radius: number, offset = 0) => {
+    const count = ringNodes.length;
+    ringNodes.forEach((node, index) => {
+      const angle = -Math.PI / 2 + offset + (Math.PI * 2 * index) / Math.max(count, 1);
+      placed.set(node.id, positioned(node, Math.cos(angle) * radius, Math.sin(angle) * radius));
+    });
+  };
+
+  if (direct.length <= 16) {
+    const radius = Math.max(220, Math.min(310, (direct.length * 125) / (Math.PI * 2)));
+    placeRing(direct, radius);
+  } else {
+    const radii = [160, 255, 350];
+    let cursor = 0;
+    radii.forEach((radius, ringIndex) => {
+      if (cursor >= direct.length) return;
+      const capacity = Math.max(1, Math.floor((Math.PI * 2 * radius) / 125));
+      const end = ringIndex === radii.length - 1
+        ? direct.length
+        : Math.min(direct.length, cursor + capacity);
+      const ringNodes = direct.slice(cursor, end);
+      placeRing(ringNodes, radius, ringIndex % 2 === 1 ? Math.PI / Math.max(ringNodes.length, 1) : 0);
+      cursor = end;
+    });
+  }
+
+  if (remaining.length > 0) placeRing(remaining, 430, Math.PI / Math.max(remaining.length, 1));
+
+  return nodes.map((node) => placed.get(node.id) ?? positioned(node, 0, 0));
 }
 
 type Props = {
@@ -97,12 +181,26 @@ export default function NetworkView({
     return { nodes, links };
   }, [memberships, relationships, visibleCompanies]);
 
+  const highDegreeHubId = useMemo(
+    () => relationsOnly ? findHighDegreeHub(relationships) : null,
+    [relationsOnly, relationships],
+  );
+
+  const highDegreeNodes = useMemo(
+    () => highDegreeHubId ? layoutHighDegreeStar(graph.nodes, relationships, highDegreeHubId) : null,
+    [graph.nodes, highDegreeHubId, relationships],
+  );
+
   const seeded = useMemo(() => {
     void runId;
     return seedSimNodes(graph.nodes, relationsOnly ? COMPACT_SEED_SPREAD : SEED_SPREAD);
   }, [graph.nodes, relationsOnly, runId]);
 
   useEffect(() => {
+    if (highDegreeNodes) {
+      setFrame(null);
+      return;
+    }
     const working = seeded.map((node) => ({ ...node }));
     let steps = 0;
     let handle = 0;
@@ -114,13 +212,13 @@ export default function NetworkView({
     };
     handle = requestAnimationFrame(advance);
     return () => cancelAnimationFrame(handle);
-  }, [graph.links, seeded]);
+  }, [graph.links, highDegreeNodes, seeded]);
 
-  const nodes = frame?.source === seeded ? frame.nodes : seeded;
+  const nodes = highDegreeNodes ?? (frame?.source === seeded ? frame.nodes : seeded);
   const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
   const viewBoxHalf = relationsOnly ? COMPACT_VIEWBOX_HALF : FULL_VIEWBOX_HALF;
-  const labelPadding = relationsOnly ? 72 : 120;
-  const minimumExtent = relationsOnly ? 105 : 240;
+  const labelPadding = highDegreeHubId ? 82 : relationsOnly ? 72 : 120;
+  const minimumExtent = highDegreeHubId ? 260 : relationsOnly ? 105 : 240;
   const fit = (viewBoxHalf - labelPadding) / simExtent(nodes, minimumExtent);
   const size = viewBoxHalf * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
@@ -135,10 +233,14 @@ export default function NetworkView({
       <div className={styles.viewTools}>
         <span>{title}</span>
         <span className={relationStyles.relationMeta}>{visibleCompanies.length}社 · {relationships.length}関係</span>
-        <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button>
+        {!highDegreeHubId ? <button type="button" className={styles.smallButton} onClick={() => setRunId((value) => value + 1)}>再配置</button> : null}
       </div>
       {relationsOnly ? (
-        <p className={claudeStyles.networkIntro}>確認済みの企業間relationだけを主図に表示。所属のみの企業は下へ分離しています。</p>
+        <p className={claudeStyles.networkIntro}>
+          {highDegreeHubId
+            ? "高密度の中心企業を固定して周辺企業を整列しています。持株比率などの関係ラベルは線を選択すると表示します。"
+            : "確認済みの企業間relationだけを主図に表示。所属のみの企業は下へ分離しています。"}
+        </p>
       ) : null}
       <div className={`${styles.svgWrap} ${relationsOnly ? relationStyles.compactGraph : ""} ${relationsOnly ? claudeStyles.networkCanvas : ""}`}>
         <div className={styles.zoomControls}>
@@ -164,9 +266,19 @@ export default function NetworkView({
               if (!source || !target) return null;
               const selected = relationship.relationId === selectedRelationId;
               const focused = selectedNeighbours === null || (selectedNeighbours.has(relationship.sourceCompanyId) && selectedNeighbours.has(relationship.targetCompanyId));
+              const selectedCompanyId = graphSelection?.kind === "company" ? graphSelection.id : null;
+              const selectedLeafRelation = Boolean(
+                highDegreeHubId &&
+                selectedCompanyId &&
+                selectedCompanyId !== highDegreeHubId &&
+                (relationship.sourceCompanyId === selectedCompanyId || relationship.targetCompanyId === selectedCompanyId),
+              );
+              const showEdgeLabel = highDegreeHubId ? selected || selectedLeafRelation : focused || selected;
+              const strokeWidth = highDegreeHubId ? (selected ? 3.2 : 1.5) : selected ? 3.6 : focused ? 2.2 : 1.2;
+              const strokeOpacity = highDegreeHubId ? (selected ? 1 : 0.62) : selected ? 1 : focused ? 0.9 : 0.22;
               return <g key={relationship.relationId}>
-                <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={selected ? 3.6 : focused ? 2.2 : 1.2} strokeOpacity={selected ? 1 : focused ? 0.9 : 0.22} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
-                {(focused || selected) ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - (relationsOnly ? 13 : 9)} textAnchor="middle" className={styles.svgEdgeLabel} style={relationsOnly ? { fontSize: 12 } : undefined}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
+                <line x1={source.x * fit} y1={source.y * fit} x2={target.x * fit} y2={target.y * fit} stroke={CATEGORY_COLOR[relationship.relationCategory]} strokeWidth={strokeWidth} strokeOpacity={strokeOpacity} strokeDasharray={relationship.verificationStatus === "verified" ? undefined : "7 6"} markerEnd="url(#company-relation-arrow)" color={CATEGORY_COLOR[relationship.relationCategory]} onClick={() => onSelectRelation(relationship.relationId)} className={styles.edgeHitTarget} />
+                {showEdgeLabel ? <text x={((source.x + target.x) / 2) * fit} y={((source.y + target.y) / 2) * fit - (relationsOnly ? 13 : 9)} textAnchor="middle" className={styles.svgEdgeLabel} style={relationsOnly ? { fontSize: highDegreeHubId ? 10 : 12 } : undefined}>{relationLabel(relationship.relationType, relationship.ownershipPct)}</text> : null}
               </g>;
             })}
             {memberships.map((membership) => {
@@ -182,14 +294,19 @@ export default function NetworkView({
             })}
             {nodes.map((node) => {
               const selected = node.id === selectedNodeId;
-              const center = node.kind === "company" && node.id === centerCompanyId;
+              const hubCenter = node.kind === "company" && node.id === highDegreeHubId;
+              const center = node.kind === "company" && (node.id === centerCompanyId || hubCenter);
               const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
               const neighbourDimmed = selectedNeighbours !== null && !selectedNeighbours.has(node.id);
               const dimmed = queryDimmed || neighbourDimmed;
-              const baseRadius = relationsOnly ? 14 : 8;
-              const radius = node.kind === "group" ? (selected ? 11 : 9) : center ? 11 : selected ? baseRadius + 2 : baseRadius;
+              const baseRadius = highDegreeHubId ? 11 : relationsOnly ? 14 : 8;
+              const radius = node.kind === "group" ? (selected ? 11 : 9) : hubCenter ? 17 : center ? 11 : selected ? baseRadius + 2 : baseRadius;
               const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
+              const outwardLeft = Boolean(highDegreeHubId && !hubCenter && node.x < 0);
+              const labelX = hubCenter ? 0 : outwardLeft ? -(radius + 7) : radius + 7;
+              const labelY = hubCenter ? radius + 14 : 0;
+              const labelAnchor = hubCenter ? "middle" : outwardLeft ? "end" : "start";
               return <g
                 key={node.id}
                 transform={`translate(${node.x * fit} ${node.y * fit})`}
@@ -212,7 +329,16 @@ export default function NetworkView({
                 <title>{node.kind === "group" ? `${node.label}（${groupTypeLabel(node.groupType ?? "")}）` : node.label}</title>
                 {selected ? <circle className={styles.pulse} r={radius + 8} fill="none" stroke={stroke} strokeWidth={2} /> : null}
                 <circle r={radius} fill={fill} stroke={stroke} strokeWidth={selected || center ? 3 : 2} />
-                <text className={styles.svgLabel} x={radius + 7} dominantBaseline="middle" style={relationsOnly ? { fontSize: 14 } : undefined}>{truncate(node.label)}</text>
+                <text
+                  className={styles.svgLabel}
+                  x={labelX}
+                  y={labelY}
+                  textAnchor={labelAnchor}
+                  dominantBaseline={hubCenter ? "hanging" : "middle"}
+                  style={relationsOnly ? { fontSize: highDegreeHubId ? (hubCenter ? 13 : 11) : 14 } : undefined}
+                >
+                  {truncate(node.label, highDegreeHubId ? (hubCenter ? 16 : 12) : 16)}
+                </text>
               </g>;
             })}
           </g>


### PR DESCRIPTION
Closes #546

## 変更概要
- 構成treeの主要ラベル/企業名をClaude/Industry Map基準の13px級へ戻す
- モバイルでも企業名を9pxへ縮小せず、長い名前はellipsisで処理
- class/function/company rowの高さ・padding・gap・meta文字を可読性優先へ調整
- NTT型の高次数starを検出し、中心企業固定＋複数リング整列へ切替
- 高次数starでは中心企業を強調し、周辺ラベルを外向きに配置
- 高次数starのedge labelは通常時に全件表示せず、選択関係または選択した非hub企業の関係だけ表示
- 高次数starではforce再配置ボタンを出さず、決定的な整列を維持

## 非変更
- NTTの機能taxonomy/DB内容
- 事業・機能Radialの少量データ表示
- 系列/機能表/表の基本構造
- Supabase schema/data

## 確認
- lint
- test
- build
- Vercel Preview Ready後にmerge