### PR TITLE
fix(company-network): Phase A 機能表と資本関係ラベルをClaude基準で改善

### DIFF
--- a/app/premium/company-network/FunctionViews.module.css
+++ b/app/premium/company-network/FunctionViews.module.css
@@ -108,43 +108,167 @@
 .unmappedBox > div { display: flex; justify-content: space-between; gap: 8px; }
 .unmappedBox p { margin: 0; line-height: 1.6; }
 
+/* Claude/Industry Map Matrixの原則を採用: 読める幅を確保し、狭い画面では圧縮せず横スクロールする。 */
 .matrixLegend {
   display: flex;
   flex-wrap: wrap;
   gap: 8px 14px;
   align-items: center;
-  padding: 8px 10px;
+  padding: 9px 10px;
   border: 1px solid var(--color-border);
   border-radius: 10px;
   background: var(--color-bg-input);
   color: var(--color-text-muted);
-  font-size: 9px;
+  font-size: 10px;
   line-height: 1.5;
 }
-.matrixLegend span { display: inline-flex; align-items: center; gap: 5px; }
-.legendCore { color: var(--color-accent); }
-.legendSupporting { color: var(--color-accent); }
-.matrixScrollHint { display: none; color: var(--color-text-muted); font-size: 9px; text-align: center; }
+.matrixLegend span { display: inline-flex; align-items: center; gap: 6px; }
+.legendCore,
+.legendSupporting {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  height: 22px;
+  padding: 0 7px;
+  border-radius: 7px;
+  font-size: 9px;
+  font-weight: 900;
+}
+.legendCore { color: white; background: var(--color-accent); border: 1px solid var(--color-accent); }
+.legendSupporting { color: var(--color-accent); background: var(--color-bg-card); border: 1px solid var(--color-accent); }
+.matrixScrollHint { display: none; color: var(--color-text-muted); font-size: 10px; text-align: center; }
 
-.matrixScroll { overflow: auto; width: 100%; border: 1px solid var(--color-border); border-radius: 12px; box-shadow: inset -18px 0 18px -20px rgba(15, 23, 42, .35); }
-.matrixTable { border-collapse: separate; border-spacing: 0; min-width: 100%; width: max-content; font-size: 10px; }
+.matrixScroll {
+  overflow: auto;
+  width: 100%;
+  max-height: min(68vh, 720px);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: inset -18px 0 18px -20px rgba(15, 23, 42, .28);
+  scrollbar-gutter: stable;
+}
+
+.matrixTable {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: max-content;
+  min-width: 100%;
+  font-size: 12px;
+}
+
 .matrixTable th,
-.matrixTable td { min-width: 82px; padding: 8px 7px; border-right: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border); text-align: center; background: var(--color-bg-card); }
-.matrixTable thead th { position: sticky; top: 0; z-index: 2; background: var(--color-bg-input); }
-.matrixTable thead button { border: 0; background: transparent; color: var(--color-text-sub); font: inherit; font-weight: 800; cursor: pointer; writing-mode: vertical-rl; max-height: 115px; }
-.matrixSticky { position: sticky !important; left: 0; z-index: 3 !important; min-width: 158px !important; text-align: left !important; box-shadow: 5px 0 10px -9px rgba(15, 23, 42, .45); }
-.matrixSticky strong { display: block; margin-top: 3px; font-size: 10px; }
-.matrixSticky small { display: block; margin-top: 3px; color: var(--color-text-muted); font-size: 8px; font-weight: 700; }
-.matrixClass { color: var(--color-text-muted); }
-.matrixClassStart > th,
-.matrixClassStart > td { border-top: 2px solid var(--color-border); }
+.matrixTable td {
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-card);
+}
+
+.matrixTable thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 8px 12px;
+  background: var(--color-bg-input);
+  color: var(--color-text-sub);
+  font-size: 10px;
+  font-weight: 900;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.matrixTable thead th:not(.matrixSticky),
+.matrixTable tbody td {
+  min-width: 118px;
+}
+
+.matrixTable thead button {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 900;
+  line-height: 1.4;
+  text-align: center;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.matrixTable thead button:hover { color: var(--color-accent); }
+
+.matrixSticky {
+  position: sticky !important;
+  left: 0;
+  z-index: 3 !important;
+  min-width: 168px !important;
+  max-width: 220px;
+  padding: 8px 10px;
+  text-align: left !important;
+  box-shadow: 5px 0 10px -9px rgba(15, 23, 42, .4);
+}
+
+.matrixTable thead .matrixSticky {
+  z-index: 4 !important;
+  background: var(--color-bg-input);
+}
+
+.matrixSticky strong {
+  display: block;
+  margin-top: 3px;
+  color: var(--color-text);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.matrixSticky small {
+  display: block;
+  margin-top: 3px;
+  color: var(--color-text-muted);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.matrixClass {
+  color: var(--color-text-muted);
+  font-size: 9px;
+  letter-spacing: .04em;
+}
+
+/* 分類境界は太い罫線ではなく余白で示す。 */
+.matrixClassStart > .matrixSticky { padding-top: 14px; }
+.matrixClassStart > td { padding-top: 10px; }
+
+.matrixTable tbody td {
+  padding: 6px 10px;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.matrixTable tbody tr:hover > th,
+.matrixTable tbody tr:hover > td {
+  background: var(--color-bg-input);
+}
+
 .matrixFocusColumn { background: var(--color-accent-sub) !important; }
 
 .matrixCore,
-.matrixSupporting { width: 28px; height: 28px; border-radius: 8px; font: inherit; font-weight: 900; cursor: pointer; }
+.matrixSupporting {
+  min-width: 42px;
+  height: 24px;
+  padding: 0 7px;
+  border-radius: 7px;
+  font: inherit;
+  font-size: 9px;
+  font-weight: 900;
+  cursor: pointer;
+}
 .matrixCore { border: 1px solid var(--color-accent); background: var(--color-accent); color: white; }
 .matrixSupporting { border: 1px solid var(--color-accent); background: var(--color-bg-card); color: var(--color-accent); }
-.matrixEmpty { color: var(--color-border); }
+.matrixCore:hover,
+.matrixSupporting:hover { box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 18%, transparent); }
+.matrixEmpty { color: var(--color-border-strong); font-size: 11px; }
 
 .tableFunction { min-width: 190px; color: var(--color-text-sub); font-weight: 700; line-height: 1.6; }
 .functionDetailList { display: grid; gap: 7px; }
@@ -168,7 +292,9 @@
   .functionClusterGrid { grid-template-columns: 1fr; }
   .functionCompany { min-width: min(150px, 100%); flex: 1 1 130px; }
   .matrixScrollHint { display: block; }
-  .matrixSticky { min-width: 128px !important; }
-  .matrixTable th, .matrixTable td { min-width: 64px; padding: 7px 5px; }
-  .matrixTable thead button { max-height: 96px; font-size: 9px; }
+  .matrixSticky { min-width: 146px !important; }
+  .matrixTable thead th:not(.matrixSticky),
+  .matrixTable tbody td { min-width: 112px; }
+  .matrixTable thead th { padding: 8px 10px; }
+  .matrixTable thead button { font-size: 10px; }
 }

--- a/app/premium/company-network/views/FunctionCoverageMatrixView.tsx
+++ b/app/premium/company-network/views/FunctionCoverageMatrixView.tsx
@@ -77,20 +77,20 @@ export default function FunctionCoverageMatrixView({
         <span>{groupName} 機能カバレッジ</span>
         <span>{rows.length}領域 × {companiesSorted.length}社</span>
       </div>
-      <div className={`${functionStyles.matrixLegend} ${claudeStyles.legendBar}`}>
-        <span><b className={functionStyles.legendCore}>●</b> 主要機能</span>
-        <span><b className={functionStyles.legendSupporting}>○</b> 追加機能</span>
+      <div className={functionStyles.matrixLegend}>
+        <span><b className={functionStyles.legendCore}>主要</b> 主担当・中核機能</span>
+        <span><b className={functionStyles.legendSupporting}>追加</b> 補完・追加機能</span>
         <span>担当機能数が多い企業を左側へ配置</span>
       </div>
-      <div className={functionStyles.matrixScrollHint}>← 横スクロールで全社を比較 →</div>
-      <div className={`${functionStyles.matrixScroll} ${claudeStyles.matrixScroll}`}>
-        <table className={`${functionStyles.matrixTable} ${claudeStyles.matrixTable}`}>
+      <div className={functionStyles.matrixScrollHint}>← 横にスクロールすると残りの企業を比較できます →</div>
+      <div className={functionStyles.matrixScroll}>
+        <table className={functionStyles.matrixTable}>
           <thead>
             <tr>
               <th className={functionStyles.matrixSticky}>機能</th>
               {companiesSorted.map((company) => (
                 <th key={company.id} className={focusCompanyId === company.id ? functionStyles.matrixFocusColumn : undefined}>
-                  <button type="button" onClick={() => onSelectCompany(company.id)}>{company.name}</button>
+                  <button type="button" onClick={() => onSelectCompany(company.id)} title={company.name}>{company.name}</button>
                 </th>
               ))}
             </tr>
@@ -99,8 +99,9 @@ export default function FunctionCoverageMatrixView({
             {rows.map((row, index) => {
               const previousClass = index > 0 ? rows[index - 1].classificationName : null;
               const newClass = previousClass !== row.classificationName;
+              const classBreak = index > 0 && newClass;
               return (
-                <tr key={`${row.classificationSlug}:${row.functionSlug}`} className={newClass ? functionStyles.matrixClassStart : undefined}>
+                <tr key={`${row.classificationSlug}:${row.functionSlug}`} className={classBreak ? functionStyles.matrixClassStart : undefined}>
                   <th className={functionStyles.matrixSticky}>
                     {newClass ? <span className={functionStyles.matrixClass}>{row.classificationName}</span> : null}
                     <strong>{row.functionName}</strong>
@@ -113,11 +114,11 @@ export default function FunctionCoverageMatrixView({
                         {link ? (
                           <button
                             type="button"
-                            className={`${link.role === "core" ? functionStyles.matrixCore : functionStyles.matrixSupporting} ${claudeStyles.matrixCellButton}`}
+                            className={link.role === "core" ? functionStyles.matrixCore : functionStyles.matrixSupporting}
                             title={`${company.name}: ${row.functionName} (${link.role === "core" ? "主要" : "追加"})`}
                             onClick={() => onSelectCompany(company.id)}
                           >
-                            {link.role === "core" ? "●" : "○"}
+                            {link.role === "core" ? "主要" : "追加"}
                           </button>
                         ) : <span className={functionStyles.matrixEmpty}>—</span>}
                       </td>

--- a/app/premium/company-network/views/NetworkView.tsx
+++ b/app/premium/company-network/views/NetworkView.tsx
@@ -23,9 +23,62 @@ const SEED_SPREAD = 270;
 const COMPACT_SEED_SPREAD = 150;
 const HIGH_DEGREE_MIN_RELATIONS = 10;
 const HIGH_DEGREE_RATIO = 0.6;
+const STAR_LABEL_LINE_LENGTH = 9;
+const STAR_LABEL_FONT_SIZE = 11;
+const STAR_LABEL_RADIUS = 11;
+const STAR_LABEL_GAP = 7;
 
 function truncate(value: string, max = 16) {
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function wrapStarLabel(value: string) {
+  const characters = Array.from(value.trim());
+  if (characters.length <= STAR_LABEL_LINE_LENGTH) return [characters.join("")];
+
+  let splitAt = STAR_LABEL_LINE_LENGTH;
+  const firstWindow = characters.slice(0, STAR_LABEL_LINE_LENGTH + 1).join("");
+  const lastSpace = firstWindow.lastIndexOf(" ");
+  if (lastSpace >= 4) splitAt = Array.from(firstWindow.slice(0, lastSpace)).length;
+
+  const first = characters.slice(0, splitAt).join("").trim();
+  const remaining = characters.slice(splitAt).join("").trim();
+  const remainingCharacters = Array.from(remaining);
+  const second = remainingCharacters.length <= STAR_LABEL_LINE_LENGTH
+    ? remaining
+    : `${remainingCharacters.slice(0, STAR_LABEL_LINE_LENGTH - 1).join("")}…`;
+
+  return second ? [first, second] : [first];
+}
+
+function estimateSvgTextWidth(value: string, fontSize = STAR_LABEL_FONT_SIZE) {
+  return Array.from(value).reduce((width, character) => {
+    if (character === " ") return width + fontSize * 0.35;
+    if (/^[\u0000-\u00ff]$/.test(character)) return width + fontSize * 0.6;
+    return width + fontSize;
+  }, 0);
+}
+
+function fitHighDegreeLabels(
+  nodes: SimNode[],
+  hubId: string,
+  viewBoxHalf: number,
+  geometryFit: number,
+) {
+  let labelFit = geometryFit;
+  const edgeSafeArea = 10;
+  const labelOffset = STAR_LABEL_RADIUS + STAR_LABEL_GAP;
+
+  for (const node of nodes) {
+    if (node.id === hubId || Math.abs(node.x) < 1) continue;
+    const lines = wrapStarLabel(node.label);
+    const labelWidth = Math.max(...lines.map((line) => estimateSvgTextWidth(line)));
+    const availableForNodeX = viewBoxHalf - edgeSafeArea - labelOffset - labelWidth;
+    if (availableForNodeX <= 0) continue;
+    labelFit = Math.min(labelFit, availableForNodeX / Math.abs(node.x));
+  }
+
+  return Math.max(0.36, labelFit);
 }
 
 function findHighDegreeHub(relationships: CompanyRelationship[]) {
@@ -214,9 +267,12 @@ export default function NetworkView({
   const nodes = highDegreeNodes ?? (frame?.source === seeded ? frame.nodes : seeded);
   const positions = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
   const viewBoxHalf = relationsOnly ? COMPACT_VIEWBOX_HALF : FULL_VIEWBOX_HALF;
-  const labelPadding = highDegreeHubId ? 82 : relationsOnly ? 72 : 120;
+  const labelPadding = highDegreeHubId ? 64 : relationsOnly ? 72 : 120;
   const minimumExtent = highDegreeHubId ? 260 : relationsOnly ? 105 : 240;
-  const fit = (viewBoxHalf - labelPadding) / simExtent(nodes, minimumExtent);
+  const geometryFit = (viewBoxHalf - labelPadding) / simExtent(nodes, minimumExtent);
+  const fit = highDegreeHubId
+    ? fitHighDegreeLabels(nodes, highDegreeHubId, viewBoxHalf, geometryFit)
+    : geometryFit;
   const size = viewBoxHalf * 2;
   const normalizedQuery = query.trim().toLocaleLowerCase("ja");
   const selectedNodeId = selectedGraphNodeId(graphSelection);
@@ -296,13 +352,14 @@ export default function NetworkView({
               const queryDimmed = normalizedQuery.length > 0 && !node.label.toLocaleLowerCase("ja").includes(normalizedQuery);
               const neighbourDimmed = selectedNeighbours !== null && !selectedNeighbours.has(node.id);
               const dimmed = queryDimmed || neighbourDimmed;
-              const baseRadius = highDegreeHubId ? 11 : relationsOnly ? 14 : 8;
+              const baseRadius = highDegreeHubId ? STAR_LABEL_RADIUS : relationsOnly ? 14 : 8;
               const radius = node.kind === "group" ? (selected ? 11 : 9) : hubCenter ? 17 : center ? 11 : selected ? baseRadius + 2 : baseRadius;
               const fill = node.kind === "group" ? "#fff7ed" : center ? "#2554ff" : "var(--color-bg-card)";
               const stroke = node.kind === "group" ? "#d97706" : "#2554ff";
               const outwardLeft = Boolean(highDegreeHubId && !hubCenter && node.x < 0);
-              const labelX = hubCenter ? 0 : outwardLeft ? -(radius + 7) : radius + 7;
-              const labelY = hubCenter ? radius + 14 : 0;
+              const labelX = hubCenter ? 0 : outwardLeft ? -(radius + STAR_LABEL_GAP) : radius + STAR_LABEL_GAP;
+              const labelLines = highDegreeHubId && !hubCenter ? wrapStarLabel(node.label) : [truncate(node.label, 16)];
+              const labelY = hubCenter ? radius + 14 : labelLines.length > 1 ? -6 : 0;
               const labelAnchor = hubCenter ? "middle" : outwardLeft ? "end" : "start";
               return <g
                 key={node.id}
@@ -332,9 +389,11 @@ export default function NetworkView({
                   y={labelY}
                   textAnchor={labelAnchor}
                   dominantBaseline={hubCenter ? "hanging" : "middle"}
-                  style={relationsOnly ? { fontSize: highDegreeHubId ? (hubCenter ? 13 : 11) : 14 } : undefined}
+                  style={relationsOnly ? { fontSize: highDegreeHubId ? (hubCenter ? 13 : STAR_LABEL_FONT_SIZE) : 14 } : undefined}
                 >
-                  {truncate(node.label, highDegreeHubId ? (hubCenter ? 16 : 12) : 16)}
+                  {labelLines.map((line, index) => (
+                    <tspan key={`${node.id}:${index}`} x={labelX} dy={index === 0 ? 0 : 12}>{line}</tspan>
+                  ))}
                 </text>
               </g>;
             })}


### PR DESCRIPTION
Closes #548

## Phase A
### 機能表
- 縦書き企業名を廃止し、横書き + nowrap + 横スクロールへ変更
- Claude/Industry Map Matrixと同じ「読める列幅を確保してスクロールする」方針へ変更
- 主要/追加を二重記号から、セル自体に「主要」「追加」と表示する単純なマークへ変更
- 縦罫線と分類境界の2px罫線を廃止
- 分類境界は左列ラベルと余白で表現
- sticky機能列、担当機能数順、選択企業列ハイライトは維持

### 資本関係
- NTT型high-degree starのリング配置は維持
- 長い企業名を最大2行へ折り返し
- 左右でtext-anchorを切替
- ラベル幅を概算してfitへ反映し、左右端の切れを抑制
- titleで企業名全文を保持
- relation labelは選択時中心の現行方針を維持

## 非変更
- DB / Supabase
- NTT機能taxonomy
- 構成/系列/表の大規模改修

## Gate
- lint
- test
- build
- Vercel Preview Ready後にmerge