### PR TITLE
feat(workspace-core): add generic Supabase registry V1

### DIFF
--- a/docs/decision-log/2026-08-30-workspace-core-boundary.md
+++ b/docs/decision-log/2026-08-30-workspace-core-boundary.md
@@ -1,0 +1,91 @@
+# Workspace Core のルート境界と ChatGPT-first 運用
+
+Date: 2026-08-30  
+Related: #551
+
+## 結論
+
+最後の Supabase Free 枠を開発専用 DB として固定しない。
+
+Project は `workspace-core` のような汎用名を採用し、V1 は `platform / registry / ops` のみを作成する。
+
+また、人間が Notion や DB UI を日常的に巡回することを前提にせず、ChatGPT / AI Agent を主インターフェースとして設計する。
+
+## 背景
+
+当初は Product / Repository / Technology / Service を整理する `product-db` を想定していた。
+
+しかし Supabase Free 枠が残り 1 Project であるため、将来別用途の構造化データを置きたくなった場合に `product-db` というルート概念が制約になる懸念がある。
+
+同時に、Notion は過去の原文・知識を保持しているものの、実運用では人間が直接見に行く頻度が下がっている。今後は「以前こういう話をしていなかったか」と ChatGPT に問い、必要なときだけ元情報を参照する運用の方が現実に近い。
+
+## 決めたこと
+
+### 1. Project は用途固定名にしない
+
+避ける:
+
+- `product-db`
+- `dev-db`
+- `mini-tools-meta`
+
+第一候補:
+
+- `workspace-core`
+
+### 2. schema で責務を分離する
+
+V1:
+
+- `platform`: Project 全体のメタ情報
+- `registry`: Product / Repository / Technology / Service / Relation
+- `ops`: Sync / Import state
+
+将来 domain は需要が発生してから追加する。
+
+### 3. ChatGPT-first
+
+ChatGPT / AI Agent を、各 Source of Truth を横断する主 UI とみなす。
+
+Workspace Core 自体は「人間が毎日表を編集する DB」を目標にしない。
+
+### 4. Notion は廃止しないが主 UI とも決めない
+
+Notion にしか存在しない原文・検証ログ・長文知識は参照価値がある。
+
+ただし Workspace Core に全文複製することも、Notion を日常 UI として維持することも必須にしない。
+
+必要に応じて `external_resources` に pointer / summary / relation を保持する。
+
+### 5. Source of Truth を分散したまま管理可能にする
+
+- GitHub: code / Issues / PRs
+- Supabase: operational DB state
+- Notion: originating long-form text when applicable
+- Runtime provider: live deployment state
+- Workspace Core: Product identity and cross-system relationships
+
+## 理由
+
+1. 最後の Free Project 枠を将来用途からロックしない。
+2. 各システムの得意領域を残し、無理なデータ複製を避ける。
+3. ChatGPT が問い合わせ時に必要な原文へ戻れるため、人間向け整理画面の維持コストを下げられる。
+4. Product / Repository / Service の relation graph は構造化 DB に置く方が再利用・検索・自動化しやすい。
+5. generic EAV にせず schema 単位で domain を増やすことで、汎用性と意味の明確さを両立できる。
+
+## 影響
+
+- V1 の SQL は既存 `mini-tools` Supabase に適用しない。
+- Product classification と GitHub repository facts を別 seed にする。
+- `source` / `confidence` / `verified_at` を relation に持たせる。
+- secret は registry に保存しない。
+- UI は DB bootstrap / discovery より後にする。
+
+## 再検討条件
+
+次の場合は boundary を再検討する。
+
+- Workspace Core が Free plan 容量・Project制約に近づく
+- 複数ユーザーによる直接クライアントアクセスが必要になる
+- knowledge / automation 等が registry と強く競合し、独立 Project の方が安全になる
+- ChatGPT / connector から必要な Source of Truth へ安定して到達できなくなる

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -16,6 +16,7 @@
 | [Phase 1 クロスデバイス同期 実装計画](./phase1-cross-device-sync-plan.md) | 任意ログイン + Supabase でツールデータをデバイス間同期する段階実装計画 |
 | [優待統合ダッシュボード（PC）実装計画](./yutai-dashboard-plan.md) | 優待候補の発掘と運用管理を PC 向けテーブルで統合する段階実装計画 |
 | [ポートフォリオ意思決定ワークスペース実装計画](./portfolio-decision-workspace-plan.md) | ChatGPT起点の相談・保存・表示・銘柄連携を完成させるクロスリポジトリ計画 |
+| [Workspace Core V1 実装計画](./workspace-core-v1.md) | 最後のSupabase Free枠を汎用Control Planeとして使うためのDB境界・初期inventory・段階実装計画 |
 
 ## 更新ルール
 

--- a/docs/plans/workspace-core-v1.md
+++ b/docs/plans/workspace-core-v1.md
@@ -1,0 +1,215 @@
+# Workspace Core V1 実装計画
+
+## 結論
+
+最後の Supabase Free 枠は `product-db` / `dev-db` のような用途固定の Project にせず、将来複数ドメインを収容できる **Workspace Core** として扱う。
+
+V1 では Project 全体を汎用化しつつ、実装対象は開発資産レジストリに絞る。
+
+```text
+Workspace Core
+├─ platform
+├─ registry
+└─ ops
+```
+
+将来 `knowledge` / `automation` / `research` 等が必要になった場合のみ schema を追加する。
+
+関連 Issue: #551
+
+## 背景
+
+GitHub、Supabase、Notion、Vercel、Google Cloud 等に情報が分散しているため、次の質問に横断的に答えにくい。
+
+- どの Product が存在するか
+- どの Repository がどの Product に属するか
+- どの技術・外部サービスを利用しているか
+- Product 間の API / データ依存がどうなっているか
+- 設計の原文や Issue がどこにあるか
+
+一方で、GitHub や Notion の本文をすべて複製すると Source of Truth が曖昧になり、同期コストも増える。
+
+そのため Workspace Core は **「何がどこにあり、何と何がどう関係するか」** を構造化する Control Plane とする。
+
+## 利用モデル
+
+日常の入口は ChatGPT / AI Agent を想定する。
+
+```text
+User
+  ↓ conversation / voice
+ChatGPT / Agent
+  ├─ Workspace Core: identity / relation / provenance
+  ├─ GitHub: code / issue / PR / actions
+  ├─ Supabase: operational DB state
+  ├─ Notion: source text / historical knowledge when needed
+  └─ Runtime providers: deployment state
+```
+
+Notion は廃止前提ではないが、人間が毎日閲覧する UI を前提にした設計にはしない。
+
+## Source of Truth
+
+| 情報 | Source of Truth | Workspace Core の役割 |
+|---|---|---|
+| Code / Repository / Issue / PR | GitHub | ID・URL・関係・同期時刻 |
+| 稼働DBの状態 | 各 Supabase Project | Project instance・Productとの関係 |
+| 長文原文 / 過去メモ | 原文が存在する Notion 等 | URL・要約・Productとの関係 |
+| Deployment | Vercel / Google Cloud / Cloudflare 等 | instance・Productとの関係 |
+| Product概念 | Workspace Core | Productの識別と横断関係 |
+| Cross-system relation | Workspace Core | provenance / confidence 付き関係 |
+
+## Schema boundary
+
+### `platform`
+
+Workspace Core 全体のメタ情報。
+
+V1:
+
+- `domains`
+- `source_systems`
+
+### `registry`
+
+V1 の中心。
+
+- `products`
+- `repositories`
+- `product_repositories`
+- `technologies`
+- `product_technologies`
+- `service_providers`
+- `service_instances`
+- `product_service_links`
+- `product_relations`
+- `external_resources`
+- `product_resources`
+
+### `ops`
+
+同期・インポートの運用情報。
+
+- `sync_runs`
+- `source_sync_state`
+
+## 設計原則
+
+1. GitHub / Notion / Supabase 等から Source of Truth を奪わない。
+2. 原文を無条件に複製しない。
+3. Product と Repository を 1:1 に固定しない。
+4. Provider と concrete instance を分離する。
+5. 関係には `source` / `confidence` / `verified_at` を残す。
+6. 推測リンクを確定事実として扱わない。
+7. secret / token を格納しない。
+8. V1 の custom schemas は Data API に直接公開しない。
+9. 将来用途のために generic EAV を作らず、実需要が出た domain だけ追加する。
+
+## 初期 GitHub inventory
+
+2026-08-30 時点で GitHub connected account から 20 repositories を確認済み。
+
+事実 inventory と Product classification は分離する。
+
+- Repository facts: GitHub connector 由来として同期可能
+- Product classification: Workspace Core の人間/AI判断として provisional から開始
+
+初期 mapping では以下の multi-repository Product を明示する。
+
+- `todo-app`
+  - `todo-app` = frontend
+  - `todo-app-backend` = backend
+- `market-info`
+  - `market_info` = data pipeline
+  - `market-info-api` = API
+
+その他はまず同名/明示的な Repository を Product に 1:1 で仮紐付けし、後続の棚卸しで統合・分割を判断する。
+
+## V1 phase
+
+### Phase 1: Schema bootstrap
+
+- [x] `platform / registry / ops` boundary を定義
+- [x] V1 schema SQL を作成
+- [x] private grants / RLS 方針を組み込む
+- [x] provenance / confidence を関係テーブルへ組み込む
+- [ ] dedicated Supabase Project を作成
+- [ ] schema SQL を適用
+- [ ] security / performance advisors を確認
+
+### Phase 2: Initial inventory
+
+- [x] GitHub 20 repositories を取得
+- [x] authoritative repository seed を作成
+- [x] Product classification を別 seed として作成
+- [ ] dedicated Project に repository seed を適用
+- [ ] 20件であることを検証
+- [ ] provisional Product mapping をレビュー・適用
+
+### Phase 3: Discovery
+
+Repository の manifest / config から証拠付きで検出する。
+
+候補:
+
+- `package.json`
+- lockfiles
+- `pyproject.toml`
+- `requirements*.txt`
+- `Dockerfile`
+- `.github/workflows/*`
+- `.env*.example`
+- framework config
+
+保存先:
+
+- `product_technologies`
+- `service_instances`
+- `product_service_links`
+
+自動検出は `source` と `evidence_uri` を必須とし、コード上に証拠がないものを推測登録しない。
+
+### Phase 4: External resources
+
+GitHub Issue / PR / docs / Notion page を `external_resources` としてリンクする。
+
+原則は本文コピーではなく pointer + summary。
+
+### Phase 5: UI
+
+グラフに有用な relation が十分蓄積してから mini-tools に Product Map を追加する。
+
+V1 database bootstrap より UI を先に作らない。
+
+## Security
+
+Supabase の 2026 年の Data API 変更を踏まえ、新規 Project では custom schema を private のまま開始する。
+
+- `anon` / `authenticated` へ schema/table grant を与えない
+- RLS enabled
+- client policy なし
+- `service_role` / privileged server-side path のみ
+
+将来 UI が必要になった場合は、registry 全体を公開するのではなく dedicated `api` schema または server route を優先する。
+
+## Project 作成前のゲート
+
+Supabase Project の作成は最後の Free 枠を消費するため、以下が揃ってから実行する。
+
+- schema SQL がレビュー可能
+- initial inventory が確認可能
+- Project の organization / region / cost confirmation が明示済み
+
+Project 名は用途固定名を避け、現時点の第一候補を `workspace-core` とする。
+
+## Done criteria for V1 bootstrap
+
+- dedicated Workspace Core Supabase Project が存在する
+- `platform / registry / ops` が作成済み
+- security advisor の重大指摘がない
+- 20 GitHub repositories が authoritative inventory として登録済み
+- Product classification が repository facts と分離されている
+- `mini-tools -> Supabase mini-tools` relation が登録済み
+- `mini-tools -> market-info` / `mini-tools -> stock-notes` API relation が登録済み
+- secret が一切保存されていない
+- ChatGPT から SQL query で Product / Repository / Service relation を辿れる

--- a/infra/workspace-core/README.md
+++ b/infra/workspace-core/README.md
@@ -1,0 +1,124 @@
+# Workspace Core Supabase
+
+This directory contains the bootstrap design for the **future second Supabase project** used as a personal structured control plane.
+
+It is deliberately **not** named `product-db` or `dev-db`. The project should be able to host additional domains later without making development inventory the root concept.
+
+## Boundary
+
+```text
+Workspace Core Supabase project
+├─ platform   # source systems, domains, shared metadata/governance primitives
+├─ registry   # V1: products, repos, technologies, services, resources, relations
+├─ ops        # sync/import state
+└─ future     # knowledge / automation / research / other domains as needed
+```
+
+Only the first three schemas are created in V1. Future schemas should be added only when an actual use case exists.
+
+## Source-of-truth policy
+
+Workspace Core is a **catalog and relationship graph**, not a content warehouse.
+
+- GitHub stays authoritative for code, repositories, Issues, PRs, Actions, and repository metadata.
+- Supabase projects stay authoritative for their operational database state.
+- Notion can remain a source/archive for long-form text and historical notes when the original lives there, but it is not required to be the daily human UI.
+- Runtime platforms such as Vercel / Google Cloud / Cloudflare remain authoritative for their live deployment configuration.
+- ChatGPT is expected to become the primary conversational interface that traverses these systems.
+
+Workspace Core stores structured identity, location, relationship, provenance, confidence, and sync metadata so an agent can answer questions such as:
+
+- Which products use Supabase?
+- Which repositories belong to this product?
+- What consumes the Market Info API?
+- Which services would be affected if a provider is unavailable?
+- Where is the original design note / Issue / decision for this product?
+
+## Security model (V1)
+
+`platform`, `registry`, and `ops` are private custom schemas.
+
+V1 intentionally does **not** expose them to `anon` or `authenticated` through the Supabase Data API. RLS is enabled as defense in depth, but no client policies are created yet.
+
+Initial access is intended through:
+
+1. Supabase management/database tooling used by ChatGPT or development agents.
+2. Server-side service access when a sync/import job is introduced.
+
+If mini-tools later needs browser/client access, prefer a small dedicated `api` schema or server route rather than exposing the entire registry directly.
+
+Never store secrets, API keys, passwords, access tokens, service-role keys, or private credentials in registry metadata.
+
+## Files
+
+- `sql/001_registry_schema.sql`
+  - creates `platform`, `registry`, and `ops`
+  - creates the V1 tables, constraints, indexes, RLS, and private grants
+- `sql/002_seed_sources_and_repositories.sql`
+  - seeds source systems / service providers
+  - records the verified existing mini-tools Supabase service instance
+  - imports the 20 GitHub repositories discovered on 2026-08-30
+- `sql/003_seed_products_provisional.sql`
+  - creates an initial Product layer separately from repository facts
+  - explicitly marks Product classifications as provisional
+  - links known multi-repository products (`todo-app`, `market-info`)
+  - adds verified mini-tools relationships supported by current repository configuration
+
+## Bootstrap order
+
+Do not apply these files to the existing `mini-tools` Supabase project.
+
+After the dedicated Workspace Core project is explicitly created:
+
+1. Apply `001_registry_schema.sql`.
+2. Verify schemas/tables and run Supabase security/performance advisors.
+3. Apply `002_seed_sources_and_repositories.sql`.
+4. Verify exactly 20 GitHub repository rows are present.
+5. Review provisional Product classification.
+6. Apply `003_seed_products_provisional.sql`.
+7. Verify Product ↔ Repository and Product ↔ Service relations.
+8. Only then begin technology/service auto-discovery.
+
+## V1 acceptance checks
+
+```sql
+select count(*) from registry.repositories;
+-- expected: 20 immediately after the initial GitHub seed
+
+select count(*) from registry.products;
+-- expected: 18 after provisional product seed
+
+select p.slug, r.full_name, pr.role, pr.confidence
+from registry.product_repositories pr
+join registry.products p on p.id = pr.product_id
+join registry.repositories r on r.id = pr.repository_id
+order by p.slug, pr.is_primary desc, r.full_name;
+
+select src.slug as source_product,
+       rel.relation_type,
+       dst.slug as target_product,
+       rel.source,
+       rel.confidence
+from registry.product_relations rel
+join registry.products src on src.id = rel.source_product_id
+join registry.products dst on dst.id = rel.target_product_id
+order by src.slug, rel.relation_type, dst.slug;
+```
+
+## Non-goals for V1
+
+- Copying all Notion page bodies into Supabase.
+- Copying all GitHub Issue / PR bodies into Supabase.
+- Storing secrets.
+- Two-way sync with every provider.
+- A generic EAV database for arbitrary future data.
+- Building a separate UI before the registry proves useful through agent queries.
+
+## Next implementation step
+
+After database bootstrap, implement the first discovery loop:
+
+1. GitHub repository sync.
+2. Manifest/config inspection (`package.json`, lockfiles, Python dependency files, Dockerfiles, workflows, env examples).
+3. Evidence-backed `product_technologies` / service link upserts.
+4. Optional mini-tools Product Map UI once the graph contains enough useful relations.

--- a/infra/workspace-core/README.md
+++ b/infra/workspace-core/README.md
@@ -63,6 +63,10 @@ Never store secrets, API keys, passwords, access tokens, service-role keys, or p
   - explicitly marks Product classifications as provisional
   - links known multi-repository products (`todo-app`, `market-info`)
   - adds verified mini-tools relationships supported by current repository configuration
+- `sql/004_schema_hardening.sql`
+  - adds provider account/team scope to service instances
+  - hardens uniqueness so identical project names can exist in different provider accounts
+  - adds reverse-FK indexes and operational counter checks
 
 ## Bootstrap order
 
@@ -71,13 +75,16 @@ Do not apply these files to the existing `mini-tools` Supabase project.
 After the dedicated Workspace Core project is explicitly created:
 
 1. Apply `001_registry_schema.sql`.
-2. Verify schemas/tables and run Supabase security/performance advisors.
-3. Apply `002_seed_sources_and_repositories.sql`.
-4. Verify exactly 20 GitHub repository rows are present.
-5. Review provisional Product classification.
-6. Apply `003_seed_products_provisional.sql`.
-7. Verify Product ↔ Repository and Product ↔ Service relations.
-8. Only then begin technology/service auto-discovery.
+2. Apply `002_seed_sources_and_repositories.sql`.
+3. Verify exactly 20 GitHub repository rows are present.
+4. Review provisional Product classification.
+5. Apply `003_seed_products_provisional.sql`.
+6. Apply `004_schema_hardening.sql`.
+7. Run Supabase security/performance advisors and fix any meaningful findings.
+8. Verify Product ↔ Repository, Product ↔ Service, and Product ↔ Product relations.
+9. Only then begin technology/service auto-discovery.
+
+The seed files use stable external identifiers wherever available so future refreshes can upsert rather than duplicate records.
 
 ## V1 acceptance checks
 
@@ -103,6 +110,16 @@ from registry.product_relations rel
 join registry.products src on src.id = rel.source_product_id
 join registry.products dst on dst.id = rel.target_product_id
 order by src.slug, rel.relation_type, dst.slug;
+
+select sp.slug as provider,
+       si.account_scope,
+       si.name,
+       si.environment,
+       si.external_id,
+       si.region
+from registry.service_instances si
+join registry.service_providers sp on sp.id = si.provider_id
+order by sp.slug, si.account_scope, si.name, si.environment;
 ```
 
 ## Non-goals for V1

--- a/infra/workspace-core/sql/001_registry_schema.sql
+++ b/infra/workspace-core/sql/001_registry_schema.sql
@@ -1,0 +1,398 @@
+-- Workspace Core V1
+--
+-- IMPORTANT:
+--   This schema is for the future dedicated Workspace Core Supabase project.
+--   Do NOT apply it to the existing mini-tools Supabase project.
+--
+-- Security model (V1):
+--   - platform / registry / ops are private custom schemas.
+--   - They are not intended to be exposed through the Supabase Data API yet.
+--   - anon/authenticated receive no schema privileges.
+--   - RLS is enabled as defense in depth; no client policies are created in V1.
+--   - service_role / direct database access is the initial integration path.
+
+begin;
+
+create extension if not exists pgcrypto;
+
+create schema if not exists platform;
+create schema if not exists registry;
+create schema if not exists ops;
+
+comment on schema platform is 'Workspace-wide metadata, source systems, domains, and governance primitives.';
+comment on schema registry is 'Structured registry of products, repositories, technologies, services, resources, and their relationships.';
+comment on schema ops is 'Synchronization state, import runs, and operational metadata for Workspace Core.';
+
+-- Keep the initial schemas private. If a future UI needs direct Data API access,
+-- expose a dedicated API schema or add explicit grants + RLS policies then.
+revoke all on schema platform from public, anon, authenticated;
+revoke all on schema registry from public, anon, authenticated;
+revoke all on schema ops from public, anon, authenticated;
+
+grant usage on schema platform, registry, ops to service_role;
+
+create or replace function platform.touch_updated_at()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+comment on function platform.touch_updated_at() is 'Shared updated_at trigger for Workspace Core tables.';
+
+create table if not exists platform.domains (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  name text not null,
+  description text,
+  lifecycle_status text not null default 'active'
+    check (lifecycle_status in ('planned', 'active', 'paused', 'retired')),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table platform.domains is 'Top-level logical domains hosted by Workspace Core. Keeps the project broader than a development-only database.';
+
+create table if not exists platform.source_systems (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  name text not null,
+  system_type text not null,
+  source_of_truth_scope text,
+  base_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table platform.source_systems is 'External systems that remain authoritative for their own content, such as GitHub, Notion, and Supabase.';
+
+create table if not exists registry.products (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  description text,
+  product_type text not null default 'application'
+    check (product_type in ('application', 'service', 'automation', 'library', 'infrastructure', 'knowledge', 'experiment', 'other')),
+  lifecycle_status text not null default 'active'
+    check (lifecycle_status in ('planned', 'experimental', 'active', 'paused', 'archived', 'unknown')),
+  importance smallint not null default 2
+    check (importance between 0 and 5),
+  domain_id uuid references platform.domains(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table registry.products is 'Human-defined product or durable asset concepts. A product is intentionally not constrained to one repository.';
+
+create table if not exists registry.repositories (
+  id uuid primary key default gen_random_uuid(),
+  source_system_id uuid not null references platform.source_systems(id) on delete restrict,
+  external_id text not null,
+  owner_name text not null,
+  repo_name text not null,
+  full_name text not null,
+  visibility text not null default 'private'
+    check (visibility in ('public', 'private', 'internal', 'unknown')),
+  default_branch text,
+  archived boolean not null default false,
+  html_url text,
+  size_kb bigint,
+  last_synced_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (source_system_id, external_id),
+  unique (source_system_id, full_name)
+);
+
+comment on table registry.repositories is 'Repository metadata mirrored from the authoritative SCM. Content, Issues, PRs, and code remain in GitHub.';
+
+create table if not exists registry.product_repositories (
+  product_id uuid not null references registry.products(id) on delete cascade,
+  repository_id uuid not null references registry.repositories(id) on delete cascade,
+  role text not null default 'primary',
+  is_primary boolean not null default false,
+  source text not null default 'manual',
+  confidence numeric(4,3) not null default 1.000
+    check (confidence >= 0 and confidence <= 1),
+  verified_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (product_id, repository_id)
+);
+
+comment on table registry.product_repositories is 'Many-to-many mapping between products and repositories, including provenance and confidence.';
+
+create table if not exists registry.technologies (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  category text not null,
+  layer text,
+  homepage_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists registry.product_technologies (
+  product_id uuid not null references registry.products(id) on delete cascade,
+  technology_id uuid not null references registry.technologies(id) on delete cascade,
+  role text,
+  version text,
+  source text not null,
+  confidence numeric(4,3) not null default 1.000
+    check (confidence >= 0 and confidence <= 1),
+  evidence_uri text,
+  last_verified_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (product_id, technology_id)
+);
+
+comment on table registry.product_technologies is 'Technology usage with evidence. Auto-detected and manually asserted facts use the same provenance model.';
+
+create table if not exists registry.service_providers (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  category text not null,
+  homepage_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists registry.service_instances (
+  id uuid primary key default gen_random_uuid(),
+  provider_id uuid not null references registry.service_providers(id) on delete restrict,
+  external_id text,
+  name text not null,
+  environment text not null default 'production',
+  region text,
+  url text,
+  status text not null default 'active'
+    check (status in ('planned', 'active', 'paused', 'retired', 'unknown')),
+  metadata jsonb not null default '{}'::jsonb,
+  last_synced_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (provider_id, name, environment)
+);
+
+create unique index if not exists service_instances_provider_external_id_uidx
+  on registry.service_instances(provider_id, external_id)
+  where external_id is not null;
+
+comment on table registry.service_instances is 'Concrete projects/deployments/accounts under a provider, e.g. the mini-tools Supabase project.';
+
+create table if not exists registry.product_service_links (
+  product_id uuid not null references registry.products(id) on delete cascade,
+  service_instance_id uuid not null references registry.service_instances(id) on delete cascade,
+  relation_type text not null,
+  environment text,
+  source text not null default 'manual',
+  confidence numeric(4,3) not null default 1.000
+    check (confidence >= 0 and confidence <= 1),
+  verified_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (product_id, service_instance_id, relation_type)
+);
+
+create table if not exists registry.product_relations (
+  source_product_id uuid not null references registry.products(id) on delete cascade,
+  target_product_id uuid not null references registry.products(id) on delete cascade,
+  relation_type text not null,
+  source text not null default 'manual',
+  confidence numeric(4,3) not null default 1.000
+    check (confidence >= 0 and confidence <= 1),
+  verified_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (source_product_id, target_product_id, relation_type),
+  check (source_product_id <> target_product_id)
+);
+
+comment on table registry.product_relations is 'Directed product dependency/relationship graph such as consumes_api, produces_data_for, or successor_of.';
+
+create table if not exists registry.external_resources (
+  id uuid primary key default gen_random_uuid(),
+  source_system_id uuid not null references platform.source_systems(id) on delete restrict,
+  external_id text not null,
+  resource_type text not null,
+  title text,
+  url text,
+  summary text,
+  status text,
+  last_synced_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (source_system_id, external_id, resource_type)
+);
+
+comment on table registry.external_resources is 'Pointers and concise structured metadata for Issues, PRs, Notion pages, docs, decisions, and similar external resources. Full bodies are not copied by default.';
+
+create table if not exists registry.product_resources (
+  product_id uuid not null references registry.products(id) on delete cascade,
+  resource_id uuid not null references registry.external_resources(id) on delete cascade,
+  relation_type text not null default 'reference',
+  is_primary boolean not null default false,
+  source text not null default 'manual',
+  confidence numeric(4,3) not null default 1.000
+    check (confidence >= 0 and confidence <= 1),
+  verified_at timestamptz,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (product_id, resource_id, relation_type)
+);
+
+create table if not exists ops.sync_runs (
+  id uuid primary key default gen_random_uuid(),
+  source_system_id uuid references platform.source_systems(id) on delete set null,
+  scope text not null,
+  status text not null
+    check (status in ('running', 'succeeded', 'partial', 'failed')),
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  records_seen integer not null default 0,
+  records_inserted integer not null default 0,
+  records_updated integer not null default 0,
+  error_summary text,
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table if not exists ops.source_sync_state (
+  source_system_id uuid not null references platform.source_systems(id) on delete cascade,
+  resource_kind text not null,
+  cursor text,
+  status text not null default 'never_run'
+    check (status in ('never_run', 'ok', 'partial', 'error')),
+  last_attempt_at timestamptz,
+  last_success_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now(),
+  primary key (source_system_id, resource_kind)
+);
+
+-- Useful indexes for conversational/agent lookups.
+create index if not exists repositories_full_name_idx on registry.repositories(full_name);
+create index if not exists products_lifecycle_idx on registry.products(lifecycle_status);
+create index if not exists product_service_links_relation_idx on registry.product_service_links(relation_type);
+create index if not exists product_relations_type_idx on registry.product_relations(relation_type);
+create index if not exists external_resources_url_idx on registry.external_resources(url);
+create index if not exists sync_runs_started_at_idx on ops.sync_runs(started_at desc);
+
+-- Defense in depth. Because these schemas are private in V1, no anon/authenticated
+-- policies are created; service_role and direct privileged DB connections remain usable.
+alter table platform.domains enable row level security;
+alter table platform.source_systems enable row level security;
+alter table registry.products enable row level security;
+alter table registry.repositories enable row level security;
+alter table registry.product_repositories enable row level security;
+alter table registry.technologies enable row level security;
+alter table registry.product_technologies enable row level security;
+alter table registry.service_providers enable row level security;
+alter table registry.service_instances enable row level security;
+alter table registry.product_service_links enable row level security;
+alter table registry.product_relations enable row level security;
+alter table registry.external_resources enable row level security;
+alter table registry.product_resources enable row level security;
+alter table ops.sync_runs enable row level security;
+alter table ops.source_sync_state enable row level security;
+
+-- Keep client roles explicitly locked out even if schema exposure changes accidentally.
+revoke all on all tables in schema platform from public, anon, authenticated;
+revoke all on all tables in schema registry from public, anon, authenticated;
+revoke all on all tables in schema ops from public, anon, authenticated;
+revoke all on all sequences in schema platform from public, anon, authenticated;
+revoke all on all sequences in schema registry from public, anon, authenticated;
+revoke all on all sequences in schema ops from public, anon, authenticated;
+revoke execute on function platform.touch_updated_at() from public, anon, authenticated;
+
+grant select, insert, update, delete on all tables in schema platform to service_role;
+grant select, insert, update, delete on all tables in schema registry to service_role;
+grant select, insert, update, delete on all tables in schema ops to service_role;
+grant usage, select on all sequences in schema platform to service_role;
+grant usage, select on all sequences in schema registry to service_role;
+grant usage, select on all sequences in schema ops to service_role;
+grant execute on function platform.touch_updated_at() to service_role;
+
+alter default privileges for role postgres in schema platform revoke all on tables from public, anon, authenticated;
+alter default privileges for role postgres in schema registry revoke all on tables from public, anon, authenticated;
+alter default privileges for role postgres in schema ops revoke all on tables from public, anon, authenticated;
+alter default privileges for role postgres in schema platform grant select, insert, update, delete on tables to service_role;
+alter default privileges for role postgres in schema registry grant select, insert, update, delete on tables to service_role;
+alter default privileges for role postgres in schema ops grant select, insert, update, delete on tables to service_role;
+
+-- updated_at triggers
+create trigger domains_touch_updated_at
+before update on platform.domains
+for each row execute function platform.touch_updated_at();
+
+create trigger source_systems_touch_updated_at
+before update on platform.source_systems
+for each row execute function platform.touch_updated_at();
+
+create trigger products_touch_updated_at
+before update on registry.products
+for each row execute function platform.touch_updated_at();
+
+create trigger repositories_touch_updated_at
+before update on registry.repositories
+for each row execute function platform.touch_updated_at();
+
+create trigger product_repositories_touch_updated_at
+before update on registry.product_repositories
+for each row execute function platform.touch_updated_at();
+
+create trigger technologies_touch_updated_at
+before update on registry.technologies
+for each row execute function platform.touch_updated_at();
+
+create trigger product_technologies_touch_updated_at
+before update on registry.product_technologies
+for each row execute function platform.touch_updated_at();
+
+create trigger service_providers_touch_updated_at
+before update on registry.service_providers
+for each row execute function platform.touch_updated_at();
+
+create trigger service_instances_touch_updated_at
+before update on registry.service_instances
+for each row execute function platform.touch_updated_at();
+
+create trigger product_service_links_touch_updated_at
+before update on registry.product_service_links
+for each row execute function platform.touch_updated_at();
+
+create trigger product_relations_touch_updated_at
+before update on registry.product_relations
+for each row execute function platform.touch_updated_at();
+
+create trigger external_resources_touch_updated_at
+before update on registry.external_resources
+for each row execute function platform.touch_updated_at();
+
+create trigger product_resources_touch_updated_at
+before update on registry.product_resources
+for each row execute function platform.touch_updated_at();
+
+create trigger source_sync_state_touch_updated_at
+before update on ops.source_sync_state
+for each row execute function platform.touch_updated_at();
+
+commit;

--- a/infra/workspace-core/sql/002_seed_sources_and_repositories.sql
+++ b/infra/workspace-core/sql/002_seed_sources_and_repositories.sql
@@ -65,8 +65,9 @@ select
   now()
 from registry.service_providers sp
 where sp.slug = 'supabase'
-on conflict (provider_id, name, environment) do update
-set external_id = excluded.external_id,
+on conflict (provider_id, external_id) where external_id is not null do update
+set name = excluded.name,
+    environment = excluded.environment,
     region = excluded.region,
     status = excluded.status,
     metadata = registry.service_instances.metadata || excluded.metadata,

--- a/infra/workspace-core/sql/002_seed_sources_and_repositories.sql
+++ b/infra/workspace-core/sql/002_seed_sources_and_repositories.sql
@@ -1,0 +1,156 @@
+-- Workspace Core V1 initial authoritative inventory.
+-- Source: GitHub connected account inventory captured 2026-08-30.
+-- This file is intended for the future Workspace Core Supabase project only.
+
+begin;
+
+insert into platform.domains (code, name, description)
+values (
+  'development',
+  'Development',
+  'Products, repositories, technologies, runtime services, and development relationships.'
+)
+on conflict (code) do update
+set name = excluded.name,
+    description = excluded.description;
+
+insert into platform.source_systems (code, name, system_type, source_of_truth_scope, base_url)
+values
+  ('github', 'GitHub', 'scm', 'Code, repositories, Issues, Pull Requests, Actions, and repository metadata.', 'https://github.com'),
+  ('notion', 'Notion', 'knowledge_base', 'Long-form notes, source text, historical knowledge, and reference pages when Notion is the originating store.', 'https://www.notion.so'),
+  ('supabase', 'Supabase', 'database_platform', 'Operational database projects, database state, and Supabase-managed runtime configuration.', 'https://supabase.com')
+on conflict (code) do update
+set name = excluded.name,
+    system_type = excluded.system_type,
+    source_of_truth_scope = excluded.source_of_truth_scope,
+    base_url = excluded.base_url;
+
+insert into registry.service_providers (slug, name, category, homepage_url)
+values
+  ('github', 'GitHub', 'source-control', 'https://github.com'),
+  ('supabase', 'Supabase', 'database-platform', 'https://supabase.com'),
+  ('vercel', 'Vercel', 'hosting', 'https://vercel.com'),
+  ('google-cloud', 'Google Cloud', 'cloud-platform', 'https://cloud.google.com'),
+  ('cloudflare', 'Cloudflare', 'edge-and-storage', 'https://www.cloudflare.com'),
+  ('notion', 'Notion', 'knowledge-platform', 'https://www.notion.so'),
+  ('openai', 'OpenAI', 'ai-platform', 'https://openai.com'),
+  ('anthropic', 'Anthropic', 'ai-platform', 'https://www.anthropic.com')
+on conflict (slug) do update
+set name = excluded.name,
+    category = excluded.category,
+    homepage_url = excluded.homepage_url;
+
+-- Verified existing Supabase instance. Do not store API keys or secrets here.
+insert into registry.service_instances (
+  provider_id,
+  external_id,
+  name,
+  environment,
+  region,
+  status,
+  metadata,
+  last_synced_at
+)
+select
+  sp.id,
+  'uqnkjitvuebwhjvmaddb',
+  'mini-tools',
+  'production',
+  'ap-northeast-1',
+  'active',
+  jsonb_build_object(
+    'postgres_version', '17.6.1.127',
+    'inventory_source', 'supabase_connector'
+  ),
+  now()
+from registry.service_providers sp
+where sp.slug = 'supabase'
+on conflict (provider_id, name, environment) do update
+set external_id = excluded.external_id,
+    region = excluded.region,
+    status = excluded.status,
+    metadata = registry.service_instances.metadata || excluded.metadata,
+    last_synced_at = excluded.last_synced_at;
+
+with github_source as (
+  select id from platform.source_systems where code = 'github'
+), inventory (
+  external_id,
+  owner_name,
+  repo_name,
+  full_name,
+  visibility,
+  default_branch,
+  archived,
+  html_url,
+  size_kb,
+  code_search_indexed
+) as (
+  values
+    ('1001986992', 'Yuichi-TanakaJP', 'todo-app', 'Yuichi-TanakaJP/todo-app', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/todo-app', 101, false),
+    ('1039456794', 'Yuichi-TanakaJP', 'todo-app-backend', 'Yuichi-TanakaJP/todo-app-backend', 'public', 'main', false, 'https://github.com/Yuichi-TanakaJP/todo-app-backend', 24, false),
+    ('1041392639', 'Yuichi-TanakaJP', 'data-gallery', 'Yuichi-TanakaJP/data-gallery', 'public', 'main', false, 'https://github.com/Yuichi-TanakaJP/data-gallery', 158, false),
+    ('1069558714', 'Yuichi-TanakaJP', 'market_info', 'Yuichi-TanakaJP/market_info', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/market_info', 2935, true),
+    ('1101866652', 'Yuichi-TanakaJP', 'test_antigravity', 'Yuichi-TanakaJP/test_antigravity', 'private', 'design-refinement-sensoria', true, 'https://github.com/Yuichi-TanakaJP/test_antigravity', 39, false),
+    ('1119637009', 'Yuichi-TanakaJP', 'mini-tools', 'Yuichi-TanakaJP/mini-tools', 'public', 'main', false, 'https://github.com/Yuichi-TanakaJP/mini-tools', 6598, true),
+    ('1131985490', 'Yuichi-TanakaJP', 'sensoria-portfolio', 'Yuichi-TanakaJP/sensoria-portfolio', 'public', 'main', false, 'https://github.com/Yuichi-TanakaJP/sensoria-portfolio', 715, false),
+    ('1175249672', 'Yuichi-TanakaJP', 'notion-script', 'Yuichi-TanakaJP/notion-script', 'public', 'master', false, 'https://github.com/Yuichi-TanakaJP/notion-script', 28, false),
+    ('1194923339', 'Yuichi-TanakaJP', 'market-info-api', 'Yuichi-TanakaJP/market-info-api', 'public', 'main', false, 'https://github.com/Yuichi-TanakaJP/market-info-api', 236, false),
+    ('1215176930', 'Yuichi-TanakaJP', 'rag-workbench', 'Yuichi-TanakaJP/rag-workbench', 'private', 'master', false, 'https://github.com/Yuichi-TanakaJP/rag-workbench', 50, false),
+    ('1241531166', 'Yuichi-TanakaJP', 'test_line_news', 'Yuichi-TanakaJP/test_line_news', 'public', 'main', false, 'https://github.com/Yuichi-TanakaJP/test_line_news', 111, true),
+    ('1270261854', 'Yuichi-TanakaJP', 'test_trade', 'Yuichi-TanakaJP/test_trade', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/test_trade', 880, false),
+    ('1278265070', 'Yuichi-TanakaJP', 'portfolio_x_post', 'Yuichi-TanakaJP/portfolio_x_post', 'private', 'master', false, 'https://github.com/Yuichi-TanakaJP/portfolio_x_post', 181, false),
+    ('1282600145', 'Yuichi-TanakaJP', 'test_ISN', 'Yuichi-TanakaJP/test_ISN', 'private', 'master', false, 'https://github.com/Yuichi-TanakaJP/test_ISN', 244, false),
+    ('1289757039', 'Yuichi-TanakaJP', 'ideas', 'Yuichi-TanakaJP/ideas', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/ideas', 86, false),
+    ('1297399438', 'Yuichi-TanakaJP', 'test_english', 'Yuichi-TanakaJP/test_english', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/test_english', 224, false),
+    ('1298383716', 'Yuichi-TanakaJP', 'repo-templates', 'Yuichi-TanakaJP/repo-templates', 'private', 'master', false, 'https://github.com/Yuichi-TanakaJP/repo-templates', 17, false),
+    ('1299392248', 'Yuichi-TanakaJP', 'claude-skills', 'Yuichi-TanakaJP/claude-skills', 'private', 'master', false, 'https://github.com/Yuichi-TanakaJP/claude-skills', 32, false),
+    ('1318887380', 'Yuichi-TanakaJP', 'stock-notes', 'Yuichi-TanakaJP/stock-notes', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/stock-notes', 816, false),
+    ('1330965207', 'Yuichi-TanakaJP', 'pc-saas-health-monitor', 'Yuichi-TanakaJP/pc-saas-health-monitor', 'private', 'main', false, 'https://github.com/Yuichi-TanakaJP/pc-saas-health-monitor', 1987, false)
+)
+insert into registry.repositories (
+  source_system_id,
+  external_id,
+  owner_name,
+  repo_name,
+  full_name,
+  visibility,
+  default_branch,
+  archived,
+  html_url,
+  size_kb,
+  last_synced_at,
+  metadata
+)
+select
+  github_source.id,
+  inventory.external_id,
+  inventory.owner_name,
+  inventory.repo_name,
+  inventory.full_name,
+  inventory.visibility,
+  inventory.default_branch,
+  inventory.archived,
+  inventory.html_url,
+  inventory.size_kb,
+  now(),
+  jsonb_build_object(
+    'code_search_indexed', inventory.code_search_indexed,
+    'inventory_source', 'github_connector',
+    'inventory_captured_at', '2026-08-30'
+  )
+from github_source
+cross join inventory
+on conflict (source_system_id, external_id) do update
+set owner_name = excluded.owner_name,
+    repo_name = excluded.repo_name,
+    full_name = excluded.full_name,
+    visibility = excluded.visibility,
+    default_branch = excluded.default_branch,
+    archived = excluded.archived,
+    html_url = excluded.html_url,
+    size_kb = excluded.size_kb,
+    last_synced_at = excluded.last_synced_at,
+    metadata = registry.repositories.metadata || excluded.metadata;
+
+commit;

--- a/infra/workspace-core/sql/003_seed_products_provisional.sql
+++ b/infra/workspace-core/sql/003_seed_products_provisional.sql
@@ -1,0 +1,182 @@
+-- Workspace Core V1 provisional Product <-> Repository classification.
+--
+-- This is intentionally separate from the authoritative GitHub repository seed.
+-- Repository facts come from GitHub; Product concepts are human/AI classifications
+-- and may be refined later without altering the source inventory.
+--
+-- The metadata field marks this classification as provisional.
+
+begin;
+
+with development_domain as (
+  select id from platform.domains where code = 'development'
+), product_seed (slug, name, product_type, lifecycle_status, importance) as (
+  values
+    ('todo-app', 'Todo App', 'application', 'active', 2),
+    ('data-gallery', 'Data Gallery', 'application', 'active', 2),
+    ('market-info', 'Market Info', 'automation', 'active', 4),
+    ('test-antigravity', 'Test Antigravity', 'experiment', 'archived', 0),
+    ('mini-tools', 'Mini Tools', 'application', 'active', 5),
+    ('sensoria-portfolio', 'Sensoria Portfolio', 'application', 'active', 2),
+    ('notion-script', 'Notion Script', 'automation', 'active', 1),
+    ('rag-workbench', 'RAG Workbench', 'experiment', 'active', 2),
+    ('test-line-news', 'Test LINE News', 'experiment', 'active', 1),
+    ('test-trade', 'Test Trade', 'experiment', 'active', 2),
+    ('portfolio-x-post', 'Portfolio X Post', 'automation', 'active', 2),
+    ('test-isn', 'Test ISN', 'experiment', 'active', 1),
+    ('ideas', 'Ideas', 'knowledge', 'active', 1),
+    ('test-english', 'Test English', 'experiment', 'active', 1),
+    ('repo-templates', 'Repository Templates', 'infrastructure', 'active', 2),
+    ('claude-skills', 'Claude Skills', 'library', 'active', 2),
+    ('stock-notes', 'Stock Notes', 'service', 'active', 5),
+    ('pc-saas-health-monitor', 'PC / SaaS Health Monitor', 'application', 'experimental', 3)
+)
+insert into registry.products (
+  slug,
+  name,
+  product_type,
+  lifecycle_status,
+  importance,
+  domain_id,
+  metadata
+)
+select
+  product_seed.slug,
+  product_seed.name,
+  product_seed.product_type,
+  product_seed.lifecycle_status,
+  product_seed.importance,
+  development_domain.id,
+  jsonb_build_object(
+    'classification_status', 'provisional',
+    'classification_source', 'workspace-core-v1-initial-inventory',
+    'classified_at', '2026-08-30'
+  )
+from development_domain
+cross join product_seed
+on conflict (slug) do update
+set name = excluded.name,
+    product_type = excluded.product_type,
+    lifecycle_status = excluded.lifecycle_status,
+    importance = excluded.importance,
+    domain_id = excluded.domain_id,
+    metadata = registry.products.metadata || excluded.metadata;
+
+-- Same-name repositories and known multi-repository products.
+with mappings (product_slug, repo_full_name, role, is_primary, confidence, notes) as (
+  values
+    ('todo-app', 'Yuichi-TanakaJP/todo-app', 'frontend', true, 1.000::numeric, 'Repository name directly matches the product concept.'),
+    ('todo-app', 'Yuichi-TanakaJP/todo-app-backend', 'backend', false, 0.990::numeric, 'Backend repository name explicitly identifies it as part of todo-app.'),
+    ('data-gallery', 'Yuichi-TanakaJP/data-gallery', 'primary', true, 1.000::numeric, null),
+    ('market-info', 'Yuichi-TanakaJP/market_info', 'data-pipeline', true, 1.000::numeric, 'Primary market data automation repository.'),
+    ('market-info', 'Yuichi-TanakaJP/market-info-api', 'api', false, 0.990::numeric, 'API repository explicitly named for market-info.'),
+    ('test-antigravity', 'Yuichi-TanakaJP/test_antigravity', 'primary', true, 1.000::numeric, null),
+    ('mini-tools', 'Yuichi-TanakaJP/mini-tools', 'primary', true, 1.000::numeric, null),
+    ('sensoria-portfolio', 'Yuichi-TanakaJP/sensoria-portfolio', 'primary', true, 1.000::numeric, null),
+    ('notion-script', 'Yuichi-TanakaJP/notion-script', 'primary', true, 1.000::numeric, null),
+    ('rag-workbench', 'Yuichi-TanakaJP/rag-workbench', 'primary', true, 1.000::numeric, null),
+    ('test-line-news', 'Yuichi-TanakaJP/test_line_news', 'primary', true, 1.000::numeric, null),
+    ('test-trade', 'Yuichi-TanakaJP/test_trade', 'primary', true, 1.000::numeric, null),
+    ('portfolio-x-post', 'Yuichi-TanakaJP/portfolio_x_post', 'primary', true, 1.000::numeric, null),
+    ('test-isn', 'Yuichi-TanakaJP/test_ISN', 'primary', true, 1.000::numeric, null),
+    ('ideas', 'Yuichi-TanakaJP/ideas', 'primary', true, 1.000::numeric, null),
+    ('test-english', 'Yuichi-TanakaJP/test_english', 'primary', true, 1.000::numeric, null),
+    ('repo-templates', 'Yuichi-TanakaJP/repo-templates', 'primary', true, 1.000::numeric, null),
+    ('claude-skills', 'Yuichi-TanakaJP/claude-skills', 'primary', true, 1.000::numeric, null),
+    ('stock-notes', 'Yuichi-TanakaJP/stock-notes', 'primary', true, 1.000::numeric, null),
+    ('pc-saas-health-monitor', 'Yuichi-TanakaJP/pc-saas-health-monitor', 'primary', true, 1.000::numeric, null)
+)
+insert into registry.product_repositories (
+  product_id,
+  repository_id,
+  role,
+  is_primary,
+  source,
+  confidence,
+  verified_at,
+  notes
+)
+select
+  p.id,
+  r.id,
+  mappings.role,
+  mappings.is_primary,
+  'github_inventory+classification',
+  mappings.confidence,
+  now(),
+  mappings.notes
+from mappings
+join registry.products p on p.slug = mappings.product_slug
+join registry.repositories r on r.full_name = mappings.repo_full_name
+on conflict (product_id, repository_id) do update
+set role = excluded.role,
+    is_primary = excluded.is_primary,
+    source = excluded.source,
+    confidence = excluded.confidence,
+    verified_at = excluded.verified_at,
+    notes = excluded.notes;
+
+-- Verified relationship: mini-tools uses the existing mini-tools Supabase project.
+insert into registry.product_service_links (
+  product_id,
+  service_instance_id,
+  relation_type,
+  environment,
+  source,
+  confidence,
+  verified_at,
+  notes
+)
+select
+  p.id,
+  si.id,
+  'uses_database',
+  'production',
+  'supabase_connector+mini-tools_env',
+  1.000,
+  now(),
+  'Verified from the connected Supabase project inventory and mini-tools Supabase environment configuration.'
+from registry.products p
+join registry.service_instances si on si.name = 'mini-tools' and si.environment = 'production'
+join registry.service_providers sp on sp.id = si.provider_id and sp.slug = 'supabase'
+where p.slug = 'mini-tools'
+on conflict (product_id, service_instance_id, relation_type) do update
+set environment = excluded.environment,
+    source = excluded.source,
+    confidence = excluded.confidence,
+    verified_at = excluded.verified_at,
+    notes = excluded.notes;
+
+-- Verified cross-product API relationships from mini-tools/.env.local.example.
+with relation_seed (source_slug, target_slug, relation_type, notes) as (
+  values
+    ('mini-tools', 'market-info', 'consumes_api', 'mini-tools defines MARKET_INFO_API_BASE_URL for the market-info API.'),
+    ('mini-tools', 'stock-notes', 'consumes_api', 'mini-tools defines STOCK_NOTES_API_BASE_URL for the stock-notes API.')
+)
+insert into registry.product_relations (
+  source_product_id,
+  target_product_id,
+  relation_type,
+  source,
+  confidence,
+  verified_at,
+  notes
+)
+select
+  source_product.id,
+  target_product.id,
+  relation_seed.relation_type,
+  'github:mini-tools/.env.local.example',
+  1.000,
+  now(),
+  relation_seed.notes
+from relation_seed
+join registry.products source_product on source_product.slug = relation_seed.source_slug
+join registry.products target_product on target_product.slug = relation_seed.target_slug
+on conflict (source_product_id, target_product_id, relation_type) do update
+set source = excluded.source,
+    confidence = excluded.confidence,
+    verified_at = excluded.verified_at,
+    notes = excluded.notes;
+
+commit;

--- a/infra/workspace-core/sql/003_seed_products_provisional.sql
+++ b/infra/workspace-core/sql/003_seed_products_provisional.sql
@@ -117,6 +117,8 @@ set role = excluded.role,
     notes = excluded.notes;
 
 -- Verified relationship: mini-tools uses the existing mini-tools Supabase project.
+-- Pin by Supabase project ref, not display name, so a future same-name project in
+-- another account/team cannot be linked accidentally.
 insert into registry.product_service_links (
   product_id,
   service_instance_id,
@@ -131,13 +133,13 @@ select
   p.id,
   si.id,
   'uses_database',
-  'production',
+  si.environment,
   'supabase_connector+mini-tools_env',
   1.000,
   now(),
   'Verified from the connected Supabase project inventory and mini-tools Supabase environment configuration.'
 from registry.products p
-join registry.service_instances si on si.name = 'mini-tools' and si.environment = 'production'
+join registry.service_instances si on si.external_id = 'uqnkjitvuebwhjvmaddb'
 join registry.service_providers sp on sp.id = si.provider_id and sp.slug = 'supabase'
 where p.slug = 'mini-tools'
 on conflict (product_id, service_instance_id, relation_type) do update

--- a/infra/workspace-core/sql/004_schema_hardening.sql
+++ b/infra/workspace-core/sql/004_schema_hardening.sql
@@ -19,6 +19,16 @@ alter table registry.service_instances
 comment on column registry.service_instances.account_scope is
   'Organization/team/account scope within the provider. Use a stable external scope ID when available; personal is the V1 fallback.';
 
+-- The existing mini-tools Supabase project is verified to belong to this
+-- organization. Store the stable organization ID rather than relying on a
+-- display label; no credentials are stored.
+update registry.service_instances si
+set account_scope = 'vqrpqdxaxzclhapylbbs'
+from registry.service_providers sp
+where si.provider_id = sp.id
+  and sp.slug = 'supabase'
+  and si.external_id = 'uqnkjitvuebwhjvmaddb';
+
 -- Secondary-side FK indexes keep reverse graph traversal efficient and avoid
 -- unnecessary sequential scans as the registry grows.
 create index if not exists products_domain_id_idx

--- a/infra/workspace-core/sql/004_schema_hardening.sql
+++ b/infra/workspace-core/sql/004_schema_hardening.sql
@@ -1,0 +1,61 @@
+-- Workspace Core V1 schema hardening.
+-- Apply after 001-003 for the initial bootstrap.
+
+begin;
+
+-- A provider can have the same project/deployment name in multiple organizations,
+-- teams, or accounts. Keep that scope explicit instead of treating provider+name
+-- as globally unique.
+alter table registry.service_instances
+  add column if not exists account_scope text not null default 'personal';
+
+alter table registry.service_instances
+  drop constraint if exists service_instances_provider_id_name_environment_key;
+
+alter table registry.service_instances
+  add constraint service_instances_provider_scope_name_environment_key
+  unique (provider_id, account_scope, name, environment);
+
+comment on column registry.service_instances.account_scope is
+  'Organization/team/account scope within the provider. Use a stable external scope ID when available; personal is the V1 fallback.';
+
+-- Secondary-side FK indexes keep reverse graph traversal efficient and avoid
+-- unnecessary sequential scans as the registry grows.
+create index if not exists products_domain_id_idx
+  on registry.products(domain_id);
+
+create index if not exists product_repositories_repository_id_idx
+  on registry.product_repositories(repository_id);
+
+create index if not exists product_technologies_technology_id_idx
+  on registry.product_technologies(technology_id);
+
+create index if not exists product_service_links_service_instance_id_idx
+  on registry.product_service_links(service_instance_id);
+
+create index if not exists product_relations_target_product_id_idx
+  on registry.product_relations(target_product_id);
+
+create index if not exists product_resources_resource_id_idx
+  on registry.product_resources(resource_id);
+
+create index if not exists sync_runs_source_system_id_idx
+  on ops.sync_runs(source_system_id);
+
+-- Operational counters should never be negative.
+alter table ops.sync_runs
+  drop constraint if exists sync_runs_records_seen_nonnegative;
+alter table ops.sync_runs
+  add constraint sync_runs_records_seen_nonnegative check (records_seen >= 0);
+
+alter table ops.sync_runs
+  drop constraint if exists sync_runs_records_inserted_nonnegative;
+alter table ops.sync_runs
+  add constraint sync_runs_records_inserted_nonnegative check (records_inserted >= 0);
+
+alter table ops.sync_runs
+  drop constraint if exists sync_runs_records_updated_nonnegative;
+alter table ops.sync_runs
+  add constraint sync_runs_records_updated_nonnegative check (records_updated >= 0);
+
+commit;


### PR DESCRIPTION
## 概要

Issue #551 の方針に沿って、最後の Supabase Free 枠を開発専用 DB に固定しない `Workspace Core` の V1 bootstrap を実装しました。

既存 `mini-tools` Supabase には一切適用していません。新しい dedicated Supabase Project 作成前のレビュー可能な設計・seed一式です。

## 変更内容

- `platform / registry / ops` の schema boundary を定義
- Product / Repository / Technology / Service / External Resource / Relation の V1 schema を追加
- private custom schema + RLS + anon/authenticated revoke を初期方針として実装
- relation に provenance / confidence / verified timestamp を保持
- GitHub connected account から確認した 20 repositories を authoritative seed 化
- Repository facts と Product classification を別 seed に分離
- 18 Product の provisional mapping を追加
- `todo-app` / `market-info` の multi-repository mapping を追加
- 既知の `mini-tools -> Supabase mini-tools` relation を追加
- `mini-tools -> market-info` / `mini-tools -> stock-notes` API relation を repo config 根拠で追加
- provider account/team scope を考慮した service instance hardening を追加
- decision log / implementation plan / bootstrap README を追加

## セキュリティ / Source of Truth

- secret / token は保存しない
- GitHub は code / Issue / PR の Source of Truth のまま
- Notion は必要時の原文・長文知識の参照元として扱い、全文複製しない
- Workspace Core は identity / relationship / provenance の Control Plane
- V1 custom schemas は Data API に直接公開しない

Supabase 2026 の safer-default / Data API 変更も踏まえ、将来 browser access が必要になった場合は dedicated `api` schema または server route を追加する前提です。

## 確認項目

- [x] main から feature branch を作成
- [x] GitHub inventory 20 repos を再取得
- [x] main に対して branch が behind 0 であることを確認
- [x] SQL / docs 差分を手動レビュー
- [x] service instance の organization/team scope 衝突を hardening で修正
- [ ] dedicated Supabase Project で SQL 実行確認
- [ ] Supabase security advisor
- [ ] Supabase performance advisor
- [ ] Codex review

ローカル clone / lint は実行環境から GitHub へのネットワーク解決ができなかったため未実施です。今回の変更は SQL / docs のみで、既存 Next.js runtime code は変更していません。

## 適用順

1. `infra/workspace-core/sql/001_registry_schema.sql`
2. `infra/workspace-core/sql/002_seed_sources_and_repositories.sql`
3. repository count = 20 を確認
4. provisional Product mapping を確認
5. `infra/workspace-core/sql/003_seed_products_provisional.sql`
6. `infra/workspace-core/sql/004_schema_hardening.sql`
7. security/performance advisor
8. relation query verification

## 関連 Issue

Refs #551
